### PR TITLE
parse: honor containers.conf seccomp_profile

### DIFF
--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -235,6 +235,7 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container config: %w", err)
 	}
+	securityOpts = addSeccompFromConfig(securityOpts, defConfig.Containers.SeccompProfile)
 	if defConfig.Containers.EnableLabeledUsers {
 		defSecurityOpts, err := currentLabelOpts()
 		if err != nil {
@@ -247,6 +248,21 @@ func CommonBuildOptionsFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name 
 		return nil, err
 	}
 	return commonOpts, nil
+}
+
+// addSeccompFromConfig appends seccompProfile as a seccomp security option
+// when seccompProfile is non-default and securityOpts does not already contain
+// a seccomp option.
+func addSeccompFromConfig(securityOpts []string, seccompProfile string) []string {
+	if seccompProfile == "" || seccompProfile == SeccompDefaultPath {
+		return securityOpts
+	}
+	for _, opt := range securityOpts {
+		if strings.HasPrefix(opt, "seccomp=") {
+			return securityOpts
+		}
+	}
+	return append(securityOpts, "seccomp="+seccompProfile)
 }
 
 // GetAdditionalBuildContext consumes a raw string and returns a parsed

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -3,6 +3,7 @@ package parse //nolint:revive,nolintlint
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.podman.io/buildah/define"
+	"go.podman.io/common/pkg/config"
 	"go.podman.io/image/v5/types"
 )
 
@@ -27,6 +29,70 @@ func TestCommonBuildOptionsFromFlagSet(t *testing.T) {
 	cbo, err := CommonBuildOptionsFromFlagSet(fs, fs.Lookup)
 	assert.NoError(t, err)
 	assert.Equal(t, cbo.Memory, int64(2147483648))
+}
+
+func TestCommonBuildOptionsSeccompFromConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "containers.conf")
+	t.Setenv("CONTAINERS_CONF", configPath)
+	t.Cleanup(func() {
+		_, err := config.Reload()
+		assert.NoError(t, err)
+	})
+
+	defaultOptions := new(define.CommonBuildOptions)
+	require.NoError(t, parseSecurityOpts(nil, defaultOptions))
+
+	tests := []struct {
+		name            string
+		containersConf  string
+		securityOpts    []string
+		expectedProfile string
+	}{
+		{
+			name:            "configured unconfined",
+			containersConf:  "[containers]\nseccomp_profile = \"unconfined\"\n",
+			expectedProfile: "unconfined",
+		},
+		{
+			name:            "command line overrides config",
+			containersConf:  "[containers]\nseccomp_profile = \"unconfined\"\n",
+			securityOpts:    []string{"seccomp=/tmp/custom-seccomp.json"},
+			expectedProfile: "/tmp/custom-seccomp.json",
+		},
+		{
+			name:            "no configured profile",
+			containersConf:  "[containers]\n",
+			expectedProfile: defaultOptions.SeccompProfilePath,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, os.WriteFile(configPath, []byte(test.containersConf), 0o600))
+			_, err := config.Reload()
+			require.NoError(t, err)
+
+			fs := newCommonBuildOptionsFlagSet(t, test.securityOpts)
+			commonOpts, err := CommonBuildOptionsFromFlagSet(fs, fs.Lookup)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedProfile, commonOpts.SeccompProfilePath)
+		})
+	}
+}
+
+func newCommonBuildOptionsFlagSet(t *testing.T, securityOpts []string) *pflag.FlagSet {
+	t.Helper()
+
+	fs := pflag.NewFlagSet("common-build-options", pflag.ContinueOnError)
+	fs.String("cpuset-cpus", "", "")
+	fs.String("cpuset-mems", "", "")
+	fs.String("cgroup-parent", "", "")
+	fs.String("shm-size", "65536k", "")
+	fs.StringArray("security-opt", nil, "")
+	for _, securityOpt := range securityOpts {
+		require.NoError(t, fs.Set("security-opt", securityOpt))
+	}
+	return fs
 }
 
 // TestDeviceParser verifies the given device strings is parsed correctly


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug


#### What this PR does / why we need it:

Buildah was already loading `containers.conf`, but it was not applying the `SeccompProfile` field to `CommonBuildOptions`. This patch wires that field into the existing security opt parsing path. If the user explicitly provides a CLI seccomp option, CLI values take precedence.


#### How to verify it

`go test ./pkg/parse`

I added a config parsing test that verifies:

- seccomp_profile = "unconfined" from containers.conf is applied.
- An explicit CLI --security-opt seccomp=... value takes precedence over the configured profile.
- When no seccomp profile is configured, the existing default behavior is preserved.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

Fixes: #6498

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Buildah now honors containers.conf's seccomp_profile setting.
```

