### PR TITLE
Correctly report archiveSource if we can't find it

### DIFF
--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -211,7 +211,8 @@ func ImageName(transportName, restOfImageName, contextDir, tmpdir string) (newFr
 	case dockerArchiveTransport.Transport.Name(), ociArchiveTransport.Transport.Name(): // these are, basically, tarballs
 		// these take the form path[:stuff]
 		transportRef := restOfImageName
-		archiveSource, refLeftover, ok := strings.Cut(transportRef, ":")
+		as, refLeftover, ok := strings.Cut(transportRef, ":")
+		archiveSource = as
 		if ok {
 			refLeftover = ":" + refLeftover
 		}
@@ -241,7 +242,8 @@ func ImageName(transportName, restOfImageName, contextDir, tmpdir string) (newFr
 	case ociLayoutTransport.Transport.Name(): // this is a directory tree
 		// this takes the form path[:stuff]
 		transportRef := restOfImageName
-		archiveSource, refLeftover, ok := strings.Cut(transportRef, ":")
+		as, refLeftover, ok := strings.Cut(transportRef, ":")
+		archiveSource = as
 		if ok {
 			refLeftover = ":" + refLeftover
 		}


### PR DESCRIPTION
#### What type of PR is this?

> /kind bug

#### What this PR does / why we need it:

Don't write only to a shadowing variable live only inside the switch, there is a formerly-shadowed variable used afterwards.

#### How to verify it

Break `newSingleItemArchive` so that it produces nothing, and observe the `expected to have archived a copy of` message.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

