### PR TITLE
copier: Fix the bookkeeping of the requested root

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -866,7 +866,6 @@ func copierMain() {
 				fmt.Fprintf(os.Stderr, "error: can't change location of chroot from %q to %q", previousRequestRoot, req.Root)
 				os.Exit(1)
 			}
-			previousRequestRoot = req.Root
 		} else {
 			// Figure out where to chroot to, if we weren't told.
 			if req.Root == "" {
@@ -884,6 +883,8 @@ func copierMain() {
 				fmt.Fprintf(os.Stderr, "%v", err)
 				os.Exit(1)
 			}
+
+			previousRequestRoot = req.Root
 		}
 
 		req.preservedRoot = req.Root

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -2661,4 +2662,51 @@ func TestTarPut(t *testing.T) {
 			require.Equal(t, "hello world", string(content), "extracted file content mismatch")
 		})
 	}
+}
+
+func TestCannotChangeMultipleRequestsWithDifferentChroot(t *testing.T) {
+	testDir := t.TempDir()
+
+	stdinR, stdinW, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, stdinR.Close())
+		assert.NoError(t, stdinW.Close())
+	})
+
+	stdoutR, stdoutW, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, stdoutR.Close())
+		assert.NoError(t, stdoutW.Close())
+	})
+
+	stderr := bytes.Buffer{}
+
+	cmd := reexec.Command(copierCommand)
+	cmd.Stdin = stdinR
+	cmd.Stdout = stdoutW
+	cmd.Stderr = &stderr
+	cmd.Dir = testDir
+
+	require.NoError(t, cmd.Start())
+
+	encoder := json.NewEncoder(stdinW)
+	decoder := json.NewDecoder(stdoutR)
+
+	req := request{Request: requestEval, Root: testDir, Directory: "/"}
+	var resp response
+
+	require.NoError(t, encoder.Encode(&req), "failed to send first request to copier")
+	require.NoError(t, stdoutR.SetReadDeadline(time.Now().Add(time.Second*5)))
+	require.NoError(t, decoder.Decode(&resp), "failed to decode response from copier")
+	require.Empty(t, resp.Error, "first request returned an error: %s", resp.Error)
+
+	require.NoError(t, encoder.Encode(&req), "failed to send second request to copier")
+	require.NoError(t, stdoutR.SetReadDeadline(time.Now().Add(time.Second*5)))
+	require.NoErrorf(t, decoder.Decode(&resp), "failed to decode response from copier: %s", stderr.String())
+	require.Empty(t, resp.Error, "second request returned an error: %s", resp.Error)
+
+	require.NoError(t, encoder.Encode(&request{Request: requestQuit}))
+	require.NoError(t, cmd.Wait())
 }


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

Previously, we would never update the previousRequestRoot after chrooting, which would lead the copier to try to chroot another time inside the earlier chroot, which is not supported.

This ensures that we keep the proper root over iterations and fail properly if another root is requested.

#### How to verify it

See the test, changing the previousRoot back and running the test will fail, claiming that the `testDir` doesn't exist.

#### Which issue(s) this PR fixes:

I have not created an issue first for this, do you want me to?

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

I am not sure here how a user of buildah would directly hit this

```release-note
None
```

