### PR TITLE
run: skip /dev/mqueue mount if not supported by the kernel

### DIFF
--- a/run_linux.go
+++ b/run_linux.go
@@ -3,6 +3,7 @@
 package buildah
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -1373,7 +1374,17 @@ func setupSpecialMountSpecChanges(spec *specs.Spec, shmSize string) ([]specs.Mou
 
 	isUserns := isNewUserns || isRootless
 
-	if isUserns && !isIpcns {
+	// Check /proc/filesystems to see if the kernel supports mqueue.
+	if !isMqueueSupported() {
+		// The default /dev/mqueue mount would fail with ENODEV, so drop it.
+		filtered := make([]specs.Mount, 0, len(mounts))
+		for _, m := range mounts {
+			if m.Destination != "/dev/mqueue" {
+				filtered = append(filtered, m)
+			}
+		}
+		mounts = filtered
+	} else if isUserns && !isIpcns {
 		devMqueue := "/dev/mqueue"
 		devMqueueMnt := specs.Mount{
 			Destination: devMqueue,
@@ -1428,6 +1439,27 @@ func setupSpecialMountSpecChanges(spec *specs.Spec, shmSize string) ([]specs.Mou
 
 	return mounts, nil
 }
+
+// isMqueueSupported reports whether the kernel supports the mqueue
+// filesystem, i.e. was built with CONFIG_POSIX_MQUEUE.
+var isMqueueSupported = sync.OnceValue(func() bool {
+	f, err := os.Open("/proc/filesystems")
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) > 0 && fields[len(fields)-1] == "mqueue" {
+			return true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		logrus.Warnf("Failed to read /proc/filesystems: %v, assuming mqueue is not supported", err)
+	}
+	return false
+})
 
 func checkIDsGreaterThan5(ids []specs.LinuxIDMapping) bool {
 	for _, r := range ids {

--- a/run_linux_test.go
+++ b/run_linux_test.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package buildah
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupSpecialMountSpecChangesMqueue(t *testing.T) {
+	orig := isMqueueSupported
+	t.Cleanup(func() { isMqueueSupported = orig })
+
+	for _, supported := range []bool{true, false} {
+		t.Run(fmt.Sprintf("mqueue supported=%v", supported), func(t *testing.T) {
+			isMqueueSupported = func() bool { return supported }
+
+			g, err := generate.New("linux")
+			require.NoError(t, err)
+			mounts, err := setupSpecialMountSpecChanges(g.Config, "65536k")
+			require.NoError(t, err)
+
+			hasMqueue := slices.ContainsFunc(mounts, func(m specs.Mount) bool {
+				return m.Destination == "/dev/mqueue"
+			})
+			assert.Equal(t, supported, hasMqueue,
+				"the /dev/mqueue mount should be present if and only if the kernel supports mqueue")
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

On kernels built without `CONFIG_POSIX_MQUEUE`, the default `type=mqueue` mount for `/dev/mqueue` (seeded by runtime-tools' `generate.New()`) makes the runtime fail with `ENODEV` on every `buildah run` — and, through the copy vendored into podman, on every `RUN` instruction in `podman build`.

This ports the fix podman already has for `podman run`/`create` (podman-container-tools/podman#28639) into buildah's spec generation: check `/proc/filesystems` for mqueue support, and drop the `/dev/mqueue` mount from the spec when the kernel doesn't provide the filesystem. When mqueue is unsupported the userns+host-IPC bind-mount replacement is skipped too, since the host has no `/dev/mqueue` to bind in that case.

The `isMqueueSupported` implementation mirrors podman's (`sync.OnceValue`, same parsing) so the two stay consistent.

#### How to verify it

On a kernel without `CONFIG_POSIX_MQUEUE` (no `mqueue` line in `/proc/filesystems`), `buildah run` previously failed with `ENODEV` mounting `/dev/mqueue`; with this change the mount is dropped and the container starts. On normal kernels behavior is unchanged.

The added unit test stubs `isMqueueSupported` and checks that the `/dev/mqueue` mount is present in the generated spec if and only if the kernel supports it.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The equivalent podman-side fix landed in podman-container-tools/podman#28639 (commits 1bda61b840 and d8df5c37ef); this change keeps buildah's behavior and implementation aligned with it.

#### Does this PR introduce a user-facing change?

```release-note
Fixed `buildah run` failing with ENODEV on kernels built without CONFIG_POSIX_MQUEUE by omitting the /dev/mqueue mount when the kernel does not support the mqueue filesystem.
```