### PR TITLE
switch buildah manifest annotations flags to use StringArrayVar

### DIFF
--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -111,7 +111,7 @@ func manifestInit() {
 	flags := manifestCreateCommand.Flags()
 	flags.BoolVar(&manifestCreateOpts.all, "all", false, "add all of the lists' images if the images to add are lists")
 	flags.BoolVar(&manifestCreateOpts.amend, "amend", false, "modify an existing list if one with the desired name already exists")
-	flags.StringSliceVar(&manifestCreateOpts.annotations, "annotation", nil, "set an `annotation` for the image index")
+	flags.StringArrayVar(&manifestCreateOpts.annotations, "annotation", nil, "set an `annotation` for the image index")
 	flags.StringVar(&manifestCreateOpts.os, "os", "", "if any of the specified images is a list, choose the one for `os`")
 	if err := flags.MarkHidden("os"); err != nil {
 		panic(fmt.Sprintf("error marking --os as hidden: %v", err))
@@ -213,7 +213,7 @@ func manifestInit() {
 	flags.StringVar(&manifestAnnotateOpts.osVersion, "os-version", "", "override the os `version` of the specified image")
 	flags.StringSliceVar(&manifestAnnotateOpts.features, "features", nil, "override the `features` of the specified image")
 	flags.StringSliceVar(&manifestAnnotateOpts.osFeatures, "os-features", nil, "override the os `features` of the specified image")
-	flags.StringSliceVar(&manifestAnnotateOpts.annotations, "annotation", nil, "set an `annotation` for the specified image")
+	flags.StringArrayVar(&manifestAnnotateOpts.annotations, "annotation", nil, "set an `annotation` for the specified image")
 	flags.StringVar(&manifestAnnotateOpts.subject, "subject", "", "set a subject for the image index")
 	manifestAnnotateCommand.SetUsageTemplate(UsageTemplate())
 	manifestCommand.AddCommand(manifestAnnotateCommand)

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -112,7 +112,7 @@ func manifestInit() {
 	flags.BoolVar(&manifestCreateOpts.all, "all", false, "add all of the lists' images if the images to add are lists")
 	flags.BoolVar(&manifestCreateOpts.amend, "amend", false, "modify an existing list if one with the desired name already exists")
 	flags.BoolVar(&manifestCreateOpts.replace, "replace", false, "replace an existing image with the desired name")
-	flags.StringSliceVar(&manifestCreateOpts.annotations, "annotation", nil, "set an `annotation` for the image index")
+	flags.StringArrayVar(&manifestCreateOpts.annotations, "annotation", nil, "set an `annotation` for the image index")
 	flags.StringVar(&manifestCreateOpts.os, "os", "", "if any of the specified images is a list, choose the one for `os`")
 	if err := flags.MarkHidden("os"); err != nil {
 		panic(fmt.Sprintf("error marking --os as hidden: %v", err))
@@ -214,7 +214,7 @@ func manifestInit() {
 	flags.StringVar(&manifestAnnotateOpts.osVersion, "os-version", "", "override the os `version` of the specified image")
 	flags.StringSliceVar(&manifestAnnotateOpts.features, "features", nil, "override the `features` of the specified image")
 	flags.StringSliceVar(&manifestAnnotateOpts.osFeatures, "os-features", nil, "override the os `features` of the specified image")
-	flags.StringSliceVar(&manifestAnnotateOpts.annotations, "annotation", nil, "set an `annotation` for the specified image")
+	flags.StringArrayVar(&manifestAnnotateOpts.annotations, "annotation", nil, "set an `annotation` for the specified image")
 	flags.StringVar(&manifestAnnotateOpts.subject, "subject", "", "set a subject for the image index")
 	manifestAnnotateCommand.SetUsageTemplate(UsageTemplate())
 	manifestCommand.AddCommand(manifestAnnotateCommand)

--- a/tests/lists.bats
+++ b/tests/lists.bats
@@ -21,10 +21,11 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     assert "$output" =~ "that name is already in use"
     run_buildah manifest create --amend foo
     assert "$output" == "$listid"
-    run_buildah manifest create --amend --annotation red=blue foo busybox
+    run_buildah manifest create --amend --annotation red=blue --annotation green=yellow,orange,purple foo busybox
     assert "$output" == "$listid"
     run_buildah manifest inspect foo
     assert "$output" =~ '"red": "blue"'
+    assert "$output" =~ '"green": "yellow,orange,purple"'
     assert "$output" =~ "${imagedigest}"
     # since manifest exists in local storage this should exit with `0`
     run_buildah manifest exists foo
@@ -130,10 +131,11 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     digest="${output##* }"
     alg="${digest%%:*}"
     encoded="${digest##*:}"
-    run_buildah manifest annotate --annotation red=blue foo $TEST_SCRATCH_DIR/randomfile
+    run_buildah manifest annotate --annotation red=blue --annotation green=yellow,orange,purple foo $TEST_SCRATCH_DIR/randomfile
     run_buildah manifest inspect foo
     assert "$output" =~ '"image/png"'
     assert "$output" =~ '"red": "blue"'
+    assert "$output" =~ '"green": "yellow,orange,purple"'
     run_buildah manifest push --all foo oci:$TEST_SCRATCH_DIR/pushed
     run cmp $TEST_SCRATCH_DIR/randomfile $TEST_SCRATCH_DIR/pushed/blobs/sha256/$blobencoded
     assert "$status" -eq 0 "pushed copy of random file did not match original"
@@ -190,9 +192,10 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     _prefetch busybox
     run_buildah manifest create foo
     run_buildah manifest add foo busybox
-    run_buildah manifest annotate --index --annotation red=blue foo
+    run_buildah manifest annotate --index --annotation red=blue --annotation green=yellow,orange,purple foo
     run_buildah manifest inspect foo
     assert "$output" =~ '"red": "blue"'
+    assert "$output" =~ '"green": "yellow,orange,purple"'
 }
 
 @test "manifest-annotate instance annotation" {
@@ -200,7 +203,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest create foo
     run_buildah manifest add foo busybox
     instance="${output##* }"
-    run_buildah manifest annotate --annotation red=blue foo "${instance}"
+    run_buildah manifest annotate --annotation red=blue --annotation green=yellow,orange,purple foo "${instance}"
     run_buildah manifest annotate --os OperatingSystem foo "${instance}"
     run_buildah manifest annotate --arch aRCHITECTURE foo "${instance}"
     run_buildah manifest annotate --variant vARIANT foo "${instance}"
@@ -208,6 +211,7 @@ IMAGE_LIST_S390X_INSTANCE_DIGEST=sha256:882a20ee0df7399a445285361d38b711c299ca09
     run_buildah manifest annotate --os-features OSFEATURE1 --os-features OSFEATURE2 foo "${instance}"
     run_buildah manifest inspect foo
     assert "$output" =~ '"red": "blue"'
+    assert "$output" =~ '"green": "yellow,orange,purple"'
     assert "$output" =~ '"os": "OperatingSystem"'
     assert "$output" =~ '"architecture": "aRCHITECTURE"'
     assert "$output" =~ '"variant": "vARIANT"'


### PR DESCRIPTION
This prevents splitting on commas, which previously made it challenging to include an actual comma in an annotation.

#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

Annotations flags shouldn't split on commas.

#### How to verify it

```sh
$ ./bin/buildah manifest create --annotation=foo=bar '--annotation=alpha=beta, gamma, and delta again' localhost/this/test:version2
9ea39caf64ab94401e16b6de5574e03720584cc12624dcd67b45660f0ed5cd5b

$ ./bin/buildah manifest inspect localhost/this/test:version2
{
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.index.v1+json",
    "manifests": [],
    "annotations": {
        "alpha": "beta, gamma, and delta again",
        "foo": "bar"
    }
}
```

#### Which issue(s) this PR fixes:

Fixes #6793

#### Does this PR introduce a user-facing change?

For people working around this issue by wrapping in quotes, this will cause the quotes to start appearing in the key and value:

```sh
$ buildah manifest create --annotation=foo=bar '--annotation="alpha=beta, gamma, and delta"' localhost/this/test:version3
1bd72d935fd0d2d6900a04ed10c84bdfea1f72f1565ea04bd871786772778872

$ buildah manifest inspect localhost/this/test:version3
{
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.index.v1+json",
    "manifests": [],
    "annotations": {
        "alpha": "beta, gamma, and delta",
        "foo": "bar"
    }
}

$ ./bin/buildah manifest create --annotation=foo=bar '--annotation="alpha=beta, gamma, and delta"' localhost/this/test:version4
e6a029efbdb496b9348f00c5a60987a22c3387ac34a9e602969dd333a6e63ccd

$ ./bin/buildah manifest inspect localhost/this/test:version4
{
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.index.v1+json",
    "manifests": [],
    "annotations": {
        "\"alpha": "beta, gamma, and delta\"",
        "foo": "bar"
    }
}
```

```release-note
`buildah manifest create --annotation` and `buildah manifest annotate --annotation` now handle annotation values the same way that `buildah bud` does, not splitting on commas, and treating surrounding quotation marks as literal characters.
```

