### PR TITLE
Copier: add CreateDestPath option to PutOptions

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -444,24 +444,25 @@ func Get(root string, directory string, options GetOptions, globs []string, bulk
 
 // PutOptions controls parts of Put()'s behavior.
 type PutOptions struct {
-	UIDMap, GIDMap       []idtools.IDMap   // map from containerIDs to hostIDs when writing contents to disk
-	DefaultDirOwner      *idtools.IDPair   // set ownership of implicitly-created directories, default is ChownDirs, or 0:0 if ChownDirs not set
-	DefaultDirMode       *os.FileMode      // set permissions on implicitly-created directories, default is Chmod or ChmodDirs, or 0755 if neither is set
-	Chmod                string            // set permissions in octal or symbolic notation. overrides ChmodDirs and ChmodFiles if set
-	ChownDirs            *idtools.IDPair   // set ownership of newly-created directories
-	ChmodDirs            *os.FileMode      // set permissions on newly-created directories
-	ChownFiles           *idtools.IDPair   // set ownership of newly-created files
-	ChmodFiles           *os.FileMode      // set permissions on newly-created files
-	StripSetuidBit       bool              // strip the setuid bit off of items being written
-	StripSetgidBit       bool              // strip the setgid bit off of items being written
-	StripStickyBit       bool              // strip the sticky bit off of items being written
-	StripXattrs          bool              // don't bother trying to set extended attributes of items being copied
-	IgnoreXattrErrors    bool              // ignore any errors encountered when attempting to set extended attributes
-	IgnoreDevices        bool              // ignore items which are character or block devices
-	NoOverwriteDirNonDir bool              // instead of quietly overwriting directories with non-directories, return an error
-	NoOverwriteNonDirDir bool              // instead of quietly overwriting non-directories with directories, return an error
-	Rename               map[string]string // rename items with the specified names, or under the specified names
-	Timestamp            *time.Time        // override timestamps on all extracted content
+	UIDMap, GIDMap       []idtools.IDMap    // map from containerIDs to hostIDs when writing contents to disk
+	DefaultDirOwner      *idtools.IDPair    // set ownership of implicitly-created directories, default is ChownDirs, or 0:0 if ChownDirs not set
+	DefaultDirMode       *os.FileMode       // set permissions on implicitly-created directories, default is Chmod or ChmodDirs, or 0755 if neither is set
+	Chmod                string             // set permissions in octal or symbolic notation. overrides ChmodDirs and ChmodFiles if set
+	ChownDirs            *idtools.IDPair    // set ownership of newly-created directories
+	ChmodDirs            *os.FileMode       // set permissions on newly-created directories
+	ChownFiles           *idtools.IDPair    // set ownership of newly-created files
+	ChmodFiles           *os.FileMode       // set permissions on newly-created files
+	StripSetuidBit       bool               // strip the setuid bit off of items being written
+	StripSetgidBit       bool               // strip the setgid bit off of items being written
+	StripStickyBit       bool               // strip the sticky bit off of items being written
+	StripXattrs          bool               // don't bother trying to set extended attributes of items being copied
+	IgnoreXattrErrors    bool               // ignore any errors encountered when attempting to set extended attributes
+	IgnoreDevices        bool               // ignore items which are character or block devices
+	NoOverwriteDirNonDir bool               // instead of quietly overwriting directories with non-directories, return an error
+	NoOverwriteNonDirDir bool               // instead of quietly overwriting non-directories with directories, return an error
+	Rename               map[string]string  // rename items with the specified names, or under the specified names
+	Timestamp            *time.Time         // override timestamps on all extracted content
+	CreateDestPath       types.OptionalBool // create the destination path if it doesn't already exist, default is true
 }
 
 // Put extracts an archive from the bulkReader at the specified directory.
@@ -2039,6 +2040,9 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 	} else {
 		if !errors.Is(err, os.ErrNotExist) {
 			return errorResponse("copier: put: %s: %v", req.Directory, err)
+		}
+		if req.PutOptions.CreateDestPath == types.OptionalBoolFalse {
+			return errorResponse("copier: put: %s: does not exist and CreateDestPath is false", req.Directory)
 		}
 		if err := ensureDirectoryUnderRoot(req.Directory); err != nil {
 			return errorResponse("copier: put: %v", err)

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -3199,3 +3199,60 @@ func testPutTimestamp(t *testing.T) {
 		assert.Equal(t, originalTime.Unix(), info.ModTime().Unix())
 	})
 }
+
+func TestPutCreateDestPathNoChroot(t *testing.T) {
+	couldChroot := canChroot
+	canChroot = false
+	defer func() { canChroot = couldChroot }()
+	testPutCreateDestPath(t)
+}
+
+func testPutCreateDestPath(t *testing.T) {
+	uidMap := []idtools.IDMap{{HostID: os.Getuid(), ContainerID: 0, Size: 1}}
+	gidMap := []idtools.IDMap{{HostID: os.Getgid(), ContainerID: 0, Size: 1}}
+
+	archive := func() io.Reader {
+		return bytes.NewReader(makeArchiveSlice([]tar.Header{
+			{Name: "file.txt", Typeflag: tar.TypeReg, Size: 5, Mode: 0o644, ModTime: testDate},
+		}))
+	}
+
+	testCases := []struct {
+		name           string
+		createDestPath types.OptionalBool
+		destExists     bool
+		fail           bool
+	}{
+		{name: "unset-creates-dest", destExists: false},
+		{name: "true-creates-dest", createDestPath: types.OptionalBoolTrue, destExists: false},
+		{name: "false-missing-dest-fails", createDestPath: types.OptionalBoolFalse, destExists: false, fail: true},
+		{name: "false-existing-dest-succeeds", createDestPath: types.OptionalBoolFalse, destExists: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			dest := filepath.Join(root, "dest")
+			if tc.destExists {
+				require.NoError(t, os.Mkdir(dest, 0o755))
+			}
+
+			opts := PutOptions{UIDMap: uidMap, GIDMap: gidMap, CreateDestPath: tc.createDestPath}
+			err := Put(root, dest, opts, archive())
+
+			if tc.fail {
+				require.ErrorContains(t, err, "does not exist and CreateDestPath is false",
+					"expected the CreateDestPath guard to reject a missing destination")
+				return
+			}
+			require.NoError(t, err)
+
+			info, err := os.Stat(dest)
+			require.NoError(t, err, "destination should exist")
+			require.True(t, info.IsDir(), "destination should be a directory")
+
+			_, err = os.Stat(filepath.Join(dest, "file.txt"))
+			require.NoError(t, err, "file should have been written into dest")
+		})
+	}
+}

--- a/copier/copier_unix_test.go
+++ b/copier/copier_unix_test.go
@@ -179,3 +179,13 @@ func TestTarPutChroot(t *testing.T) {
 	defer func() { canChroot = couldChroot }()
 	testTarPut(t)
 }
+
+func TestPutCreateDestPathChroot(t *testing.T) {
+	if uid != 0 {
+		t.Skip("chroot() requires root privileges, skipping")
+	}
+	couldChroot := canChroot
+	canChroot = true
+	defer func() { canChroot = couldChroot }()
+	testPutCreateDestPath(t)
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind api-change

#### What this PR does / why we need it:
Adds `CreateDestPath` to `copier.PutOptions`, letting callers enable or disable the implicit creation of the destination directory when it doesn't already exist. Default behavior is unchanged: destination is created unless `CreateDestPath` is explicitly set to `OptionalBoolFalse`. Will throw an error if `CreateDestPath` = False and the directory does not exist. 

#### How to verify it
`go test ./copier -run TestPutCreateDestPath -v`

#### Which issue(s) this PR fixes:
Part of #6732
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Part of #6732
or
None
-->

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

