### PR TITLE
Fix TARGETARCH resolution in COPY --from and ADD --from

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -1131,6 +1131,30 @@ symlink(subdir)"
   expect_output --substring "This is built for $myarch"
 }
 
+@test "build with TARGETARCH in COPY --from" {
+  _prefetch alpine
+  run_buildah info --format '{{.host.arch}}'
+  myarch="$output"
+
+  # Test COPY --from with TARGETARCH variable substitution
+  run_buildah build --platform linux/$myarch $WITH_POLICY_JSON -t test-copy-from -f $BUDFILES/targetarch-copy-from/Containerfile
+  run_buildah from --name myctr test-copy-from
+  run_buildah run myctr cat /arch
+  expect_output "$myarch"
+}
+
+@test "build with TARGETARCH in FROM" {
+  _prefetch alpine
+  run_buildah info --format '{{.host.arch}}'
+  myarch="$output"
+
+  # Test FROM with TARGETARCH variable substitution
+  run_buildah build --platform linux/$myarch $WITH_POLICY_JSON -t test-from -f $BUDFILES/targetarch-copy-from/Containerfile-from
+  run_buildah from --name myctr test-from
+  run_buildah run myctr cat /arch
+  expect_output "$myarch"
+}
+
 @test "build with basename resolving default arg" {
   run_buildah info --format '{{.host.os}}/{{.host.arch}}{{if .host.variant}}/{{.host.variant}}{{end}}'
   myplatform="$output"

--- a/tests/bud/targetarch-copy-from/Containerfile
+++ b/tests/bud/targetarch-copy-from/Containerfile
@@ -1,0 +1,9 @@
+FROM alpine AS artifacts-amd64
+RUN echo "amd64" > /arch
+
+FROM alpine AS artifacts-arm64
+RUN echo "arm64" > /arch
+
+FROM scratch AS artifacts
+ARG TARGETARCH
+COPY --from=artifacts-${TARGETARCH} /arch /arch

--- a/tests/bud/targetarch-copy-from/Containerfile-from
+++ b/tests/bud/targetarch-copy-from/Containerfile-from
@@ -1,0 +1,9 @@
+FROM alpine AS artifacts-amd64
+RUN echo "amd64" > /arch
+
+FROM alpine AS artifacts-arm64
+RUN echo "arm64" > /arch
+
+FROM artifacts-${TARGETARCH} AS artifacts
+ARG TARGETARCH
+RUN echo "Hello $(cat /arch): ${TARGETARCH}"

--- a/vendor/github.com/openshift/imagebuilder/dispatchers.go
+++ b/vendor/github.com/openshift/imagebuilder/dispatchers.go
@@ -174,6 +174,8 @@ func add(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 		}
 	}
 	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
+	userArgs = mergeEnv(envMapAsSlice(b.BuiltinArgDefaults), userArgs)
+	userArgs = mergeEnv(envMapAsSlice(b.HeadingArgs), userArgs)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {
@@ -255,6 +257,8 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, flagArg
 		}
 	}
 	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
+	userArgs = mergeEnv(envMapAsSlice(b.BuiltinArgDefaults), userArgs)
+	userArgs = mergeEnv(envMapAsSlice(b.HeadingArgs), userArgs)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {
@@ -456,6 +460,8 @@ func run(b *Builder, args []string, attributes map[string]bool, flagArgs []strin
 		}
 	}
 	userArgs := mergeEnv(envMapAsSlice(filteredUserArgs), b.Env)
+	userArgs = mergeEnv(envMapAsSlice(b.BuiltinArgDefaults), userArgs)
+	userArgs = mergeEnv(envMapAsSlice(b.HeadingArgs), userArgs)
 	for _, a := range flagArgs {
 		arg, err := ProcessWord(a, userArgs)
 		if err != nil {


### PR DESCRIPTION
The dispatchCopy, add, and run dispatchers in the vendored openshift/imagebuilder library did not include BuiltinArgDefaults (contains TARGETARCH, TARGETOS, TARGETPLATFORM, etc.) or HeadingArgs in their userArgs when resolving flag arguments via ProcessWord.

This caused COPY --from=artifacts-${TARGETARCH} to fail with:
  COPY --from=artifacts-arm64: no stage or image found with that name

The from() dispatcher already correctly included these args, which is why FROM artifacts-${TARGETARCH} worked but COPY --from did not.

Fix by adding BuiltinArgDefaults and HeadingArgs to userArgs in the add(), dispatchCopy(), and run() dispatchers, matching the pattern used by from().

Adds integration tests for both COPY --from and FROM with TARGETARCH variable substitution.

Fixes: https://github.com/podman-container-tools/buildah/issues/6964

