### PR TITLE
Reject symlinked Containerfile and ignore files escaping build context

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -1422,37 +1422,66 @@ func ContainerIgnoreFile(contextDir, path string, containerFiles []string) ([]st
 		excludes, err := imagebuilder.ParseIgnore(path)
 		return excludes, path, err
 	}
-	// If path was not supplied give priority to `<containerfile>.containerignore` first.
+	// If path was not supplied, look for `<containerfile>.dockerignore` and
+	// `<containerfile>.containerignore`. When both exist, `.containerignore` wins.
+	// securejoin confines lookups with RESOLVE_IN_ROOT semantics, matching
+	// Docker BuildKit behavior. When the containerfile is inside contextDir
+	// we resolve relative to contextDir; when it is outside (e.g.
+	// overlay-mounted context or -f pointing elsewhere) we resolve relative
+	// to the containerfile's parent directory.
 	for _, containerfile := range containerFiles {
 		if !filepath.IsAbs(containerfile) {
 			containerfile = filepath.Join(contextDir, containerfile)
 		}
-		containerfileIgnore := ""
-		if err := fileutils.Exists(containerfile + ".containerignore"); err == nil {
-			containerfileIgnore = containerfile + ".containerignore"
+		cleanPath := filepath.Clean(containerfile)
+		relPath, relErr := filepath.Rel(contextDir, cleanPath)
+		insideContext := relErr == nil && relPath != ".." && !strings.HasPrefix(relPath, ".."+string(filepath.Separator))
+		var rootDir, baseName string
+		if insideContext {
+			rootDir = contextDir
+			baseName = relPath
+		} else {
+			rootDir = filepath.Dir(cleanPath)
+			baseName = filepath.Base(cleanPath)
 		}
-		if err := fileutils.Exists(containerfile + ".dockerignore"); err == nil {
-			containerfileIgnore = containerfile + ".dockerignore"
+		excludes, resolved, err := findIgnoreFile(rootDir, baseName+".dockerignore", baseName+".containerignore")
+		if err != nil {
+			return nil, "", err
 		}
-		if containerfileIgnore != "" {
-			excludes, err := imagebuilder.ParseIgnore(containerfileIgnore)
-			return excludes, containerfileIgnore, err
+		if resolved != "" {
+			return excludes, resolved, nil
 		}
 	}
-	path, symlinkErr := securejoin.SecureJoin(contextDir, ".containerignore")
-	if symlinkErr != nil {
-		return nil, "", symlinkErr
+	excludes, resolved, err := findIgnoreFile(contextDir, ".dockerignore", ".containerignore")
+	if err != nil {
+		return nil, "", err
 	}
-	excludes, err := imagebuilder.ParseIgnore(path)
-	if errors.Is(err, os.ErrNotExist) {
-		path, symlinkErr = securejoin.SecureJoin(contextDir, ".dockerignore")
-		if symlinkErr != nil {
-			return nil, "", symlinkErr
+	if resolved != "" {
+		return excludes, resolved, nil
+	}
+	return nil, "", nil
+}
+
+// findIgnoreFile tries each candidate name resolved under rootDir using
+// securejoin (RESOLVE_IN_ROOT semantics). When both exist the last one wins.
+func findIgnoreFile(rootDir string, candidates ...string) ([]string, string, error) {
+	var excludes []string
+	var matched string
+	for _, name := range candidates {
+		resolved, err := securejoin.SecureJoin(rootDir, name)
+		if err != nil {
+			continue
 		}
-		excludes, err = imagebuilder.ParseIgnore(path)
+		f, err := os.Open(resolved)
+		if err != nil {
+			continue
+		}
+		excludes, err = imagebuilder.ParseIgnoreReader(f)
+		f.Close()
+		if err != nil {
+			return nil, "", err
+		}
+		matched = resolved
 	}
-	if errors.Is(err, os.ErrNotExist) {
-		return excludes, "", nil
-	}
-	return excludes, path, err
+	return excludes, matched, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,10 +2,12 @@ package util //nolint:revive,nolintlint
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"go.podman.io/buildah/pkg/parse"
 )
 
@@ -41,42 +43,77 @@ func MirrorToTempFileIfPathIsDescriptor(file string) (string, bool) {
 }
 
 // DiscoverContainerfile tries to find a Containerfile or a Dockerfile within the provided `path`.
+// The path may be a directory (in which case Containerfile/Dockerfile is searched inside it)
+// or a direct path to a container file.
+//
+// When path is a directory (or a symlink to one), Containerfile/Dockerfile
+// candidates are resolved with RESOLVE_IN_ROOT semantics so that symlinks
+// escaping the context are clamped back.  When path points directly at a
+// file (or a symlink to one), it is returned as-is.
 func DiscoverContainerfile(path string) (foundCtrFile string, err error) {
-	// Test for existence of the file
-	target, err := os.Stat(path)
+	path, err = filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("discovering Containerfile: %w", err)
 	}
 
-	switch mode := target.Mode(); {
-	case mode.IsDir():
-		// If the path is a real directory, we assume a Containerfile or a Dockerfile within it
-		ctrfile := filepath.Join(path, "Containerfile")
-
-		// Test for existence of the Containerfile file
-		file, err := os.Stat(ctrfile)
-		if err != nil {
-			// See if we have a Dockerfile within it
-			ctrfile = filepath.Join(path, "Dockerfile")
-
-			// Test for existence of the Dockerfile file
-			file, err = os.Stat(ctrfile)
-			if err != nil {
-				return "", fmt.Errorf("cannot find Containerfile or Dockerfile in context directory: %w", err)
-			}
-		}
-
-		// The file exists, now verify the correct mode
-		if mode := file.Mode(); mode.IsRegular() {
-			foundCtrFile = ctrfile
-		} else {
-			return "", fmt.Errorf("assumed Containerfile %q is not a file", ctrfile)
-		}
-
-	case mode.IsRegular():
-		// If the context dir is a file, we assume this as Containerfile
-		foundCtrFile = path
+	target, err := os.Lstat(path)
+	if err != nil {
+		return "", fmt.Errorf("discovering Containerfile: %w", err)
 	}
 
-	return foundCtrFile, nil
+	// If path is a symlink to a directory (e.g. the build context itself is
+	// a symlink), follow it so the IsDir() branch handles it.
+	if target.Mode()&os.ModeSymlink != 0 {
+		if realInfo, err := os.Stat(path); err == nil && realInfo.IsDir() {
+			target = realInfo
+		}
+	}
+
+	switch {
+	case target.IsDir():
+		for _, name := range []string{"Containerfile", "Dockerfile"} {
+			ctrfile := filepath.Join(path, name)
+			if resolved, ok := isRegularFileInContext(path, ctrfile); ok {
+				return resolved, nil
+			}
+		}
+		return "", fmt.Errorf("cannot find Containerfile or Dockerfile in context directory: %w", fs.ErrNotExist)
+
+	case target.Mode().IsRegular():
+		return path, nil
+
+	case target.Mode()&os.ModeSymlink != 0:
+		if fi, err := os.Stat(path); err == nil && fi.Mode().IsRegular() {
+			return path, nil
+		}
+		return "", fmt.Errorf("assumed Containerfile %q is not a file", path)
+
+	default:
+		return "", fmt.Errorf("assumed Containerfile %q is not a file", path)
+	}
+}
+
+// isRegularFileInContext checks whether path resolves to a regular file
+// inside contextDir using RESOLVE_IN_ROOT semantics (securejoin.SecureJoin):
+// ".." components are clamped to the root and absolute symlink targets are
+// re-rooted under contextDir.  This matches Docker BuildKit's behavior.
+//
+// On success it returns the resolved host path.
+func isRegularFileInContext(contextDir, path string) (string, bool) {
+	name, err := filepath.Rel(contextDir, path)
+	if err != nil {
+		return "", false
+	}
+	resolved, err := securejoin.SecureJoin(contextDir, name)
+	if err != nil {
+		return "", false
+	}
+	fi, err := os.Stat(resolved)
+	if err != nil {
+		return "", false
+	}
+	if !fi.Mode().IsRegular() {
+		return "", false
+	}
+	return resolved, true
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,10 +1,21 @@
 package util //nolint:revive,nolintlint
 
 import (
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func absPath(t *testing.T, rel string) string {
+	t.Helper()
+	p, err := filepath.Abs(rel)
+	require.NoError(t, err)
+	return p
+}
 
 func TestDiscoverContainerfile(t *testing.T) {
 	t.Parallel()
@@ -16,17 +27,120 @@ func TestDiscoverContainerfile(t *testing.T) {
 
 	name, err := DiscoverContainerfile("test/test1/Dockerfile")
 	assert.Nil(t, err)
-	assert.Equal(t, name, "test/test1/Dockerfile")
+	assert.Equal(t, absPath(t, "test/test1/Dockerfile"), name)
 
 	name, err = DiscoverContainerfile("test/test1/Containerfile")
 	assert.Nil(t, err)
-	assert.Equal(t, name, "test/test1/Containerfile")
+	assert.Equal(t, absPath(t, "test/test1/Containerfile"), name)
 
 	name, err = DiscoverContainerfile("test/test1")
 	assert.Nil(t, err)
-	assert.Equal(t, name, "test/test1/Containerfile")
+	assert.Equal(t, absPath(t, "test/test1/Containerfile"), name)
 
 	name, err = DiscoverContainerfile("test/test2")
 	assert.Nil(t, err)
-	assert.Equal(t, name, "test/test2/Dockerfile")
+	assert.Equal(t, absPath(t, "test/test2/Dockerfile"), name)
+}
+
+func TestDiscoverContainerfileRejectsSymlinkOutsideContext(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	secretFile := filepath.Join(tmpDir, "secret-Containerfile")
+	require.NoError(t, os.WriteFile(secretFile, []byte("FROM scratch\n"), 0o644))
+
+	contextDir := filepath.Join(tmpDir, "context")
+	require.NoError(t, os.Mkdir(contextDir, 0o755))
+	require.NoError(t, os.Symlink(secretFile, filepath.Join(contextDir, "Containerfile")))
+
+	_, err := DiscoverContainerfile(contextDir)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestDiscoverContainerfileAcceptsSymlinkInsideContext(t *testing.T) {
+	t.Parallel()
+	contextDir := t.TempDir()
+
+	subdir := filepath.Join(contextDir, "subdir")
+	require.NoError(t, os.Mkdir(subdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "Containerfile.real"), []byte("FROM scratch\n"), 0o644))
+	require.NoError(t, os.Symlink(filepath.Join("subdir", "Containerfile.real"), filepath.Join(contextDir, "Containerfile")))
+
+	name, err := DiscoverContainerfile(contextDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(contextDir, "subdir", "Containerfile.real"), name)
+}
+
+func TestDiscoverContainerfileAcceptsEscapeClampedToRoot(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	contextDir := filepath.Join(tmpDir, "context")
+	require.NoError(t, os.Mkdir(contextDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(contextDir, "file"), []byte("FROM scratch\n"), 0o644))
+	require.NoError(t, os.Symlink("../file", filepath.Join(contextDir, "Containerfile")))
+
+	name, err := DiscoverContainerfile(contextDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(contextDir, "file"), name)
+}
+
+func TestDiscoverContainerfileAcceptsAbsoluteSymlinkRerooted(t *testing.T) {
+	t.Parallel()
+	contextDir := t.TempDir()
+
+	subdir := filepath.Join(contextDir, "subdirectory")
+	require.NoError(t, os.Mkdir(subdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "real.file"), []byte("FROM scratch\n"), 0o644))
+	require.NoError(t, os.Symlink("/subdirectory/real.file", filepath.Join(contextDir, "Containerfile")))
+
+	name, err := DiscoverContainerfile(contextDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(contextDir, "subdirectory", "real.file"), name)
+}
+
+func TestDiscoverContainerfileAcceptsMultiLevelEscapeClampedToRoot(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	contextDir := filepath.Join(tmpDir, "context")
+	require.NoError(t, os.Mkdir(contextDir, 0o755))
+	subdir := filepath.Join(contextDir, "subdir")
+	require.NoError(t, os.Mkdir(subdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "file"), []byte("FROM scratch\n"), 0o644))
+	require.NoError(t, os.Symlink("../../subdir/file", filepath.Join(contextDir, "Containerfile")))
+
+	name, err := DiscoverContainerfile(contextDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(contextDir, "subdir", "file"), name)
+}
+
+func TestDiscoverContainerfileAcceptsSymlinkedDirectory(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	realDir := filepath.Join(tmpDir, "real-context")
+	require.NoError(t, os.Mkdir(realDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(realDir, "Containerfile"), []byte("FROM scratch\n"), 0o644))
+
+	symlinkedDir := filepath.Join(tmpDir, "symlinked-context")
+	require.NoError(t, os.Symlink(realDir, symlinkedDir))
+
+	name, err := DiscoverContainerfile(symlinkedDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(symlinkedDir, "Containerfile"), name)
+}
+
+func TestDiscoverContainerfileRejectsNonExistentClampedTarget(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	contextDir := filepath.Join(tmpDir, "context")
+	require.NoError(t, os.Mkdir(contextDir, 0o755))
+	require.NoError(t, os.Symlink("../nonexistent", filepath.Join(contextDir, "Containerfile")))
+
+	_, err := DiscoverContainerfile(contextDir)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -5087,19 +5087,19 @@ _EOF
 @test "bud without any arguments should fail when no Dockerfile exists" {
   cd $TEST_SCRATCH_DIR
   run_buildah 125 build --signature-policy ${TEST_SOURCES}/policy.json
-  expect_output --substring "no such file or directory"
+  expect_output --substring "cannot find Containerfile or Dockerfile"
 }
 
 @test "bud with specified context should fail if directory contains no Dockerfile" {
   mkdir -p $TEST_SCRATCH_DIR/empty-dir
   run_buildah 125 build $WITH_POLICY_JSON "$TEST_SCRATCH_DIR"/empty-dir
-  expect_output --substring "no such file or directory"
+  expect_output --substring "cannot find Containerfile or Dockerfile"
 }
 
 @test "bud with specified context should fail if Dockerfile in context directory is actually a file" {
   mkdir -p "$TEST_SCRATCH_DIR"/Dockerfile
   run_buildah 125 build $WITH_POLICY_JSON "$TEST_SCRATCH_DIR"
-  expect_output --substring "is not a file"
+  expect_output --substring "cannot find Containerfile or Dockerfile"
 }
 
 @test "bud with specified context should fail if context directory does not exist" {
@@ -8394,6 +8394,202 @@ srv.serve_forever()
   run_buildah 125 build $WITH_POLICY_JSON - < ${broken_tar}
   run cat ${targetfile}
   assert "$output" = "ORIGINAL_CONTENT"
+}
+
+# https://github.com/podman-container-tools/buildah/issues/6861
+@test "bud with local context symlinked Containerfile outside context" {
+  _prefetch alpine
+
+  local secretfile=${TEST_SCRATCH_DIR}/secretfile
+  cat > ${secretfile} << _EOF
+FROM alpine
+RUN echo SECRETHOSTCONTENT
+_EOF
+
+  local contextdir=${TEST_SCRATCH_DIR}/dir2
+  mkdir -p ${contextdir}
+  ln -s ${secretfile} ${contextdir}/Containerfile
+
+  run_buildah 125 build $WITH_POLICY_JSON ${contextdir}
+  assert "$output" !~ "SECRETHOSTCONTENT"
+}
+
+# https://github.com/podman-container-tools/buildah/issues/6861
+@test "bud with local context symlinked Containerfile within context" {
+  _prefetch alpine
+
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p ${contextdir}/subdir
+  cat > ${contextdir}/subdir/Containerfile.real << _EOF
+FROM alpine
+RUN echo symlink-within-context-works
+_EOF
+  ln -s subdir/Containerfile.real ${contextdir}/Containerfile
+
+  run_buildah build $WITH_POLICY_JSON ${contextdir}
+  assert "$output" =~ "symlink-within-context-works"
+}
+
+# https://github.com/podman-container-tools/buildah/pull/6886#discussion_r3524076920
+@test "bud accepts symlinked context directory" {
+  _prefetch alpine
+
+  local realdir=${TEST_SCRATCH_DIR}/real-context
+  mkdir -p ${realdir}
+  cat > ${realdir}/Containerfile << _EOF
+FROM alpine
+RUN echo symlinked-context-dir-works
+_EOF
+
+  ln -s ${realdir} ${TEST_SCRATCH_DIR}/symlinked-context
+
+  run_buildah build $WITH_POLICY_JSON ${TEST_SCRATCH_DIR}/symlinked-context
+  assert "$output" =~ "symlinked-context-dir-works"
+}
+
+# https://github.com/podman-container-tools/buildah/issues/6861
+# https://github.com/podman-container-tools/buildah/pull/6886#discussion_r3363659942
+@test "bud accepts symlinked Dockerfile with relative escape clamped to context root" {
+  _prefetch alpine
+
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p ${contextdir}
+  cat > ${contextdir}/file << _EOF
+FROM alpine
+RUN echo escape-clamped-works
+_EOF
+  # ../file escapes via ".." but RESOLVE_IN_ROOT clamps it to the context
+  # root, so it resolves to ./file inside the context.  Docker BuildKit
+  # accepts this (see moby/buildkit#6840).
+  ln -s ../file ${contextdir}/Dockerfile
+
+  run_buildah build $WITH_POLICY_JSON ${contextdir}
+  assert "$output" =~ "escape-clamped-works"
+}
+
+@test "bud rejects symlinked Dockerfile whose clamped path does not exist" {
+  _prefetch alpine
+
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p ${contextdir}
+  cat > ${contextdir}/file << _EOF
+FROM alpine
+RUN echo SHOULD-NOT-RUN
+_EOF
+  ln -s ../context/file ${contextdir}/Dockerfile
+
+  run_buildah 125 build $WITH_POLICY_JSON ${contextdir}
+  expect_output --substring "cannot find Containerfile or Dockerfile"
+  assert "$output" !~ "SHOULD-NOT-RUN"
+}
+
+# https://github.com/podman-container-tools/buildah/issues/6861
+@test "bud rejects symlinked Dockerfile to non-existent target" {
+  _prefetch alpine
+
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p ${contextdir}
+  ln -s ../nonexistent ${contextdir}/Dockerfile
+
+  run_buildah 125 build $WITH_POLICY_JSON ${contextdir}
+  expect_output --substring "cannot find Containerfile or Dockerfile"
+}
+
+# https://github.com/podman-container-tools/buildah/issues/6861
+@test "bud accepts absolute symlinked Dockerfile re-rooted under context" {
+  _prefetch alpine
+
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p ${contextdir}/subdirectory
+  cat > ${contextdir}/subdirectory/Containerfile.real << _EOF
+FROM alpine
+RUN echo absolute-rerooted-works
+_EOF
+  ln -s /subdirectory/Containerfile.real ${contextdir}/Dockerfile
+
+  run_buildah build $WITH_POLICY_JSON ${contextdir}
+  assert "$output" =~ "absolute-rerooted-works"
+}
+
+# https://github.com/podman-container-tools/buildah/issues/6861
+@test "bud with stdin tar context rejects symlinked Dockerfile pointing outside temp dir" {
+  local targetfile=${TEST_SCRATCH_DIR}/targetfile
+  echo "SECRET_CONTENT" > ${targetfile}
+
+  local tarsrc=${TEST_SCRATCH_DIR}/tarsrc
+  mkdir -p ${tarsrc}
+  ln -s ${targetfile} ${tarsrc}/Dockerfile
+  local context_tar=${TEST_SCRATCH_DIR}/context.tar
+  tar -cf ${context_tar} --owner=0:0 --numeric-owner -C ${tarsrc} Dockerfile
+
+  run_buildah 125 build $WITH_POLICY_JSON - < ${context_tar}
+  assert "$output" =~ "cannot find Containerfile or Dockerfile"
+  assert "$output" !~ "SECRET_CONTENT"
+}
+
+# https://github.com/podman-container-tools/buildah/issues/6861
+@test "bud with http tar context rejects symlinked Dockerfile pointing outside temp dir" {
+  local targetfile=${TEST_SCRATCH_DIR}/targetfile
+  echo "SECRET_CONTENT" > ${targetfile}
+
+  local tarsrc=${TEST_SCRATCH_DIR}/tarsrc
+  mkdir -p ${tarsrc}
+  ln -s ${targetfile} ${tarsrc}/Dockerfile
+  local contentdir=${TEST_SCRATCH_DIR}/content
+  mkdir -p ${contentdir}
+  tar -cf ${contentdir}/context.tar --owner=0:0 --numeric-owner -C ${tarsrc} Dockerfile
+  starthttpd ${contentdir}
+
+  run_buildah 125 build $WITH_POLICY_JSON http://0.0.0.0:${HTTP_SERVER_PORT}/context.tar
+  assert "$output" =~ "cannot find Containerfile or Dockerfile"
+  assert "$output" !~ "SECRET_CONTENT"
+}
+
+# https://github.com/podman-container-tools/buildah/issues/6861
+# https://github.com/podman-container-tools/podman/issues/28749
+@test "bud does not follow symlinked dockerignore outside context" {
+  _prefetch alpine
+
+  # dir/
+  #   ign                  <- ignore file outside context (excludes "file")
+  #   context/
+  #     Dockerfile
+  #     file
+  #     Dockerfile.dockerignore -> ../ign   (relative symlink escaping context)
+  local dir=${TEST_SCRATCH_DIR}
+  local contextdir=${dir}/context
+  mkdir -p ${contextdir}
+  echo "file" > ${dir}/ign
+
+  cat > ${contextdir}/Dockerfile << _EOF
+FROM alpine
+COPY file /dir/
+RUN test -f /dir/file
+_EOF
+  touch ${contextdir}/file
+  ln -s ../ign ${contextdir}/Dockerfile.dockerignore
+
+  run_buildah build $WITH_POLICY_JSON ${contextdir}
+}
+
+# https://github.com/podman-container-tools/buildah/issues/6861
+# https://github.com/podman-container-tools/podman/issues/28749
+@test "bud follows symlinked containerignore within context" {
+  _prefetch alpine
+
+  local contextdir=${TEST_SCRATCH_DIR}/context
+  mkdir -p ${contextdir}/conf
+  echo "file" > ${contextdir}/conf/ignore-rules
+
+  cat > ${contextdir}/Containerfile << _EOF
+FROM alpine
+COPY * /dir/
+RUN test ! -f /dir/file
+_EOF
+  touch ${contextdir}/file
+  ln -s conf/ignore-rules ${contextdir}/.containerignore
+
+  run_buildah build $WITH_POLICY_JSON ${contextdir}
 }
 
 @test "build-validates-bind-bind-propagation" {


### PR DESCRIPTION
Fixes: https://github.com/podman-container-tools/buildah/issues/6861 
Fixes: https://github.com/podman-container-tools/podman/issues/28749

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Buildah no longer follows symlinked Containerfile/Dockerfile or ignore files (e.g. Dockerfile.dockerignore) that point outside the build context directory, matching docker build behavior.
```

