### PR TITLE
[release-1.26] Bump buildah to 1.26.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 # Changelog
 
+## v1.26.11 (2026-05-01)
+
+    CI: Fix conformance tests API version
+    CI: Workaround conformance testing bugaboo
+    Fix selinux spc test
+    Skip conformance test failures with Docker 23.0.1
+    tests/from.bats "from cpu-shares test": update cgroupv2 weights
+    Update "bud with --cpu-shares" test, and rename it
+    copier: drain tar stream to prevent broken pipe errors
+    CI: Fix disablement of systemd-resolved
+    Fix CVE-2025-47913 with x/crypto + minimum go bump
+
 ## v1.26.10 (2025-12-11)
 
     conformance test: ignore file type bits when comparing layers

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,14 @@
+- Changelog for v1.26.11 (2026-05-01)
+  * CI: Fix conformance tests API version
+  * CI: Workaround conformance testing bugaboo
+  * Fix selinux spc test
+  * Skip conformance test failures with Docker 23.0.1
+  * tests/from.bats "from cpu-shares test": update cgroupv2 weights
+  * Update "bud with --cpu-shares" test, and rename it
+  * copier: drain tar stream to prevent broken pipe errors
+  * CI: Fix disablement of systemd-resolved
+  * Fix CVE-2025-47913 with x/crypto + minimum go bump
+
 - Changelog for v1.26.10 (2025-12-11)
   * conformance test: ignore file type bits when comparing layers
   * Builder.SetWorkDir(): trim off a path separator suffix, if there is one

--- a/define/types.go
+++ b/define/types.go
@@ -29,7 +29,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.26.10"
+	Version = "1.26.11"
 
 	// DefaultRuntime if containers.conf fails.
 	DefaultRuntime = "runc"


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Bump buildah for #6813 changes

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Someone with permissions will need to tag this after merge.

#### Does this PR introduce a user-facing change?

```release-note
  * CI: Fix conformance tests API version
  * CI: Workaround conformance testing bugaboo
  * Fix selinux spc test
  * Skip conformance test failures with Docker 23.0.1
  * tests/from.bats "from cpu-shares test": update cgroupv2 weights
  * Update "bud with --cpu-shares" test, and rename it
  * copier: drain tar stream to prevent broken pipe errors
  * CI: Fix disablement of systemd-resolved
  * Fix CVE-2025-47913 with x/crypto + minimum go bump
```

