### PR TITLE
ci: apt-get update before installing docker.io on debian-sid

### DIFF
--- a/contrib/ci/runner.sh
+++ b/contrib/ci/runner.sh
@@ -45,6 +45,7 @@ if [[ "$TEST" == "conformance" ]]; then
             sudo dnf install -y docker || sudo dnf install -y moby-engine
             ;;
         debian)
+            sudo apt-get update
             sudo apt-get install -y --no-install-recommends docker.io
             ;;
     esac


### PR DESCRIPTION
The conformance jobs on debian-sid have been failing intermittently with 404s when fetching docker.io, e.g.:

    E: Failed to fetch https://deb.debian.org/debian/pool/main/d/docker.io/docker.io_28.5.2+dfsg4-1_amd64.deb  404  Not Found

4-1 is not longer existing. 

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

