### PR TITLE
rpm/buildah.spec tests: require xz and /usr/bin/selinuxenabled

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -97,6 +97,9 @@ Requires: bats
 Recommends: bats
 %endif
 Requires: bzip2
+Requires: xz
+Requires: zstd
+Requires: which
 Requires: podman
 Requires: golang
 Requires: jq
@@ -104,6 +107,7 @@ Requires: httpd-tools
 Requires: openssl
 Requires: nmap-ncat
 Requires: git-daemon
+Requires: libselinux-utils
 
 %description tests
 %{summary}

--- a/tests/validate/pr-should-include-tests
+++ b/tests/validate/pr-should-include-tests
@@ -54,7 +54,7 @@ filtered_changes=$(git diff --name-status $base $head   |
                        grep -E -v  '^contrib/'          |
                        grep -E -v  '^docs/'             |
                        grep -E -v  '^hack/'             |
-                       grep -E -v  '^nix/'              |
+                       grep -E -v  '^rpm/'              |
                        grep -E -v  '^vendor/')
 if [[ -z "$filtered_changes" ]]; then
     exit 0


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Tests use selinuxenabled to check if SELinux is enabled and relabeling is required when using volumes.
Some tarballs downloaded by tests are compressed using xz, as some are created using bzip2, which is called by tar, so make sure it's there.

#### How to verify it

Testing farm Raw Hide tests should pass.

#### Which issue(s) this PR fixes:

Taking a guess at the cause of the errors seen at https://github.com/containers/buildah/pull/6800#issuecomment-4442001624.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

