### PR TITLE
Add an environment variable and CLI flag to use cpp

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -274,6 +274,8 @@ type BuildOptions struct {
 	CommonBuildOpts *CommonBuildOptions
 	// CPPFlags are additional arguments to pass to the C Preprocessor (cpp).
 	CPPFlags []string
+	// Preprocess tells the builder to run the C Preprocessor (cpp) regardless of the file extension.
+	Preprocess types.OptionalBool
 	// DefaultMountsFilePath is the file path holding the mounts to be mounted for RUN
 	// instructions in "host-path:container-path" format
 	DefaultMountsFilePath string

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -18,7 +18,7 @@ The build context directory can be specified as the http(s) URL of an archive, g
 
 If no context directory is specified, then Buildah will assume the current working directory as build context, which should contain a Containerfile.
 
-Containerfiles ending with a ".in" suffix will be preprocessed via cpp(1).  This can be useful to decompose Containerfiles into several reusable parts that can be used via CPP's **#include** directive.  Notice, a Containerfile.in file can still be used by other tools when manually preprocessing them via `cpp -E`. Any comments ( Lines beginning with `#` ) in included Containerfile(s) that are not preprocess commands, will be printed as warnings during builds.
+Containerfiles ending with a ".in" suffix will be automatically preprocessed via cpp(1).  This can be useful to decompose Containerfiles into several reusable parts that can be used via CPP's **#include** directive.  Notice, a Containerfile.in file can still be used by other tools when manually preprocessing them via `cpp -E`. Any comments ( Lines beginning with `#` ) in included Containerfile(s) that are not preprocess commands, will be printed as warnings during builds.
 
 When the URL is an archive, the contents of the URL is downloaded to a temporary location and extracted before execution.
 
@@ -828,6 +828,13 @@ and can also be found by running `go tool dist list`.
 The `buildah build` command allows building images for all Linux architectures, even non-native architectures. When building images for a different architecture,  the `RUN` instructions require emulation software installed on the host provided by packages like `qemu-user-static`. Note: it is always preferred to build images on the native architecture if possible.
 
 **NOTE:** The `--platform` option may not be used in combination with the `--arch`, `--os`, or `--variant` options.
+
+**--preprocess**
+
+If specified, will always attempt to use the C Preprocessor cpp(1),
+even if the Containerfile doesn't end with the ".in" suffix.
+Note: You can also configure this behavior by setting the BUILDAH\_PREPROCESS
+environment variable to `1`, `true`, or `yes`.
 
 **--pull**
 

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -162,8 +162,10 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			data = contents
 		}
 
-		// pre-process Dockerfiles with ".in" suffix
-		if strings.HasSuffix(dfile, ".in") {
+		// pre-process Dockerfiles with ".in" suffix, if --preprocess is specified, or if BUILDAH_PREPROCESS is set
+		preprocessSpecified := options.Preprocess == types.OptionalBoolTrue
+		preprocessInferred := (options.Preprocess == types.OptionalBoolUndefined) && strings.HasSuffix(dfile, ".in")
+		if preprocessSpecified || preprocessInferred {
 			pData, err := preprocessContainerfileContents(logger, dfile, data, options.ContextDirectory, options.CPPFlags)
 			if err != nil {
 				return "", nil, err

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -399,7 +399,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		sbomScanOptions = append(sbomScanOptions, *sbomScanOption)
 	}
 
-	var compatVolumes, createdAnnotation, inheritAnnotations, inheritLabels, skipUnusedStages types.OptionalBool
+	var compatVolumes, createdAnnotation, inheritAnnotations, inheritLabels, skipUnusedStages, preprocess types.OptionalBool
 	if c.Flag("compat-volumes").Changed {
 		compatVolumes = types.NewOptionalBool(iopts.CompatVolumes)
 	}
@@ -414,6 +414,9 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 	}
 	if c.Flag("skip-unused-stages").Changed {
 		skipUnusedStages = types.NewOptionalBool(iopts.SkipUnusedStages)
+	}
+	if c.Flag("preprocess").Changed || DefaultPreprocess() {
+		preprocess = types.NewOptionalBool(iopts.Preprocess)
 	}
 
 	options = define.BuildOptions{
@@ -433,6 +436,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		CompatVolumes:           compatVolumes,
 		ConfidentialWorkload:    confidentialWorkloadOptions,
 		CPPFlags:                iopts.CPPFlags,
+		Preprocess:              preprocess,
 		CommonBuildOpts:         commonOpts,
 		Compression:             compression,
 		CompressionFormat:       compressionFormat,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -95,6 +95,7 @@ type BudResults struct {
 	Timestamp              int64
 	OmitHistory            bool
 	OCIHooksDir            []string
+	Preprocess             bool
 	Pull                   string
 	PullAlways             bool
 	PullNever              bool
@@ -250,6 +251,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.BoolVar(&flags.InheritLabels, "inherit-labels", true, "inherit the labels from the base image or base stages.")
 	fs.BoolVar(&flags.InheritAnnotations, "inherit-annotations", true, "inherit the annotations from the base image or base stages.")
 	fs.StringArrayVar(&flags.CPPFlags, "cpp-flag", []string{}, "set additional flag to pass to C preprocessor (cpp)")
+	fs.BoolVar(&flags.Preprocess, "preprocess", DefaultPreprocess(), "use the C preprocessor (cpp) on a Dockerfile, regardless of the file suffix. Use BUILDAH_PREPROCESS environment variable to change default.")
 	fs.BoolVar(&flags.CreatedAnnotation, "created-annotation", true, `set an "org.opencontainers.image.created" annotation in the image`)
 	fs.StringVar(&flags.Creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	fs.StringVarP(&flags.CWOptions, "cw", "", "", "confidential workload `options`")
@@ -539,6 +541,16 @@ func DefaultIsolation() string {
 func DefaultHistory() bool {
 	history := os.Getenv("BUILDAH_HISTORY")
 	if strings.ToLower(history) == "true" || history == "1" {
+		return true
+	}
+	return false
+}
+
+// DefaultPreprocess returns true if BUILDAH_PREPROCESS is set to "1" or "true"
+// otherwise it returns false
+func DefaultPreprocess() bool {
+	preprocess := os.Getenv("BUILDAH_PREPROCESS")
+	if strings.ToLower(preprocess) == "true" || strings.ToLower(preprocess) == "yes" || preprocess == "1" {
 		return true
 	}
 	return false

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4126,6 +4126,66 @@ _EOF
   expect_output --substring "Ignoring <stdin>:5:2: error: #error"
 }
 
+@test "bud with preprocessor, via --preprocess" {
+  _prefetch busybox
+  target=alpine-image
+  run_buildah build $WITH_POLICY_JSON -t ${target} --preprocess -f Decomposed.tpl $BUDFILES/preprocess
+}
+
+@test "bud with preprocessor-requiring containerfile, without --preprocess" {
+  _prefetch busybox
+  target=alpine-image
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} -f Decomposed.tpl $BUDFILES/preprocess
+  expect_output --substring 'Build error: Unknown instruction: "RUNHELLO"'
+}
+
+@test "bud with preprocessor error, via --preprocess" {
+  _prefetch busybox
+  target=alpine-image
+  run_buildah bud $WITH_POLICY_JSON -t ${target} --preprocess -f Error.tpl $BUDFILES/preprocess
+  expect_output --substring "Ignoring <stdin>:5:2: error: #error"
+}
+
+@test "bud with preprocessor, via env var 1" {
+  _prefetch busybox
+  target=alpine-image
+  BUILDAH_PREPROCESS=1 run_buildah build $WITH_POLICY_JSON -t ${target} -f Decomposed.tpl $BUDFILES/preprocess
+}
+
+@test "bud with preprocessor, via env var true" {
+  _prefetch busybox
+  target=alpine-image
+  BUILDAH_PREPROCESS=true run_buildah build $WITH_POLICY_JSON -t ${target} -f Decomposed.tpl $BUDFILES/preprocess
+}
+
+@test "bud with preprocessor, via env var yes" {
+  _prefetch busybox
+  target=alpine-image
+  BUILDAH_PREPROCESS=yes run_buildah build $WITH_POLICY_JSON -t ${target} -f Decomposed.tpl $BUDFILES/preprocess
+}
+
+@test "bud with preprocessor error, via env var" {
+  _prefetch busybox
+  target=alpine-image
+  BUILDAH_PREPROCESS=1 run_buildah bud $WITH_POLICY_JSON -t ${target} -f Error.tpl $BUDFILES/preprocess
+  expect_output --substring "Ignoring <stdin>:5:2: error: #error"
+}
+
+@test "bud with preprocessor-requiring containerfile.in, with preprocess force disabled" {
+  _prefetch busybox
+  target=alpine-image
+  starthttpd $BUDFILES/preprocess
+  run_buildah 125 build $WITH_POLICY_JSON -t ${target} --preprocess=false -f Decomposed.in $BUDFILES/preprocess
+  expect_output --substring 'Build error: Unknown instruction: "RUNHELLO"'
+}
+
+@test "bud with preprocessor-requiring containerfile, via explicit cli flag, defaulted on via env var" {
+  _prefetch busybox
+  target=alpine-image
+  BUILDAH_PREPROCESS=1 run_buildah 125 build $WITH_POLICY_JSON -t ${target} --preprocess=false -f Decomposed.tpl $BUDFILES/preprocess
+  expect_output --substring 'Build error: Unknown instruction: "RUNHELLO"'
+}
+
 @test "bud-with-rejected-name" {
   target=ThisNameShouldBeRejected
   run_buildah 125 build -q $WITH_POLICY_JSON -t ${target} $BUDFILES/from-scratch

--- a/tests/bud/preprocess/Decomposed.tpl
+++ b/tests/bud/preprocess/Decomposed.tpl
@@ -1,0 +1,5 @@
+FROM busybox
+
+#include "common"
+
+RUNHELLO

--- a/tests/bud/preprocess/Error.tpl
+++ b/tests/bud/preprocess/Error.tpl
@@ -1,0 +1,5 @@
+FROM busybox
+
+#include "common"
+
+#error THISERROR


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add an environment variable and CLI flag to force the use of the C
Preprocessor (cpp) instead of only relying on the Containerfile suffix.

See #6744 for additional discussion of the use cases.

#### How to verify it

`bats` tests were included and run locally as follows:

```
$ BUILDAH_BINARY=${PWD}/bin/buildah tests/test_runner.sh bud.bats -f '.*preprocessor.*'
++ time bats -j 32 --tap bud.bats -f .*preprocessor.*
1..6
ok 1 bud with preprocessor
ok 2 bud with preprocessor error
ok 3 bud with preprocessor, via --preprocess
ok 4 bud with preprocessor error, via --preprocess
ok 5 bud with preprocessor, via env var
ok 6 bud with preprocessor error, via env var
Error: open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied
time="2026-03-25T17:42:38-04:00" level=warning msg="failed to shutdown storage: \"open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied\""
Error: open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied
time="2026-03-25T17:42:38-04:00" level=warning msg="failed to shutdown storage: \"open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied\""
Error: open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied
time="2026-03-25T17:42:38-04:00" level=warning msg="failed to shutdown storage: \"open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied\""
Error: open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied
time="2026-03-25T17:42:38-04:00" level=warning msg="failed to shutdown storage: \"open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied\""
Error: open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied
time="2026-03-25T17:42:38-04:00" level=warning msg="failed to shutdown storage: \"open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied\""
Error: open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied
time="2026-03-25T17:42:38-04:00" level=warning msg="failed to shutdown storage: \"open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied\""
Error: open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied
time="2026-03-25T17:42:38-04:00" level=warning msg="failed to shutdown storage: \"open /var/lib/containers/storage/storage.lock: open /var/lib/containers/storage/storage.lock: permission denied\""

real	0m4.710s
user	0m4.844s
sys	0m1.461s
```

The existing preprocessor tests were simply copied to new Containerfiles with different file suffixes.

#### Which issue(s) this PR fixes:

Fixes #6744

#### Special notes for your reviewer:

I've not contributed to Buildah before. Happy to get feedback if there's anything you'd like changed.

#### Does this PR introduce a user-facing change?

```release-note
build: add --preprocess flag and BUILDAH_PREPROCESS env var to use cpp on any Containerfile
```

