### PR TITLE
fix: duplicated "the" in define/types.go and pkg/sshagent comments

### DIFF
--- a/define/types.go
+++ b/define/types.go
@@ -124,7 +124,7 @@ func (s Secret) ResolveValue() ([]byte, error) {
 	}
 }
 
-// BuildOutputOptions contains the the outcome of parsing the value of a build --output flag
+// BuildOutputOptions contains the outcome of parsing the value of a build --output flag
 // Deprecated: This structure is now internal
 type BuildOutputOption struct {
 	Path     string // Only valid if !IsStdout

--- a/pkg/sshagent/sshagent.go
+++ b/pkg/sshagent/sshagent.go
@@ -70,7 +70,7 @@ func newAgentServerSocket(socketPath string) (*AgentServer, error) {
 func (a *AgentServer) Serve(processLabel string) (string, error) {
 	// Calls to `selinux.SetSocketLabel` should be wrapped in
 	// runtime.LockOSThread()/runtime.UnlockOSThread() until
-	// the the socket is created to guarantee another goroutine
+	// the socket is created to guarantee another goroutine
 	// does not migrate to the current thread before execution
 	// is complete.
 	// Ref: https://github.com/opencontainers/selinux/blob/main/go-selinux/selinux.go#L158


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in source comments:
- `define/types.go` — "// BuildOutputOptions contains the the outcome of parsing the value of a build --output flag" → "...contains the outcome of parsing..."
- `pkg/sshagent/sshagent.go` — "	// the the socket is created to guarantee another goroutine" → "	// the socket is created to guarantee another goroutine"

No code/behavior change.

Signed-off-by: Kai Tanaka <275430420+quyentonndbs@users.noreply.github.com>