### PR TITLE
Don't report an error in a possible RPC server start/stop ordering

### DIFF
--- a/cmd/buildah/rpc.go
+++ b/cmd/buildah/rpc.go
@@ -71,7 +71,9 @@ func rpcCmd(c *cobra.Command, args []string) error {
 	})
 	defer func() {
 		s.GracefulStop() // closes the listening socket
-		if err := errgroup.Wait(); err != nil {
+		// We might have called GracefulStop() before Serve() had a chance to start;
+		// in that case it returns ErrServerStopped.
+		if err := errgroup.Wait(); err != nil && err != grpc.ErrServerStopped {
 			logrus.Errorf("while waiting for rpc service to shut down: %v", err)
 		}
 	}()


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

```
not ok 897 rpc noop
# (from function `assert' in file ./helpers.bash, line 553,
#  in test file ./rpc.bats, line 7)
#   `assert "$output" = $(pwd)' failed
# …/buildah/tests …/buildah/tests
# # …/buildah/tests/./../bin/buildah rpc -l /var/tmp/buildah_tests.ufg3rg/socket pwd
# …/buildah/tests
# time="2026-05-21T06:40:46+02:00" level=error msg="while waiting for rpc service to shut down: grpc: the server has been stopped"
# #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
# #|     FAIL: buildah rpc -l /var/tmp/buildah_tests.ufg3rg/socket pwd
# #| expected: = '…/buildah/tests'
# #|   actual:   '…/buildah/tests'
# #|         >   'time="2026-05-21T06:40:46+02:00" level=error msg="while waiting for rpc service to shut down: grpc: the server has been stopped"'
# #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

#### How to verify it

Reproducible on a pretty slow VM.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
None
```

