### PR TITLE
[release-1.43] rpm/buildah.spec tests: require xz and /usr/bin/selinuxenabled

### DIFF
--- a/rpm/buildah.spec
+++ b/rpm/buildah.spec
@@ -97,6 +97,9 @@ Requires: bats
 Recommends: bats
 %endif
 Requires: bzip2
+Requires: xz
+Requires: zstd
+Requires: which
 Requires: podman
 Requires: golang
 Requires: jq
@@ -104,6 +107,7 @@ Requires: httpd-tools
 Requires: openssl
 Requires: nmap-ncat
 Requires: git-daemon
+Requires: libselinux-utils
 
 %description tests
 %{summary}


### PR DESCRIPTION
Tests use selinuxenabled to check if SELinux is enabled and relabeling is required when using volumes.
Some tarballs downloaded by tests are compressed using xz, as some are created using bzip2, which is called by tar, so make sure it's there.


(cherry picked from commit 6c0ab880947127292c8b48e9d2772d77334525b4)

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Address concern in https://github.com/podman-container-tools/buildah/pull/6887#issuecomment-4616712513 

#### How to verify it

Verify cherrypicked change and see if tests blow up

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

