### PR TITLE
copier.TestTarPut(): test both with and without chroot

### DIFF
--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -2581,7 +2581,14 @@ func TestSortedExtendedGlob(t *testing.T) {
 	require.ElementsMatch(t, expect, matched, "sorted globbing")
 }
 
-func TestTarPut(t *testing.T) {
+func TestTarPutNoChroot(t *testing.T) {
+	couldChroot := canChroot
+	canChroot = false
+	defer func() { canChroot = couldChroot }()
+	testTarPut(t)
+}
+
+func testTarPut(t *testing.T) {
 	testCases := []struct {
 		name               string
 		trailingNullsBytes int
@@ -2627,34 +2634,8 @@ func TestTarPut(t *testing.T) {
 				tarBuf.Write(extraNulls)
 			}
 
-			pipeReader, pipeWriter := io.Pipe()
-			writeErrChan := make(chan error, 1)
-
-			go func() {
-				defer pipeWriter.Close()
-				_, err := io.Copy(pipeWriter, &tarBuf)
-				writeErrChan <- err
-			}()
-
-			req := request{
-				Root:      testDir,
-				Directory: "/",
-				Request:   requestPut,
-			}
-
-			resp, cb, err := copierHandlerPut(pipeReader, req, nil)
-			require.NoError(t, err, "copierHandlerPut returned error")
-			require.Empty(t, resp.Error, "copierHandlerPut returned error response")
-			require.NotNil(t, cb, "expected callback to be returned")
-
-			require.NoError(t, cb(), "callback returned error")
-
-			select {
-			case writeErr := <-writeErrChan:
-				require.NoError(t, writeErr, "write to pipe failed (broken pipe)")
-			case <-time.After(5 * time.Second):
-				t.Fatal("timeout waiting for write to complete")
-			}
+			err = Put(testDir, testDir, PutOptions{}, &tarBuf)
+			require.NoError(t, err, "Put returned error")
 
 			extractedFile := filepath.Join(testDir, "testfile.txt")
 			content, err := os.ReadFile(extractedFile)

--- a/copier/copier_unix_test.go
+++ b/copier/copier_unix_test.go
@@ -109,3 +109,13 @@ func checkStatInfoOwnership(t *testing.T, result *StatForItem) {
 	require.EqualValues(t, 0, result.UID, "expected the owning user to be reported")
 	require.EqualValues(t, 0, result.GID, "expected the owning group to be reported")
 }
+
+func TestTarPutChroot(t *testing.T) {
+	if uid != 0 {
+		t.Skip("chroot() requires root privileges, skipping")
+	}
+	couldChroot := canChroot
+	canChroot = true
+	defer func() { canChroot = couldChroot }()
+	testTarPut(t)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Update the copier.TestTarPut() test to exercise both chroot and non-chroot code paths when they're available.

#### How to verify it

Updated unit test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```