### PR TITLE
 Clean up TempDirForURL directories for --build-context and ADD git

### DIFF
--- a/add.go
+++ b/add.go
@@ -602,12 +602,12 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 				go func() {
 					defer wg.Done()
 					defer pipeWriter.Close()
-					// TODO: the returned cloneDir is never cleaned up, leaking disk space.
 					var cloneDir, subdir string
 					cloneDir, subdir, getErr = define.TempDirForURL(tmpdir.GetTempDir(), "", src)
 					if getErr != nil {
 						return
 					}
+					defer os.RemoveAll(cloneDir)
 					getOptions := copier.GetOptions{
 						UIDMap:             srcUIDMap,
 						GIDMap:             srcGIDMap,

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -40,8 +40,16 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/archive"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
+
+type additionalBuildContext struct {
+	define.AdditionalBuildContext
+	// downloadedTempDir is the temporary directory created for the additional build context.
+	// It should be removed when the build ends.
+	downloadedTempDir string
+}
 
 // builtinAllowedBuildArgs is list of built-in allowed build args.  Normally we
 // complain if we're given values for arguments which have no corresponding ARG
@@ -161,7 +169,7 @@ type executor struct {
 	imageInfoLock                           sync.Mutex
 	imageInfoCache                          map[string]imageTypeAndHistoryAndDiffIDs
 	fromOverride                            string
-	additionalBuildContexts                 map[string]*define.AdditionalBuildContext
+	additionalBuildContexts                 map[string]*additionalBuildContext
 	manifest                                string
 	secrets                                 map[string]define.Secret
 	sshsources                              map[string]*sshagent.Source
@@ -268,6 +276,11 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		buildOutputs = append(buildOutputs, options.BuildOutput) //nolint:staticcheck
 	}
 
+	wrappedAdditionalBuildContexts := make(map[string]*additionalBuildContext, len(options.AdditionalBuildContexts))
+	for name, ctx := range options.AdditionalBuildContexts {
+		wrappedAdditionalBuildContexts[name] = &additionalBuildContext{AdditionalBuildContext: *ctx}
+	}
+
 	exec := executor{
 		args:                                    options.Args,
 		cacheFrom:                               options.CacheFrom,
@@ -358,7 +371,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		rusageLogFile:                           rusageLogFile,
 		imageInfoCache:                          make(map[string]imageTypeAndHistoryAndDiffIDs),
 		fromOverride:                            options.From,
-		additionalBuildContexts:                 options.AdditionalBuildContexts,
+		additionalBuildContexts:                 wrappedAdditionalBuildContexts,
 		manifest:                                options.Manifest,
 		secrets:                                 secrets,
 		sshsources:                              sshsources,
@@ -856,6 +869,21 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			}
 		}
 		cleanupImages = nil
+
+		var g errgroup.Group
+		for _, additionalBuildContext := range b.additionalBuildContexts {
+			if additionalBuildContext.downloadedTempDir != "" {
+				dir := additionalBuildContext.downloadedTempDir
+				g.Go(func() error {
+					logrus.Debugf("Removing additional build context temp dir %q", dir)
+					return os.RemoveAll(dir)
+				})
+			}
+		}
+		if err := g.Wait(); err != nil {
+			logrus.Debugf("Failed to cleanup additional build context temp dir: %v", err)
+			lastErr = err
+		}
 
 		if b.rusageLogFile != nil && b.rusageLogFile != b.out {
 			// we deliberately ignore the error here, as this

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -484,7 +484,7 @@ func (s *stageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 			if fromErr != nil {
 				return fmt.Errorf("unable to resolve argument %q: %w", copy.From, fromErr)
 			}
-			var additionalBuildContext *define.AdditionalBuildContext
+			var additionalBuildContext *additionalBuildContext
 			if foundContext, ok := s.executor.additionalBuildContexts[from]; ok {
 				additionalBuildContext = foundContext
 			} else {
@@ -512,18 +512,14 @@ func (s *stageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 							// additional context contains a tar file
 							// so download and explode tar to buildah
 							// temp and point context to that.
-							// TODO: the returned path is never cleaned up, leaking disk space.
 							path, subdir, err := define.TempDirForURL(tmpdir.GetTempDir(), internal.BuildahExternalArtifactsDir, additionalBuildContext.Value)
 							if err != nil {
 								return fmt.Errorf("unable to download context from external source %q: %w", additionalBuildContext.Value, err)
 							}
-							// point context dir to the extracted path
-							contextDir = filepath.Join(path, subdir)
-							// populate cache for next RUN step
-							additionalBuildContext.DownloadedCache = contextDir
-						} else {
-							contextDir = additionalBuildContext.DownloadedCache
+							additionalBuildContext.downloadedTempDir = path
+							additionalBuildContext.DownloadedCache = filepath.Join(path, subdir)
 						}
+						contextDir = additionalBuildContext.DownloadedCache
 					} else {
 						// This points to a path on the filesystem
 						// Check to see if there's a .containerignore
@@ -733,18 +729,14 @@ func (s *stageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 								// additional context contains a tar file
 								// so download and explode tar to buildah
 								// temp and point context to that.
-								// TODO: the returned path is never cleaned up, leaking disk space.
 								path, subdir, err := define.TempDirForURL(tmpdir.GetTempDir(), internal.BuildahExternalArtifactsDir, additionalBuildContext.Value)
 								if err != nil {
 									return nil, fmt.Errorf("unable to download context from external source %q: %w", additionalBuildContext.Value, err)
 								}
-								// point context dir to the extracted path
-								mountPoint = filepath.Join(path, subdir)
-								// populate cache for next RUN step
-								additionalBuildContext.DownloadedCache = mountPoint
-							} else {
-								mountPoint = additionalBuildContext.DownloadedCache
+								additionalBuildContext.downloadedTempDir = path
+								additionalBuildContext.DownloadedCache = filepath.Join(path, subdir)
 							}
+							mountPoint = additionalBuildContext.DownloadedCache
 						}
 						stageMountPoints[from] = internal.StageMountDetails{
 							IsAdditionalBuildContext: true,

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -3396,6 +3396,13 @@ _EOF
   done
 }
 
+# assert_no_tempdir_leaks checks $1 has no leftover temp download directories.
+function assert_no_tempdir_leaks() {
+  local tmpdir=$1
+  local leftovers=$(find $tmpdir -mindepth 1 -maxdepth 1 -print)
+  assert "$leftovers" == ""
+}
+
 # Helper function for several of the tests which pull from http.
 #
 #  Usage:  _test_http  SUBDIRECTORY  URL_PATH  [EXTRA ARGS]
@@ -3416,11 +3423,14 @@ function _test_http() {
 
   starthttpd "$BUDFILES/$testdir"
   target=scratch-image
-  run_buildah build $WITH_POLICY_JSON \
+  local tmpdir=${TEST_SCRATCH_DIR}/tmpdir
+  mkdir -p $tmpdir
+  TMPDIR=$tmpdir run_buildah build $WITH_POLICY_JSON \
 	      -t ${target} \
 	      "$@"         \
 	      http://0.0.0.0:${HTTP_SERVER_PORT}/$urlpath
   stophttpd
+  assert_no_tempdir_leaks $tmpdir
   run_buildah from ${target}
 }
 
@@ -3500,9 +3510,7 @@ function validate_instance_compression {
   mkdir -p "${tmpdir}"
   TMPDIR="${tmpdir}" run_buildah build $WITH_POLICY_JSON -t ${target} "${gitrepo}"
   run_buildah from "${target}"
-  run find "${tmpdir}" -type d -print
-  echo "$output"
-  test "${#lines[*]}" -le 2
+  assert_no_tempdir_leaks $tmpdir
 }
 
 @test "bud-git-context-failure" {
@@ -8180,7 +8188,10 @@ _EOF
 file.txt
 _EOF
 
-  run_buildah build -f $contextdir/Dockerfile -t add-git-ignoring-files $contextdir
+  local tmpdir=${TEST_SCRATCH_DIR}/tmpdir
+  mkdir -p $tmpdir
+  TMPDIR=$tmpdir run_buildah build -f $contextdir/Dockerfile -t add-git-ignoring-files $contextdir
+  assert_no_tempdir_leaks $tmpdir
 }
 
 @test "bud with ADD with git repository source escape directory" {
@@ -8214,9 +8225,11 @@ ADD http://0.0.0.0:${HTTP_SERVER_PORT}/git/test-bug.git#main:proj${secretdir} /m
 RUN cat /mydir/secretfile
 _EOF
 
-  run_buildah 125 build -f $contextdir/Containerfile -t escape-image --no-cache $contextdir
+  local tmpdir=${TEST_SCRATCH_DIR}/tmpdir
+  mkdir -p $tmpdir
+  TMPDIR=$tmpdir run_buildah 125 build -f $contextdir/Containerfile -t escape-image --no-cache $contextdir
   assert "$output" !~ "mysecret"
-  expect_output --substring "no such file or directory"
+  assert_no_tempdir_leaks $tmpdir
 }
 
 @test "bud with http context symlinked Dockerfile does not write through symlink on fallback" {
@@ -10509,4 +10522,36 @@ _EOF
 
   # Verify final image IDs match (complete cache hit)
   assert "$first_build_final_image_id" "==" "$second_build_final_image_id" "final image ID should match when cache is fully reused"
+}
+
+@test "build-with-additional-build-context URL temp dirs are cleaned up" {
+  _prefetch alpine
+
+  local tmpdir=${TEST_SCRATCH_DIR}/tmpdir
+  mkdir -p $tmpdir
+  local tarball_content=${TEST_SCRATCH_DIR}/tarball-src
+  mkdir -p $tarball_content/myproject
+  echo secret-content > $tarball_content/myproject/file.txt
+  local tarball=${TEST_SCRATCH_DIR}/context.tar.gz
+  tar -czf $tarball -C $tarball_content .
+  local httpdir=${TEST_SCRATCH_DIR}/http
+  mkdir -p $httpdir
+  cp $tarball $httpdir/context.tar.gz
+
+  starthttpd $httpdir
+  local contextdir=${TEST_SCRATCH_DIR}/bud/context
+  mkdir -p $contextdir
+  cat > $contextdir/Dockerfile << _EOF
+FROM alpine
+COPY --from=ctx myproject/file.txt /file.txt
+RUN cat /file.txt
+RUN --mount=type=bind,src=myproject,from=ctx2,target=/mnt,z cmp /file.txt /mnt/file.txt
+_EOF
+
+  TMPDIR=$tmpdir run_buildah build $WITH_POLICY_JSON \
+    --build-context ctx=http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar.gz \
+    --build-context ctx2=http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar.gz \
+    -t source -f $contextdir/Dockerfile $contextdir
+  expect_output --substring "secret-content"
+  assert_no_tempdir_leaks $tmpdir
 }


### PR DESCRIPTION
URL-based `--build-context` downloads and ADD git clones left temporary directories under `$TMPDIR` after builds. This PR removes them in `executor.cleanup()` and after ADD git handling, and adds bats checks via `assert_no_tempdir_leaks`.

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> 
/kind bug
> 
/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

