### PR TITLE
Add a FollowSymlink option to AddAndCopyOptions to allow disabling deference of symlinks

### DIFF
--- a/add.go
+++ b/add.go
@@ -122,6 +122,9 @@ type AddAndCopyOptions struct {
 	// AllowEmptyWildcard controls whether the operation succeeds when all
 	// glob patterns match nothing. Defaults to false.
 	AllowEmptyWildcard types.OptionalBool
+	// FollowSymlink controls whether symlinks should be followed when copying content.
+	// When set to false, symlinks are not dereferenced.
+	FollowSymlink types.OptionalBool
 }
 
 // getURL writes a tar archive containing the named content
@@ -615,6 +618,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						ChownFiles:         chownFiles,
 						ChmodFiles:         chmodDirsFiles,
 						KeepDirectoryNames: options.DirCopyContents == types.OptionalBoolFalse,
+						NoDerefSymlinks:    options.FollowSymlink == types.OptionalBoolFalse,
 						StripSetuidBit:     options.StripSetuidBit,
 						StripSetgidBit:     options.StripSetgidBit,
 						StripStickyBit:     options.StripStickyBit,
@@ -790,6 +794,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					Timestamp:          options.Timestamp,
 					DisallowWildcard:   options.AllowWildcard == types.OptionalBoolFalse,
 					AllowEmptyWildcard: options.AllowEmptyWildcard == types.OptionalBoolTrue,
+					NoDerefSymlinks:    options.FollowSymlink == types.OptionalBoolFalse,
 				}
 				getErr = copier.Get(contextDir, contextDir, getOptions, []string{globbedToGlobbable(globbed)}, writer)
 				closeErr = writer.Close()

--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -45,6 +45,7 @@ type addCopyResults struct {
 	link               bool
 	allowWildcard      bool
 	allowEmptyWildcard bool
+	noFollowSymlinks   bool
 }
 
 func createCommand(addCopy string, desc string, short string, opts *addCopyResults) *cobra.Command {
@@ -80,6 +81,7 @@ func applyFlagVars(flags *pflag.FlagSet, opts *addCopyResults) {
 	flags.StringVar(&opts.chmod, "chmod", "", "set the access permissions of the destination content")
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing registries when pulling images")
 	flags.BoolVar(&opts.link, "link", false, "enable layer caching for this operation (creates an independent layer)")
+	flags.BoolVar(&opts.noFollowSymlinks, "no-follow-symlinks", false, "do not follow symlinks when copying content (copy the symlink itself)")
 	if err := flags.MarkHidden("creds"); err != nil {
 		panic(fmt.Sprintf("error marking creds as hidden: %v", err))
 	}
@@ -256,6 +258,11 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 		timestamp = &t
 	}
 
+	followSymlink := types.OptionalBoolUndefined
+	if iopts.noFollowSymlinks {
+		followSymlink = types.OptionalBoolFalse
+	}
+
 	options := buildah.AddAndCopyOptions{
 		Chmod:             iopts.chmod,
 		Chown:             iopts.chown,
@@ -272,6 +279,7 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 		Parents:               iopts.parents,
 		Timestamp:             timestamp,
 		Link:                  iopts.link,
+		FollowSymlink:         followSymlink,
 	}
 	if iopts.contextdir != "" {
 		var excludes []string

--- a/docs/buildah-add.1.md
+++ b/docs/buildah-add.1.md
@@ -84,6 +84,11 @@ container's filesystem. If `buildah run` creates a file and `buildah add --link`
 to the same path, the file from `buildah add --link` will be present in the committed image.
 The --link layer is applied after all container filesystem changes at commit time.
 
+**--no-follow-symlinks**
+
+When a local source is a symbolic link, copy the link as a symbolic link
+instead of dereferencing the link and copying the contents of the target.
+
 **--quiet**, **-q**
 
 Refrain from printing a digest of the added content.

--- a/docs/buildah-copy.1.md
+++ b/docs/buildah-copy.1.md
@@ -84,6 +84,11 @@ container's filesystem. If `buildah run` creates a file and `buildah copy --link
 to the same path, the file from `buildah copy --link` will be present in the committed image.
 The --link layer is applied after all container filesystem changes at commit time.
 
+**--no-follow-symlinks**
+
+Don't follow and dereference the symlinks when copying the files. Instead, copy
+the symlinks themselves.
+
 **--parents**
 
 Preserve leading directories in the paths of items being copied, relative to either the

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -401,19 +401,19 @@ EOF
   cid=$output
   run_buildah mount $cid
   root=$output
-  
+
   run_buildah config --workingdir=/ $cid
-  
+
   # Test 1: Simple add
   run_buildah add --link $cid ${TEST_SCRATCH_DIR}/randomfile
-  
+
   # Test 2: Add with rename (file to file with different name)
   run_buildah add --link $cid ${TEST_SCRATCH_DIR}/randomfile /renamed-file
-  
+
   # Test 3: Multiple files to directory
   mkdir $root/subdir
   run_buildah add --link $cid ${TEST_SCRATCH_DIR}/randomfile ${TEST_SCRATCH_DIR}/other-randomfile /subdir
-  
+
   run_buildah unmount $cid
   run_buildah commit $WITH_POLICY_JSON $cid add-link-image
 
@@ -430,13 +430,13 @@ EOF
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
-  
+
   test -s $newroot/randomfile
   cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/randomfile
-  
+
   test -s $newroot/renamed-file
   cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/renamed-file
-  
+
   test -s $newroot/subdir/randomfile
   cmp ${TEST_SCRATCH_DIR}/randomfile $newroot/subdir/randomfile
   test -s $newroot/subdir/other-randomfile
@@ -446,18 +446,18 @@ EOF
 @test "add-link-archive" {
   createrandom ${TEST_SCRATCH_DIR}/file1
   createrandom ${TEST_SCRATCH_DIR}/file2
-  
+
   tar -c -C ${TEST_SCRATCH_DIR} -f ${TEST_SCRATCH_DIR}/archive.tar file1 file2
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
-  
+
   run_buildah config --workingdir=/ $cid
-  
+
   run_buildah add --link $cid ${TEST_SCRATCH_DIR}/archive.tar
-  
+
   run_buildah add --link $cid ${TEST_SCRATCH_DIR}/archive.tar /destdir/
-  
+
   run_buildah commit $WITH_POLICY_JSON $cid add-link-archive-image
 
   run_buildah inspect --type=image add-link-archive-image
@@ -471,12 +471,12 @@ EOF
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
-  
+
   test -s $newroot/file1
   cmp ${TEST_SCRATCH_DIR}/file1 $newroot/file1
   test -s $newroot/file2
   cmp ${TEST_SCRATCH_DIR}/file2 $newroot/file2
-  
+
   test -s $newroot/destdir/file1
   cmp ${TEST_SCRATCH_DIR}/file1 $newroot/destdir/file1
   test -s $newroot/destdir/file2
@@ -490,22 +490,22 @@ EOF
 
   run_buildah from $WITH_POLICY_JSON scratch
   cid=$output
-  
+
   run_buildah config --workingdir=/ $cid
-  
+
   run_buildah add --link $cid ${TEST_SCRATCH_DIR}/testdir /testdir
-  
+
   run_buildah commit $WITH_POLICY_JSON $cid add-link-dir-image
 
   run_buildah from $WITH_POLICY_JSON add-link-dir-image
   newcid=$output
   run_buildah mount $newcid
   newroot=$output
-  
+
   test -d $newroot/testdir
   test -s $newroot/testdir/file1
   test -s $newroot/testdir/subdir/file2
-  
+
   cmp ${TEST_SCRATCH_DIR}/testdir/file1 $newroot/testdir/file1
   cmp ${TEST_SCRATCH_DIR}/testdir/subdir/file2 $newroot/testdir/subdir/file2
 }
@@ -561,4 +561,73 @@ EOF
   # Literal non-existent file should still error even with allow-empty-wildcard=true
   run_buildah 125 add --allow-empty-wildcard=true $cid ${TEST_SCRATCH_DIR}/no-such-file /dest4/
   expect_output --substring "no such file or directory"
+}
+
+@test "add-symlink-root-follow-default" {
+  createrandom ${TEST_SCRATCH_DIR}/file
+  ln -s ./file ${TEST_SCRATCH_DIR}/symlink
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/symlink /dest
+
+  run_buildah mount $cid
+  root=$output
+  ls -lahR $root
+  cmp ${TEST_SCRATCH_DIR}/file $root/dest
+  test -f $root/dest
+}
+
+@test "add-symlink-root-no-follow" {
+  createrandom ${TEST_SCRATCH_DIR}/file
+  ln -s ./file ${TEST_SCRATCH_DIR}/symlink
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+
+  # The symlink needs to point to something existing
+  run_buildah add --no-follow-symlinks $cid ${TEST_SCRATCH_DIR}/file /file
+  run_buildah add --no-follow-symlinks $cid ${TEST_SCRATCH_DIR}/symlink /dest
+
+  run_buildah mount $cid
+  root=$output
+  ls -lahR $root
+  cmp ${TEST_SCRATCH_DIR}/file $root/dest
+  test -L $root/dest
+  test "$(readlink $root/dest)" = "./file"
+}
+
+@test "add-symlink-child-follow-default" {
+  mkdir ${TEST_SCRATCH_DIR}/src
+  createrandom ${TEST_SCRATCH_DIR}/src/file
+  ln -s ./file ${TEST_SCRATCH_DIR}/src/symlink
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+
+  run_buildah add $cid ${TEST_SCRATCH_DIR}/src /dest
+
+  run_buildah mount $cid
+  root=$output
+  ls -lahR $root
+  cmp ${TEST_SCRATCH_DIR}/src/file $root/dest/symlink
+  test -f $root/dest/symlink
+}
+
+@test "add-symlink-child-no-follow" {
+  mkdir ${TEST_SCRATCH_DIR}/src
+  createrandom ${TEST_SCRATCH_DIR}/src/file
+  ln -s ./file ${TEST_SCRATCH_DIR}/src/symlink
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+
+  run_buildah add --no-follow-symlinks $cid ${TEST_SCRATCH_DIR}/src /dest
+
+  run_buildah mount $cid
+  root=$output
+  ls -lahR $root
+  test -L $root/dest/symlink
+  test "$(readlink $root/dest/symlink)" = "./file"
 }


### PR DESCRIPTION
#### What type of PR is this?

> /kind feature

#### What this PR does / why we need it:

This PR adds the ability to skip the dereference of symlinks when doing a ADD or COPY.

Depends on #6759 

#### How to verify it

See the bats tests provided

#### Which issue(s) this PR fixes:

Fixes #6737 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add a --no-follow-symlinks option to `buildah add` to skip dereferencing the symlinks when copying
```

