### PR TITLE
copier: add AddAndCopyOptions.DirCopyContents

### DIFF
--- a/add.go
+++ b/add.go
@@ -112,6 +112,9 @@ type AddAndCopyOptions struct {
 	// inheritAnnotations, newAnnotations). This field is internally managed and should
 	// not be set by external API users.
 	BuildMetadata string
+	// DirCopyContents copies the directory's contents instead of the
+	// directory with its contents below it, default true.
+	DirCopyContents types.OptionalBool
 }
 
 // gitURLFragmentSuffix matches fragments to use as Git reference and build
@@ -610,18 +613,19 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						return
 					}
 					getOptions := copier.GetOptions{
-						UIDMap:         srcUIDMap,
-						GIDMap:         srcGIDMap,
-						Excludes:       options.Excludes,
-						ExpandArchives: extract,
-						ChownDirs:      chownDirs,
-						ChmodDirs:      chmodDirsFiles,
-						ChownFiles:     chownFiles,
-						ChmodFiles:     chmodDirsFiles,
-						StripSetuidBit: options.StripSetuidBit,
-						StripSetgidBit: options.StripSetgidBit,
-						StripStickyBit: options.StripStickyBit,
-						Timestamp:      options.Timestamp,
+						UIDMap:             srcUIDMap,
+						GIDMap:             srcGIDMap,
+						Excludes:           options.Excludes,
+						ExpandArchives:     extract,
+						ChownDirs:          chownDirs,
+						ChmodDirs:          chmodDirsFiles,
+						ChownFiles:         chownFiles,
+						ChmodFiles:         chmodDirsFiles,
+						KeepDirectoryNames: options.DirCopyContents == types.OptionalBoolFalse,
+						StripSetuidBit:     options.StripSetuidBit,
+						StripSetgidBit:     options.StripSetgidBit,
+						StripStickyBit:     options.StripStickyBit,
+						Timestamp:          options.Timestamp,
 					}
 					writer := io.WriteCloser(pipeWriter)
 					repositoryDir := filepath.Join(cloneDir, subdir)
@@ -777,19 +781,20 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					return false, false, nil
 				})
 				getOptions := copier.GetOptions{
-					UIDMap:         srcUIDMap,
-					GIDMap:         srcGIDMap,
-					Excludes:       options.Excludes,
-					ExpandArchives: extract,
-					ChownDirs:      chownDirs,
-					ChmodDirs:      chmodDirsFiles,
-					ChownFiles:     chownFiles,
-					ChmodFiles:     chmodDirsFiles,
-					StripSetuidBit: options.StripSetuidBit,
-					StripSetgidBit: options.StripSetgidBit,
-					StripStickyBit: options.StripStickyBit,
-					Parents:        options.Parents,
-					Timestamp:      options.Timestamp,
+					UIDMap:             srcUIDMap,
+					GIDMap:             srcGIDMap,
+					Excludes:           options.Excludes,
+					ExpandArchives:     extract,
+					ChownDirs:          chownDirs,
+					ChmodDirs:          chmodDirsFiles,
+					ChownFiles:         chownFiles,
+					ChmodFiles:         chmodDirsFiles,
+					KeepDirectoryNames: options.DirCopyContents == types.OptionalBoolFalse,
+					StripSetuidBit:     options.StripSetuidBit,
+					StripSetgidBit:     options.StripSetgidBit,
+					StripStickyBit:     options.StripStickyBit,
+					Parents:            options.Parents,
+					Timestamp:          options.Timestamp,
 				}
 				getErr = copier.Get(contextDir, contextDir, getOptions, []string{globbedToGlobbable(globbed)}, writer)
 				closeErr = writer.Close()

--- a/add_test.go
+++ b/add_test.go
@@ -1,0 +1,38 @@
+package buildah
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.podman.io/image/v5/types"
+)
+
+func TestDirCopyContentsToKeepDirectoryNames(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		dirCopyContents    types.OptionalBool
+		keepDirectoryNames bool
+	}{
+		{
+			name:               "undefined defaults to not keeping directory names",
+			dirCopyContents:    types.OptionalBoolUndefined,
+			keepDirectoryNames: false,
+		},
+		{
+			name:               "true means copy contents, don't keep directory names",
+			dirCopyContents:    types.OptionalBoolTrue,
+			keepDirectoryNames: false,
+		},
+		{
+			name:               "false means keep directory names",
+			dirCopyContents:    types.OptionalBoolFalse,
+			keepDirectoryNames: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			options := AddAndCopyOptions{DirCopyContents: tc.dirCopyContents}
+			got := options.DirCopyContents == types.OptionalBoolFalse
+			assert.Equal(t, tc.keepDirectoryNames, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
Adds a new `AddAndCopyOptions.DirCopyContents` field (of type `types.OptionalBool`) that controls whether copying a source directory copies just its contents (default, `true`) or the directory itself with its contents nested below it.

This wires the existing `GetOptions.KeepDirectoryNames` setting through the `AddAndCopyOptions` API, aligning with BuildKit's `FileAction_Copy.dirCopyContents` logic.

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->


Fixes #6803
<!--
or
None
-->

#### Special notes for your reviewer:
`KeepDirectoryNames` is the opposite of `DirCopyContents`: `DirCopyContents == OptionalBoolFalse` maps to `KeepDirectoryNames = true`. Both `OptionalBoolUndefined` and `OptionalBoolTrue` preserve existing default behavior (copy contents only). The added test covers this inversion logic only, since `KeepDirectoryNames` already has tests in `copier/copier_test.go`.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

