### PR TITLE
copier: Fix some log messages

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -566,7 +566,7 @@ func convertToRelSubdirectory(root, directory string) (relative string, err erro
 		return "", fmt.Errorf("expected root directory to be an absolute path, got %q", root)
 	}
 	if directory == "" || !filepath.IsAbs(directory) {
-		return "", fmt.Errorf("expected directory to be an absolute path, got %q", root)
+		return "", fmt.Errorf("expected directory to be an absolute path, got %q", directory)
 	}
 	if filepath.VolumeName(root) != filepath.VolumeName(directory) {
 		return "", fmt.Errorf("%q and %q are on different volumes", root, directory)
@@ -1786,7 +1786,7 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 			return fmt.Errorf("copying %s: %w", contentPath, err)
 		}
 		if n != hdr.Size {
-			return fmt.Errorf("copying %s: incorrect size (expected %d bytes, read %d bytes)", contentPath, n, hdr.Size)
+			return fmt.Errorf("copying %s: incorrect size (expected %d bytes, read %d bytes)", contentPath, hdr.Size, n)
 		}
 		tw.Flush()
 	}
@@ -1828,7 +1828,7 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			containerFilePair := idtools.IDPair{UID: *fileUID, GID: *fileGID}
 			hostFilePair, err := idMappings.ToHost(containerFilePair)
 			if err != nil {
-				return errorResponse("copier: put: error mapping container filesystem owner %d:%d to host filesystem owners: %v", fileUID, fileGID, err)
+				return errorResponse("copier: put: error mapping container filesystem owner %d:%d to host filesystem owners: %v", *fileUID, *fileGID, err)
 			}
 			fileUID, fileGID = &hostFilePair.UID, &hostFilePair.GID
 		}


### PR DESCRIPTION
#### What type of PR is this?

> /kind cleanup

#### What this PR does / why we need it:

- The error when checking if directory is an absolute path doesn't log the right directory
- The incorrect size read inverted the read vs expected bytes
- The fileUID and fileGID logs logged the pointer to the values instead of the values themselves

#### How to verify it

N/A

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

