### PR TITLE
chroot: skip setgroups when namespace denies it

### DIFF
--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -684,24 +684,33 @@ func runUsingChrootExecMain() {
 
 	// Drop privileges.
 	user := options.Spec.Process.User
+
+	// Check if /proc/self/setgroups is set to "deny" before attempting to set supplemental groups.
+	denied := setgroupsDenied()
+
 	if len(user.AdditionalGids) > 0 {
-		gids := make([]int, len(user.AdditionalGids))
-		for i := range user.AdditionalGids {
-			gids[i] = int(user.AdditionalGids[i])
-		}
-		logrus.Debugf("setting supplemental groups")
-		if err = syscall.Setgroups(gids); err != nil {
-			fmt.Fprintf(os.Stderr, "error setting supplemental groups list: %v\n", err)
-			os.Exit(1)
+		if denied {
+			logrus.Debugf("not setting supplemental groups %v: /proc/self/setgroups is \"deny\"", user.AdditionalGids)
+		} else {
+			gids := make([]int, len(user.AdditionalGids))
+			for i := range user.AdditionalGids {
+				gids[i] = int(user.AdditionalGids[i])
+			}
+			logrus.Debugf("setting supplemental groups")
+			if err = syscall.Setgroups(gids); err != nil {
+				fmt.Fprintf(os.Stderr, "error setting supplemental groups list: %v\n", err)
+				os.Exit(1)
+			}
 		}
 	} else {
-		setgroups, _ := os.ReadFile("/proc/self/setgroups")
-		if strings.Trim(string(setgroups), "\n") != "deny" {
+		if !denied {
 			logrus.Debugf("clearing supplemental groups")
 			if err = syscall.Setgroups([]int{}); err != nil {
 				fmt.Fprintf(os.Stderr, "error clearing supplemental groups list: %v\n", err)
 				os.Exit(1)
 			}
+		} else {
+			logrus.Debugf("not clearing supplemental groups: /proc/self/setgroups is \"deny\"")
 		}
 	}
 

--- a/chroot/run_freebsd.go
+++ b/chroot/run_freebsd.go
@@ -270,3 +270,8 @@ func setPdeathsig(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
 }
+
+// setgroupsDenied always returns false on FreeBSD; no such mechanism exists.
+func setgroupsDenied() bool {
+	return false
+}

--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -838,3 +838,16 @@ func setPdeathsig(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
 }
+
+// setgroupsDenied reports whether this process's user namespace denies
+// setgroups(). Returns false on read error, so callers still attempt it.
+func setgroupsDenied() bool {
+	setgroupState, err := os.ReadFile("/proc/self/setgroups")
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logrus.Warnf("error reading /proc/self/setgroups: %v", err)
+		}
+		return false
+	}
+	return strings.TrimSpace(string(setgroupState)) == "deny"
+}

--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -215,3 +215,157 @@ EOF
   chmod +rx ${TEST_SCRATCH_DIR}/script1 ${TEST_SCRATCH_DIR}/script2
   env -i unshare -inCfpm bash ${TEST_SCRATCH_DIR}/script1
 }
+
+@test "chroot RUN succeeds when setgroups is denied" {
+  skip_if_no_unshare
+  if test `uname` != Linux ; then
+    skip "not meaningful except on Linux"
+  fi
+
+  baseimage=registry.access.redhat.com/ubi10:latest
+  _prefetch $baseimage
+  baseimagef=$(tr -c a-zA-Z0-9.- - <<< "$baseimage")
+
+  storagedir=${TEST_SCRATCH_DIR}/storage
+  mkdir $storagedir
+  rootdir=${storagedir}/rootdir
+  mkdir $rootdir
+  runrootdir=${storagedir}/runrootdir
+  mkdir $runrootdir
+  # ignore_chown_errors lets the base image extract in the single-ID namespace,
+  # where high gids in the rootfs can't be represented; unrelated to the bug.
+  storageopts="--storage-driver vfs --storage-opt vfs.ignore_chown_errors=true --root $rootdir --runroot $runrootdir"
+
+  context=${TEST_SCRATCH_DIR}/context ; mkdir $context
+  echo "FROM $baseimage" > $context/Dockerfile
+  echo "RUN echo regression-marker-ran" >> $context/Dockerfile
+
+  cp ${COPY_BINARY} ${TEST_SCRATCH_DIR}/copy
+  cp ${BUILDAH_BINARY} ${TEST_SCRATCH_DIR}/buildah
+
+  echo set -e > ${TEST_SCRATCH_DIR}/script.sh
+  echo "mount -t tmpfs tmpfs /run/lock" >> ${TEST_SCRATCH_DIR}/script.sh
+  # confirm we really are in a setgroups-denied namespace -- the bug's precondition
+  echo "test \"\$(cat /proc/self/setgroups)\" = deny" >> ${TEST_SCRATCH_DIR}/script.sh
+  # seed the store from the prefetched cache so the build needs no network
+  echo "${TEST_SCRATCH_DIR}/copy ${storageopts} dir:\$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
+  # the actual regression: this build used to fail at the RUN step with EPERM
+  echo "${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} build --isolation chroot --pull=never $context" >> ${TEST_SCRATCH_DIR}/script.sh
+
+  run unshare --user --map-root-user --mount bash ${TEST_SCRATCH_DIR}/script.sh
+  echo "$output"
+  assert "$status" -eq 0
+  expect_output --substring "regression-marker-ran"
+}
+
+@test "chroot run denies group access to a member when group bits are restrictive" {
+  skip_if_no_unshare
+  if test `uname` != Linux ; then
+    skip "not meaningful except on Linux"
+  fi
+  if ! test -e /etc/subgid ; then
+    skip "no /etc/subgid allocation to set up the probe"
+  fi
+  if ! test -e /etc/subuid ; then
+    skip "no /etc/subuid allocation to set up the probe"
+  fi
+
+  baseimage=registry.access.redhat.com/ubi10:latest
+  _prefetch $baseimage
+  baseimagef=$(tr -c a-zA-Z0-9.- - <<< "$baseimage")
+
+  storagedir=${TEST_SCRATCH_DIR}/storage
+  mkdir $storagedir
+  rootdir=${storagedir}/rootdir
+  mkdir $rootdir
+  runrootdir=${storagedir}/runrootdir
+  mkdir $runrootdir
+  storageopts="--storage-driver vfs --storage-opt vfs.ignore_chown_errors=true --root $rootdir --runroot $runrootdir"
+
+  probe=${TEST_SCRATCH_DIR}/probe
+  mkdir $probe
+
+  subgidline=$(grep "^$(id -un):" /etc/subgid | head -1)
+  substart=$(echo "$subgidline" | cut -d: -f2)
+  subsize=$(echo "$subgidline" | cut -d: -f3)
+  if test -z "$substart" || test -z "$subsize" ; then
+    skip "no subgid range for $(id -un) to set up the probe"
+  fi
+
+  subuidline=$(grep "^$(id -un):" /etc/subuid | head -1)
+  subuidstart=$(echo "$subuidline" | cut -d: -f2)
+  subuidsize=$(echo "$subuidline" | cut -d: -f3)
+  if test -z "$subuidstart" || test -z "$subuidsize" ; then
+    skip "no subuid range for $(id -un) to set up the probe"
+  fi
+
+  # The namespaces below map inner gid 0 to our real egid, and inner gids
+  # 1..${subsize} to our subordinate gid range.  The innermost namespace, where
+  # the build runs, maps only our real uid/gid to 0, so:
+  #   okgid   -- inner 0 -> our real egid, which is also the RUN process's
+  #              primary gid, so the RUN process is a member of it.
+  #   notmine -- an inner gid from the subordinate range, which the build's
+  #              namespace does not map and the RUN process does not hold.
+  okgid=0
+  notmine=4242
+  if test "$notmine" -lt 1 || test "$notmine" -gt "$subsize" ; then
+    skip "gid $notmine is outside the mappable subordinate range 1..$subsize"
+  fi
+
+  # member_denied: group okgid, mode 0004 (owner ---, group ---, other r).  The
+  # RUN process is a member of the group, so the group bits must deny it even
+  # though "other" would allow.  This checks in_group_p()'s fsgid path.
+  echo secret_member > $probe/member_denied
+  # nonmember_allowed: group notmine, mode 0004.  The RUN process is not a
+  # member, so it falls through to "other" (r) and is allowed.  Control for the
+  # above: if both were denied, member_denied would prove nothing.
+  echo ok_nonmember > $probe/nonmember_allowed
+
+  # Set ownership and bits from a namespace that maps our subordinate ranges, so
+  # no sudo is needed.  Files are chown'ed to inner uid 1 (our subordinate
+  # range) so the RUN process is not their owner and cannot use CAP_DAC_OVERRIDE
+  # on them -- capable_wrt_inode_uidgid() requires the inode's uid to be mapped,
+  # and inner uid 1 is not mapped in the build's namespace.
+  unshare --user --mount \
+    --map-users=$(id -u),0,1 --map-users=${subuidstart},1,1 \
+    --map-groups=$(id -g),0,1 --map-groups=${substart},1,${subsize} \
+    sh -c "
+    set -e
+    chown 1:$okgid   $probe/member_denied     && chmod 0004 $probe/member_denied
+    chown 1:$notmine $probe/nonmember_allowed && chmod 0004 $probe/nonmember_allowed
+  " || skip "user namespace could not map the uid/gids for the probe"
+
+  cp ${COPY_BINARY} ${TEST_SCRATCH_DIR}/copy
+  cp ${BUILDAH_BINARY} ${TEST_SCRATCH_DIR}/buildah
+
+  echo set -e > ${TEST_SCRATCH_DIR}/script.sh
+  echo "mount -t tmpfs tmpfs /run/lock" >> ${TEST_SCRATCH_DIR}/script.sh
+  # setgroups-denied single-ID namespace -- same environment as #6947
+  echo "test \"\$(cat /proc/self/setgroups)\" = deny" >> ${TEST_SCRATCH_DIR}/script.sh
+  echo "${TEST_SCRATCH_DIR}/copy ${storageopts} dir:\$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
+  echo "ctr=\$(${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} from --pull=never -q $baseimage)" >> ${TEST_SCRATCH_DIR}/script.sh
+  echo "${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} run --isolation chroot -v $probe:/probe:ro,z \"\$ctr\" -- sh -c 'echo setgroups:\$(cat /proc/self/setgroups); stat -c \"member_denied=%u:%g:%a\" /probe/member_denied; stat -c \"nonmember_allowed=%u:%g:%a\" /probe/nonmember_allowed; grep ^Gid: /proc/self/status; cat /probe/nonmember_allowed && ! cat /probe/member_denied'" >> ${TEST_SCRATCH_DIR}/script.sh
+
+  # Two namespaces, mirroring the reported environment: the outer one is mapped
+  # via newuidmap/newgidmap, which leaves setgroups() permitted, so we can drop
+  # our supplemental groups the way the container runtime would have; the inner
+  # one is the single-ID namespace, where the kernel requires setgroups to be
+  # denied before it will accept the mappings.
+  run unshare --user --mount \
+    --map-users=$(id -u),0,1 --map-users=${subuidstart},1,${subuidsize} \
+    --map-groups=$(id -g),0,1 --map-groups=${substart},1,${subsize} \
+    sh -c "setpriv --groups 0 -- unshare --user --map-root-user --mount bash ${TEST_SCRATCH_DIR}/script.sh"
+  echo "$output"
+  assert "$status" -eq 0
+  # the probes have to run inside buildah run, in the denied namespace
+  expect_output --substring "setgroups:deny"
+  # both files must be owned by an unmapped uid (65534), so neither the owner
+  # bits nor CAP_DAC_OVERRIDE apply, and both must still be mode 0004
+  expect_output --substring "member_denied=65534:${okgid}:4"
+  expect_output --substring "nonmember_allowed=65534:65534:4"
+  # okgid must be the RUN process's primary gid, otherwise member_denied is not
+  # exercising group-bit enforcement against a member
+  expect_output --substring "Gid:	${okgid}"
+  expect_output --substring "ok_nonmember"
+  assert "$output" !~ "secret_member"
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:
In a single-ID user namespace whose /proc/self/setgroups is "deny", any setgroups() call returns EPERM, so every RUN step under --isolation chroot fails. The kernel has permanently frozen the supplementary group set in that case, so the call can neither succeed nor be needed, and is skipped. The read is split into Linux/BSD helpers since /proc/self/setgroups does not exist on FreeBSD.

This keeps the primary-GID force-add in configureUIDGID rather than removing it, leaving the protection intact

Adds a regression test that a RUN step succeeds in a setgroups-denied namespace, and a test that the skip does not widen access: a probe file owned by a group the build namespace cannot map (surfacing as overflow gid 65534, present in the process's groups list) is still denied, while a legitimately-held group is readable.

This builds on the patch michelemodolo proposed in #6947, extended to gate on the setgroups-denied state, split across the Linux/BSD paths, with regression and no leak tests added.

#### How to verify it
Two new Linux only tests in tests/chroot.bats
`bats ./tests/chroot.bats`
- "chroot RUN succeeds when setgroups is denied" — builds with a RUN step
  inside a setgroups-denied namespace (unshare --user --map-root-user) and
  asserts it reaches the RUN step instead of failing with EPERM. 
- "chroot RUN does not honor unmapped supplemental group when setgroups is
  denied" — a probe file owned by a group the build's single-ID namespace
  can't map surfaces inside as overflow gid 65534 and appears in the process's
  groups list, yet the read is still denied, while a legitimately-held group
  reads fine. Confirms skipping setgroups() doesn't widen access.
#### Which issue(s) this PR fixes:
Fixes #6947 
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #6947 
or
None
-->

#### Special notes for your reviewer:
Chose to gate the setgroups() call on the deny state rather than dropping the
primary-GID force-add in configureUIDGID (the issue's alternative), since that
force-add is the fix for rhbz#2121453 and removing it risks reopening it.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed chroot isolation RUN steps failing with "error setting supplemental groups list: operation not permitted" in user namespaces where setgroups is denied.
```

