### PR TITLE
Fix stale cache when using bind mount with build stage

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -2053,8 +2053,13 @@ func (s *stageExecutor) getCreatedBy(node *parser.Node, addedContentSummary stri
 			}
 			// Source specified is part of stage, image or additional-build-context.
 			if mountOptionFrom != "" {
-				// If this is not a stage then get digest of image or additional build context
-				if _, ok := s.executor.stages[mountOptionFrom]; !ok {
+				if stage, ok := s.executor.stages[mountOptionFrom]; ok {
+					// If source is a previous stage then checksum is image digest for that stage
+					if image, isPreviousStage := s.executor.imageMap[stage.name]; isPreviousStage {
+						mountCheckSum = image
+					}
+				} else {
+					// If this is not a stage then get digest of image or additional build context
 					if builder, ok := s.executor.containerMap[mountOptionFrom]; ok {
 						// Found valid image, get image digest.
 						mountCheckSum = builder.FromImageDigest


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug


#### What this PR does / why we need it:
This fixes a bug where stale images would be used when using a previous build stage as a bind mount source

#### How to verify it
Trivial example to reproduce:

```dockerfile
FROM ubi8/ubi as base

FROM base as builder
RUN mkdir /build && echo "1" > /build/foo.txt

FROM base as prod
RUN --mount=type=bind,source=/build,from=builder,target=/build \
     cp /build/foo.txt bar.txt
```

1. Build this file with `buildah build -f <dockerfile> --layers`.
2. Change the "1" to a "2" and build again, observing the final image hash changes
3. Change the "2" back to a "1" and observe the hash not change as it should

#### Which issue(s) this PR fixes:
Fixes #6609 
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

I'm not particularly familiar with this code base, this was just an annoyance I wanted to fix, so comments welcome.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes bug where stale images could be used when using a previous build stage as a bind mount source
```

