### PR TITLE
Fix --from with absolute paths to local image transports

### DIFF
--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -168,6 +168,7 @@ type executor struct {
 	imageInfoLock                           sync.Mutex
 	imageInfoCache                          map[string]imageTypeAndHistoryAndDiffIDs
 	fromOverride                            string
+	fromOverrideStage                       int // stage position that received --from, or -1 if none
 	additionalBuildContexts                 map[string]*additionalBuildContext
 	manifest                                string
 	secrets                                 map[string]define.Secret
@@ -370,6 +371,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		rusageLogFile:                           rusageLogFile,
 		imageInfoCache:                          make(map[string]imageTypeAndHistoryAndDiffIDs),
 		fromOverride:                            options.From,
+		fromOverrideStage:                       -1,
 		additionalBuildContexts:                 wrappedAdditionalBuildContexts,
 		manifest:                                options.Manifest,
 		secrets:                                 secrets,
@@ -944,6 +946,7 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 						if b.fromOverride != "" {
 							child.Next.Value = b.fromOverride
 							b.fromOverride = ""
+							b.fromOverrideStage = stage.Position
 						}
 						base := child.Next.Value
 						if base != "" && base != buildah.BaseImageFakeName {

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -983,7 +983,7 @@ func (s *stageExecutor) UnrecognizedInstruction(step *imagebuilder.Step) error {
 // copy of the original image, under "tmpdir", which contains no symbolic
 // links, and return either the original image reference or a reference to a
 // sanitized copy which should be used instead.
-func (s *stageExecutor) sanitizeFrom(from, tmpdir string) (newFrom string, err error) {
+func (s *stageExecutor) sanitizeFrom(from, tmpdir string, allowAbsolutePaths bool) (newFrom string, err error) {
 	transportName, restOfImageName, maybeHasTransportName := strings.Cut(from, ":")
 	if !maybeHasTransportName || transports.Get(transportName) == nil {
 		if _, err = reference.ParseNormalizedNamed(from); err == nil {
@@ -997,7 +997,7 @@ func (s *stageExecutor) sanitizeFrom(from, tmpdir string) (newFrom string, err e
 		return "", fmt.Errorf("parsing image name %q: %w", from, err)
 	}
 	// TODO: drop this part and just return an error... someday
-	return sanitize.ImageName(s.executor.store, transportName, restOfImageName, s.executor.contextDir, tmpdir)
+	return sanitize.ImageName(s.executor.store, transportName, restOfImageName, s.executor.contextDir, tmpdir, allowAbsolutePaths)
 }
 
 // prepare creates a working container based on the specified image, or if one
@@ -1062,7 +1062,8 @@ func (s *stageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		}
 	}
 
-	sanitizedFrom, err := s.sanitizeFrom(from, tmpdir.GetTempDir())
+	allowAbsolutePaths := s.executor.fromOverrideStage == s.index
+	sanitizedFrom, err := s.sanitizeFrom(from, tmpdir.GetTempDir(), allowAbsolutePaths)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base image specification %q: %w", from, err)
 	}

--- a/internal/sanitize/sanitize.go
+++ b/internal/sanitize/sanitize.go
@@ -183,9 +183,14 @@ func writeToDirectory(root string, hdr *tar.Header, content io.Reader) error {
 // ImageName limits which image transports we'll accept.  For those it accepts
 // which refer to filesystem objects, where relative path names are evaluated
 // relative to "contextDir", it will create a copy of the original image, under
-// "tmpdir", which contains no symbolic links.  It it returns a parseable
+// "tmpdir", which contains no symbolic links.  It returns a parseable
 // reference to the image which should be used.
-func ImageName(store storage.Store, transportName, restOfImageName, contextDir, tmpdir string) (newFrom string, err error) {
+//
+// When allowAbsolutePaths is true and the image path is absolute, it is read
+// directly from the host filesystem (e.g. for paths supplied via --from).
+// Archive contents are still sanitized; directory-based transports are returned
+// as-is since they are read directly by the image library.
+func ImageName(store storage.Store, transportName, restOfImageName, contextDir, tmpdir string, allowAbsolutePaths bool) (newFrom string, err error) {
 	seenEntries := make(map[string]struct{})
 	// we're going to try to create a temporary directory or file, but if
 	// we fail, make sure that they get removed immediately
@@ -241,9 +246,17 @@ func ImageName(store storage.Store, transportName, restOfImageName, contextDir, 
 				}
 			}
 		}()
-		// archive only the archive file for copying to the new archive file
-		imageArchive, err = newSingleItemArchive(contextDir, archiveSource)
-		isEmbeddedArchive = true
+		if allowAbsolutePaths && filepath.IsAbs(archiveSource) {
+			var rawFile *os.File
+			rawFile, err = os.Open(archiveSource)
+			if err == nil {
+				defer rawFile.Close()
+				imageArchive, _, err = compression.AutoDecompress(rawFile)
+			}
+		} else {
+			imageArchive, err = newSingleItemArchive(contextDir, archiveSource)
+			isEmbeddedArchive = true
+		}
 		// generate the new reference using the temporary file's name
 		newFrom = transportName + ":" + newImageDestination + refLeftover
 	case ociLayoutTransport.Transport.Name(): // this is a directory tree
@@ -253,6 +266,10 @@ func ImageName(store storage.Store, transportName, restOfImageName, contextDir, 
 		archiveSource = as
 		if ok {
 			refLeftover = ":" + refLeftover
+		}
+		if allowAbsolutePaths && filepath.IsAbs(archiveSource) {
+			succeeded = true
+			return transportName + ":" + archiveSource + refLeftover, nil
 		}
 		// create a new directory to use as our new layout directory
 		if newImageDestination, err = newDirectoryDestination(tmpdir); err != nil {
@@ -266,6 +283,10 @@ func ImageName(store storage.Store, transportName, restOfImageName, contextDir, 
 	case directoryTransport.Transport.Name(): // this is also a directory tree
 		// this takes the form of just a path
 		transportRef := restOfImageName
+		if allowAbsolutePaths && filepath.IsAbs(transportRef) {
+			succeeded = true
+			return transportName + ":" + transportRef, nil
+		}
 		// create a new directory to use as our new image directory
 		if newImageDestination, err = newDirectoryDestination(tmpdir); err != nil {
 			return "", fmt.Errorf("creating temporary copy of base image: %w", err)
@@ -280,7 +301,7 @@ func ImageName(store storage.Store, transportName, restOfImageName, contextDir, 
 		return "", fmt.Errorf("unexpected container image transport %q", transportName)
 	}
 	if err != nil {
-		return "", fmt.Errorf("error archiving source at %q under %q", archiveSource, contextDir)
+		return "", fmt.Errorf("error archiving source at %q under %q: %w", archiveSource, contextDir, err)
 	}
 
 	// start reading the archived content

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -374,19 +374,19 @@ func TestSanitizeImageName(t *testing.T) {
 	// sanitize them all
 	goodLayoutRel, err := filepath.Rel(contextDir, goodLayout)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", goodLayout)
-	newGoodLayout, err := ImageName(store, "oci", goodLayoutRel, contextDir, t.TempDir())
+	newGoodLayout, err := ImageName(store, "oci", goodLayoutRel, contextDir, t.TempDir(), false)
 	require.NoError(t, err, "sanitizing good OCI layout")
 	goodDirRel, err := filepath.Rel(contextDir, goodDir)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", goodDir)
-	newGoodDir, err := ImageName(store, "dir", goodDirRel, contextDir, t.TempDir())
+	newGoodDir, err := ImageName(store, "dir", goodDirRel, contextDir, t.TempDir(), false)
 	require.NoError(t, err, "sanitizing good directory")
 	goodOCIArchiveRel, err := filepath.Rel(contextDir, goodOCIArchive)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", goodOCIArchive)
-	newGoodOCIArchive, err := ImageName(store, "oci-archive", goodOCIArchiveRel, contextDir, t.TempDir())
+	newGoodOCIArchive, err := ImageName(store, "oci-archive", goodOCIArchiveRel, contextDir, t.TempDir(), false)
 	require.NoError(t, err, "sanitizing good OCI archive")
 	goodDockerArchiveRel, err := filepath.Rel(contextDir, goodDockerArchive)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", goodDockerArchive)
-	newGoodDockerArchive, err := ImageName(store, "docker-archive", goodDockerArchiveRel, contextDir, t.TempDir())
+	newGoodDockerArchive, err := ImageName(store, "docker-archive", goodDockerArchiveRel, contextDir, t.TempDir(), false)
 	require.NoError(t, err, "sanitizing good docker archive")
 
 	// make sure the sanitized versions can all be read without error
@@ -399,24 +399,45 @@ func TestSanitizeImageName(t *testing.T) {
 	badLayout := mutateDirectory(t, contextDir, goodLayout, filepath.Join(v1.ImageBlobsDir, blobDigest.Algorithm().String(), blobDigest.Encoded()))
 	badLayoutRel, err := filepath.Rel(contextDir, badLayout)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", badLayout)
-	_, err = ImageName(store, "oci", badLayoutRel, contextDir, t.TempDir())
+	_, err = ImageName(store, "oci", badLayoutRel, contextDir, t.TempDir(), false)
 	require.ErrorIs(t, err, os.ErrNotExist, "sanitizing bad OCI layout")
 
 	badDir := mutateDirectory(t, contextDir, goodDir, blobDigest.Encoded())
 	badDirRel, err := filepath.Rel(contextDir, badDir)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", badDir)
-	_, err = ImageName(store, "dir", badDirRel, contextDir, t.TempDir())
+	_, err = ImageName(store, "dir", badDirRel, contextDir, t.TempDir(), false)
 	require.ErrorIs(t, err, os.ErrNotExist, "sanitizing bad directory")
 
 	badOCIArchive := mutateArchive(t, contextDir, goodOCIArchive, filepath.Join(v1.ImageBlobsDir, blobDigest.Algorithm().String(), blobDigest.Encoded()))
 	badOCIArchiveRel, err := filepath.Rel(contextDir, badOCIArchive)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", badOCIArchive)
-	_, err = ImageName(store, "oci-archive", badOCIArchiveRel, contextDir, t.TempDir())
+	_, err = ImageName(store, "oci-archive", badOCIArchiveRel, contextDir, t.TempDir(), false)
 	require.ErrorContains(t, err, "invalid symbolic link", "sanitizing bad oci archive")
 
 	badDockerArchive := mutateArchive(t, contextDir, goodDockerArchive, diffDigest.Encoded()+".tar")
 	badDockerArchiveRel, err := filepath.Rel(contextDir, badDockerArchive)
 	require.NoErrorf(t, err, "converting absolute path %q to a relative one", badDockerArchive)
-	_, err = ImageName(store, "docker-archive", badDockerArchiveRel, contextDir, t.TempDir())
+	_, err = ImageName(store, "docker-archive", badDockerArchiveRel, contextDir, t.TempDir(), false)
 	require.ErrorContains(t, err, "invalid symbolic link", "sanitizing bad docker archive")
+
+	// sanitize with absolute paths (simulating --from CLI flag)
+	// For archives, the file is read directly and still sanitized.
+	// For directories, the absolute path is returned as-is.
+	newAbsOCIArchive, err := ImageName(store, "oci-archive", goodOCIArchive, contextDir, t.TempDir(), true)
+	require.NoError(t, err, "sanitizing absolute OCI archive path")
+	requireImageReadable(t, newAbsOCIArchive)
+
+	newAbsDockerArchive, err := ImageName(store, "docker-archive", goodDockerArchive, contextDir, t.TempDir(), true)
+	require.NoError(t, err, "sanitizing absolute docker archive path")
+	requireImageReadable(t, newAbsDockerArchive)
+
+	newAbsLayout, err := ImageName(store, "oci", goodLayout, contextDir, t.TempDir(), true)
+	require.NoError(t, err, "sanitizing absolute OCI layout path")
+	assert.Equal(t, "oci:"+goodLayout, newAbsLayout)
+	requireImageReadable(t, newAbsLayout)
+
+	newAbsDir, err := ImageName(store, "dir", goodDir, contextDir, t.TempDir(), true)
+	require.NoError(t, err, "sanitizing absolute directory path")
+	assert.Equal(t, "dir:"+goodDir, newAbsDir)
+	requireImageReadable(t, newAbsDir)
 }

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -10752,3 +10752,45 @@ _EOF
     done
   done
 }
+
+@test "bud --from with absolute path to local transport" {
+  _prefetch busybox
+
+  local buildcontext=${TEST_SCRATCH_DIR}/buildcontext
+  mkdir -p ${buildcontext}
+
+  # Create a working container and get its image ID for comparison
+  run_buildah from -q $WITH_POLICY_JSON busybox
+  local cid=$output
+  run_buildah inspect --format '{{.FromImageID}}' "$cid"
+  local expected_id=$output
+
+  # Create images outside build context using all local transports
+  local imgdir=${TEST_SCRATCH_DIR}/images
+  mkdir -p ${imgdir}
+
+  run_buildah push $WITH_POLICY_JSON busybox oci-archive:${imgdir}/test.ociarchive
+  run_buildah push $WITH_POLICY_JSON busybox docker-archive:${imgdir}/test.dockerarchive
+  run_buildah push $WITH_POLICY_JSON busybox oci:${imgdir}/test-oci
+  run_buildah push $WITH_POLICY_JSON busybox dir:${imgdir}/test-dir
+
+  # Multi-stage Containerfile: --from should only override the first FROM.
+  # The second stage must still resolve "busybox" normally, proving that
+  # allowAbsolutePaths does not leak to later stages.
+  cat > ${buildcontext}/Containerfile << _EOF
+FROM placeholder-to-be-overridden AS stage0
+RUN echo stage0 > /stage.txt
+FROM busybox AS stage1
+COPY --from=stage0 /stage.txt /from-stage0.txt
+RUN cat /from-stage0.txt
+_EOF
+
+  for transport in \
+    "oci-archive:${imgdir}/test.ociarchive" \
+    "docker-archive:${imgdir}/test.dockerarchive" \
+    "oci:${imgdir}/test-oci" \
+    "dir:${imgdir}/test-dir" ; do
+    run_buildah build $WITH_POLICY_JSON --from "$transport" ${buildcontext}
+    expect_output --substring "FROM busybox AS stage1"
+  done
+}


### PR DESCRIPTION
Fixes: https://github.com/podman-container-tools/buildah/issues/6932

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test 
> /kind feature
> /kind flake
> /kind other

#### What this PR does / why we need it:

#### How to verify it

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `buildah build --from` with absolute paths to oci-archive, docker-archive, oci, and dir transports.
```

