### PR TITLE
copier: add Mkfile() for creating files with inline content

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -516,6 +516,59 @@ func Mkdir(root string, directory string, options MkdirOptions) error {
 	return nil
 }
 
+// MkfileOptions controls parts of Mkfile()'s behavior.
+type MkfileOptions struct {
+	UIDMap, GIDMap []idtools.IDMap // map from containerIDs to hostIDs when creating the file
+	ModTimeNew     *time.Time      // set mtime and atime of the newly-created file
+	ChownNew       *idtools.IDPair // set ownership of the newly-created file
+	ChmodNew       *os.FileMode    // set permissions on the newly-created file
+}
+
+// Mkfile creates a file at the specified path under root with the given
+// content, permissions, and ownership.  It builds a tar archive containing
+// a single entry and passes it to Put().
+func Mkfile(root string, path string, options MkfileOptions, content []byte) error {
+	uid, gid := 0, 0
+	if options.ChownNew != nil {
+		uid, gid = options.ChownNew.UID, options.ChownNew.GID
+	}
+	mode := os.FileMode(0o644)
+	if options.ChmodNew != nil {
+		mode = *options.ChmodNew
+	}
+	modTime := time.Now()
+	if options.ModTimeNew != nil {
+		modTime = *options.ModTimeNew
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	hdr := &tar.Header{
+		Name:     cleanerReldirectory(path),
+		Size:     int64(len(content)),
+		Mode:     int64(mode),
+		Uid:      uid,
+		Gid:      gid,
+		ModTime:  modTime,
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("copier: mkfile: error writing tar header: %w", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		return fmt.Errorf("copier: mkfile: error writing tar content: %w", err)
+	}
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("copier: mkfile: error closing tar writer: %w", err)
+	}
+
+	putOptions := PutOptions{
+		UIDMap: options.UIDMap,
+		GIDMap: options.GIDMap,
+	}
+	return Put(root, root, putOptions, &buf)
+}
+
 // RemoveOptions controls parts of Remove()'s behavior.
 type RemoveOptions struct {
 	All           bool // if Directory is a directory, remove its contents as well

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -1897,6 +1897,123 @@ func testMkdir(t *testing.T) {
 	}
 }
 
+func TestMkfileNoChroot(t *testing.T) {
+	couldChroot := canChroot
+	canChroot = false
+	testMkfile(t)
+	canChroot = couldChroot
+}
+
+func testMkfile(t *testing.T) {
+	currentOwner := &idtools.IDPair{UID: os.Getuid(), GID: os.Getgid()}
+	mkfileOpts := func(chmod *os.FileMode, modTime *time.Time) MkfileOptions {
+		return MkfileOptions{
+			ModTimeNew: modTime,
+			ChownNew:   currentOwner,
+			ChmodNew:   chmod,
+		}
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		root := t.TempDir()
+		content := []byte("hello world")
+		err := Mkfile(root, "newfile", mkfileOpts(nil, nil), content)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(root, "newfile"))
+		require.NoError(t, err)
+		assert.Equal(t, content, got)
+
+		info, err := os.Stat(filepath.Join(root, "newfile"))
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "default permissions should be 0644")
+	})
+
+	t.Run("empty-content", func(t *testing.T) {
+		root := t.TempDir()
+		err := Mkfile(root, "emptyfile", mkfileOpts(nil, nil), []byte{})
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(root, "emptyfile"))
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("with-permissions", func(t *testing.T) {
+		root := t.TempDir()
+		mode := os.FileMode(0o600)
+		err := Mkfile(root, "secret", mkfileOpts(&mode, nil), []byte("secret"))
+		require.NoError(t, err)
+
+		info, err := os.Stat(filepath.Join(root, "secret"))
+		require.NoError(t, err)
+		assert.Equal(t, mode, info.Mode().Perm())
+	})
+
+	t.Run("with-timestamp", func(t *testing.T) {
+		root := t.TempDir()
+		err := Mkfile(root, "dated", mkfileOpts(nil, &testDate), []byte("dated"))
+		require.NoError(t, err)
+
+		info, err := os.Stat(filepath.Join(root, "dated"))
+		require.NoError(t, err)
+		assert.Equal(t, testDate.Unix(), info.ModTime().Unix())
+	})
+
+	t.Run("nested-path", func(t *testing.T) {
+		archive := makeArchive([]tar.Header{
+			{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+			{Name: "subdir-a/subdir-b", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+		}, nil)
+		root, err := makeContextFromArchive(t, archive, "")
+		require.NoError(t, err)
+
+		content := []byte("very deep content")
+		err = Mkfile(root, "subdir-a/subdir-b/deepfile", mkfileOpts(nil, nil), content)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(root, "subdir-a", "subdir-b", "deepfile"))
+		require.NoError(t, err)
+		assert.Equal(t, content, got)
+	})
+
+	t.Run("path-traversal", func(t *testing.T) {
+		root := t.TempDir()
+		content := []byte("should be contained")
+		err := Mkfile(root, "../../escaped", mkfileOpts(nil, nil), content)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(root, "escaped"))
+		require.NoError(t, err)
+		assert.Equal(t, content, got)
+	})
+
+	t.Run("absolute-path", func(t *testing.T) {
+		root := t.TempDir()
+		content := []byte("absolute")
+		err := Mkfile(root, "/absolutefile", mkfileOpts(nil, nil), content)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(root, "absolutefile"))
+		require.NoError(t, err)
+		assert.Equal(t, content, got)
+	})
+
+	t.Run("overwrite", func(t *testing.T) {
+		root := t.TempDir()
+		err := Mkfile(root, "target", mkfileOpts(nil, nil), []byte("original"))
+		require.NoError(t, err)
+
+		replacement := []byte("replacement")
+		err = Mkfile(root, "target", mkfileOpts(nil, nil), replacement)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(root, "target"))
+		require.NoError(t, err)
+		assert.Equal(t, replacement, got)
+	})
+}
+
 func TestCleanerSubdirectory(t *testing.T) {
 	testCases := [][2]string{
 		{".", "."},

--- a/copier/copier_unix_test.go
+++ b/copier/copier_unix_test.go
@@ -104,6 +104,16 @@ func TestConditionalRemoveChroot(t *testing.T) {
 	canChroot = couldChroot
 }
 
+func TestMkfileChroot(t *testing.T) {
+	if uid != 0 {
+		t.Skip("chroot() requires root privileges, skipping")
+	}
+	couldChroot := canChroot
+	canChroot = true
+	testMkfile(t)
+	canChroot = couldChroot
+}
+
 func checkStatInfoOwnership(t *testing.T, result *StatForItem) {
 	t.Helper()
 	require.EqualValues(t, 0, result.UID, "expected the owning user to be reported")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind feature

#### What this PR does / why we need it:
Add a Mkfile() function that creates a file at a given path with provided content, permissions, ownership, and timestamp. Internally it builds a single-entry tar archive and passes it to Put(), reusing the existing infrastructure.

This aligns with BuildKit's FileActionMkFile operation and is part of the broader effort to support build definition file operations.
#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->
Fixes #6804

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

