### PR TITLE
Fix a race in TestCannotChangeMultipleRequestsWithDifferentChroot

### DIFF
--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -3034,16 +3034,24 @@ func TestCannotChangeMultipleRequestsWithDifferentChroot(t *testing.T) {
 	decoder := json.NewDecoder(stdoutR)
 
 	req := request{Request: requestEval, Root: testDir, Directory: "/"}
-	var resp response
+
+	receiveResponse := func() response {
+		var resp response
+		require.NoError(t, stdoutR.SetReadDeadline(time.Now().Add(time.Second*5)))
+		if !assert.NoError(t, decoder.Decode(&resp), "failed to decode response from copier") {
+			_ = cmd.Wait()
+			t.Logf("stderr: %s", stderr.String())
+			t.FailNow()
+		}
+		return resp
+	}
 
 	require.NoError(t, encoder.Encode(&req), "failed to send first request to copier")
-	require.NoError(t, stdoutR.SetReadDeadline(time.Now().Add(time.Second*5)))
-	require.NoError(t, decoder.Decode(&resp), "failed to decode response from copier")
+	resp := receiveResponse()
 	require.Empty(t, resp.Error, "first request returned an error: %s", resp.Error)
 
 	require.NoError(t, encoder.Encode(&req), "failed to send second request to copier")
-	require.NoError(t, stdoutR.SetReadDeadline(time.Now().Add(time.Second*5)))
-	require.NoErrorf(t, decoder.Decode(&resp), "failed to decode response from copier: %s", stderr.String())
+	resp = receiveResponse()
 	require.Empty(t, resp.Error, "second request returned an error: %s", resp.Error)
 
 	require.NoError(t, encoder.Encode(&request{Request: requestQuit}))


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

`make test-unit` on a fairly slow machine reports a race.

The stderr buffer cannot be concurrently accessed while the process is still running, at least not without synchronization.

We should never need it, so only try to read it if the assertion fails.

#### How to verify it

`-race` reproduces the failure reliably for me, on a fairly small / slow arm64 VM.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Original report (redacted):
```
==================
WARNING: DATA RACE
Read at 0x00c000173c08 by goroutine 13:
  bytes.(*Buffer).String()
      /usr/lib/golang/src/bytes/buffer.go:77 +0x88c
  go.podman.io/buildah/copier.TestCannotChangeMultipleRequestsWithDifferentChroot()
      buildah/copier/copier_test.go:2707 +0x854
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /usr/lib/golang/src/testing/testing.go:1997 +0x3c

Previous write at 0x00c000173c08 by goroutine 14:
  bytes.(*Buffer).grow()
      /usr/lib/golang/src/bytes/buffer.go:160 +0x2e8
  bytes.(*Buffer).ReadFrom()
      /usr/lib/golang/src/bytes/buffer.go:215 +0x5c
  io.copyBuffer()
      /usr/lib/golang/src/io/io.go:415 +0x1bc
  io.Copy()
      /usr/lib/golang/src/io/io.go:388 +0x64
  os.genericWriteTo()
      /usr/lib/golang/src/os/file.go:295 +0x18
  os.(*File).WriteTo()
      /usr/lib/golang/src/os/file.go:273 +0xc0
  io.copyBuffer()
      /usr/lib/golang/src/io/io.go:411 +0xa8
  io.Copy()
      /usr/lib/golang/src/io/io.go:388 +0x58
  os/exec.(*Cmd).writerDescriptor.func1()
      /usr/lib/golang/src/os/exec/exec.go:596 +0x34
  os/exec.(*Cmd).Start.func2()
      /usr/lib/golang/src/os/exec/exec.go:749 +0x38
  os/exec.(*Cmd).Start.gowrap1()
      /usr/lib/golang/src/os/exec/exec.go:761 +0x40
…
Goroutine 14 (running) created at:
  os/exec.(*Cmd).Start()
      /usr/lib/golang/src/os/exec/exec.go:748 +0xb28
  go.podman.io/buildah/copier.TestCannotChangeMultipleRequestsWithDifferentChroot()
      buildah/copier/copier_test.go:2692 +0x3d0
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /usr/lib/golang/src/testing/testing.go:1997 +0x3c
```

#### Does this PR introduce a user-facing change?

```release-note
None
```

