### PR TITLE
Added --include flag to buildah add and buildah copy

### DIFF
--- a/add.go
+++ b/add.go
@@ -126,6 +126,10 @@ type AddAndCopyOptions struct {
 	// FollowSymlink controls whether symlinks should be followed when copying content.
 	// When set to false, symlinks are not dereferenced.
 	FollowSymlink types.OptionalBool
+	// Includes is a list of patterns to include, the complement to Excludes.
+	// Only items matching one of these patterns are copied. Has the same
+	// pattern format as lines of a .containerignore file.
+	Includes []string
 }
 
 // getURL writes a tar archive containing the named content
@@ -608,6 +612,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						UIDMap:             srcUIDMap,
 						GIDMap:             srcGIDMap,
 						Excludes:           options.Excludes,
+						Includes:           options.Includes,
 						ExpandArchives:     extract,
 						Chmod:              options.Chmod,
 						ChownDirs:          chownDirs,
@@ -774,6 +779,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					UIDMap:             srcUIDMap,
 					GIDMap:             srcGIDMap,
 					Excludes:           options.Excludes,
+					Includes:           options.Includes,
 					ExpandArchives:     extract,
 					Chmod:              options.Chmod,
 					ChownDirs:          chownDirs,

--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -46,6 +46,7 @@ type addCopyResults struct {
 	allowWildcard      bool
 	allowEmptyWildcard bool
 	noFollowSymlinks   bool
+	includes           []string
 }
 
 func createCommand(addCopy string, desc string, short string, opts *addCopyResults) *cobra.Command {
@@ -108,6 +109,7 @@ func applyFlagVars(flags *pflag.FlagSet, opts *addCopyResults) {
 	flags.StringVar(&opts.timestamp, "timestamp", "", "set timestamps on new content to `seconds` after the epoch")
 	flags.BoolVar(&opts.allowWildcard, "allow-wildcard", true, "allow glob patterns in source paths")
 	flags.BoolVar(&opts.allowEmptyWildcard, "allow-empty-wildcard", false, "don't error when glob patterns match nothing")
+	flags.StringSliceVar(&opts.includes, "include", nil, "include pattern when copying files")
 }
 
 func addcopyInit() {
@@ -297,6 +299,7 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 		Timestamp:             timestamp,
 		Link:                  iopts.link,
 		FollowSymlink:         followSymlink,
+		Includes:              iopts.includes,
 	}
 	if iopts.contextdir != "" {
 		var excludes []string

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -198,6 +198,15 @@ func (req *request) Excludes() []string {
 	}
 }
 
+func (req *request) Includes() []string {
+	switch req.Request {
+	case requestGet:
+		return req.GetOptions.Includes
+	default:
+		return nil
+	}
+}
+
 func (req *request) UIDMap() []idtools.IDMap {
 	switch req.Request {
 	case requestEval:
@@ -405,6 +414,7 @@ type GetOptions struct {
 	Timestamp          *time.Time        // timestamp to force on all contents
 	DisallowWildcard   bool              // reject glob patterns in source paths
 	AllowEmptyWildcard bool              // don't error when glob patterns match nothing
+	Includes           []string          // include only contents matching at least one of these patterns; Excludes take precedence
 }
 
 // Get produces an archive containing items that match the specified glob
@@ -1072,9 +1082,17 @@ func copierHandler(bulkReader io.Reader, bulkWriter io.Writer, req request) (*re
 	// os.PathSeparator, implying that it expects OS-specific naming
 	// conventions.
 	excludes := req.Excludes()
-	pm, err := fileutils.NewPatternMatcher(excludes)
+	pmExcludes, err := fileutils.NewPatternMatcher(excludes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("processing excludes list %v: %w", excludes, err)
+	}
+
+	var pmIncludes *fileutils.PatternMatcher
+	if includes := req.Includes(); len(includes) > 0 {
+		pmIncludes, err = fileutils.NewPatternMatcher(includes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("processing includes list %v: %w", includes, err)
+		}
 	}
 
 	var idMappings *idtools.IDMappings
@@ -1090,10 +1108,10 @@ func copierHandler(bulkReader io.Reader, bulkWriter io.Writer, req request) (*re
 		resp := copierHandlerEval(req)
 		return resp, nil, nil
 	case requestStat:
-		resp := copierHandlerStat(req, pm, idMappings)
+		resp := copierHandlerStat(req, pmExcludes, idMappings)
 		return resp, nil, nil
 	case requestGet:
-		return copierHandlerGet(bulkWriter, req, pm, idMappings)
+		return copierHandlerGet(bulkWriter, req, pmExcludes, pmIncludes, idMappings)
 	case requestPut:
 		return copierHandlerPut(bulkReader, req, idMappings)
 	case requestMkdir:
@@ -1112,10 +1130,11 @@ func copierHandler(bulkReader io.Reader, bulkWriter io.Writer, req request) (*re
 	}
 }
 
-// pathIsExcluded computes path relative to root, then asks the pattern matcher
-// if the result is excluded.  Returns the relative path and the matcher's
-// results.
-func pathIsExcluded(root, path string, pm *fileutils.PatternMatcher) (string, bool, error) {
+// pathMatches computes path relative to root, then asks the pattern matcher
+// if the result matches.  Returns the relative path and the matcher's
+// results. Callers treat a match as "excluded" or "included" depending on
+// whether pm is the excludes or includes pattern matcher.
+func pathMatches(root, path string, pm *fileutils.PatternMatcher) (string, bool, error) {
 	rel, err := convertToRelSubdirectory(root, path)
 	if err != nil {
 		return "", false, fmt.Errorf("copier: error computing path of %q relative to root %q: %w", path, root, err)
@@ -1158,7 +1177,7 @@ func resolvePath(root, path string, evaluateFinalComponent bool, pm *fileutils.P
 	excluded := false
 	for len(components) > 0 {
 		// if anything we try to examine is excluded, then resolution has to "break"
-		_, thisExcluded, err := pathIsExcluded(root, filepath.Join(workingPath, components[0]), pm)
+		_, thisExcluded, err := pathMatches(root, filepath.Join(workingPath, components[0]), pm)
 		if err != nil {
 			return "", err
 		}
@@ -1221,7 +1240,7 @@ func containsWildcards(path string) bool {
 	return strings.ContainsAny(path, "*?[")
 }
 
-func copierHandlerStat(req request, pm *fileutils.PatternMatcher, idMappings *idtools.IDMappings) *response {
+func copierHandlerStat(req request, pmExcludes *fileutils.PatternMatcher, idMappings *idtools.IDMappings) *response {
 	errorResponse := func(fmtspec string, args ...any) *response {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Stat: statResponse{}}
 	}
@@ -1250,7 +1269,7 @@ func copierHandlerStat(req request, pm *fileutils.PatternMatcher, idMappings *id
 		s.Globbed = make([]string, 0, len(globMatched))
 		s.Results = make(map[string]*StatForItem)
 		for _, globbed := range globMatched {
-			rel, excluded, err := pathIsExcluded(req.Root, globbed, pm)
+			rel, excluded, err := pathMatches(req.Root, globbed, pmExcludes)
 			if err != nil {
 				return errorResponse("copier: stat: %v", err)
 			}
@@ -1310,7 +1329,7 @@ func copierHandlerStat(req request, pm *fileutils.PatternMatcher, idMappings *id
 				// could be a relative link) and in the context
 				// of the chroot
 				result.ImmediateTarget = immediateTarget
-				resolvedTarget, err := resolvePath(req.Root, globbed, true, pm)
+				resolvedTarget, err := resolvePath(req.Root, globbed, true, pmExcludes)
 				if err != nil {
 					return errorResponse("copier: stat: error resolving %q: %v", globbed, err)
 				}
@@ -1403,8 +1422,8 @@ func checkLinks(item string, req request, info os.FileInfo) (string, os.FileInfo
 	return item, info, nil
 }
 
-func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMatcher, idMappings *idtools.IDMappings) (*response, func() error, error) {
-	statResponse := copierHandlerStat(req, pm, idMappings)
+func copierHandlerGet(bulkWriter io.Writer, req request, pmExcludes, pmIncludes *fileutils.PatternMatcher, idMappings *idtools.IDMappings) (*response, func() error, error) {
+	statResponse := copierHandlerStat(req, pmExcludes, idMappings)
 	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Stat: statResponse.Stat, Get: getResponse{}}, nil, nil
 	}
@@ -1570,7 +1589,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 						// skip the "." entry
 						return nil
 					}
-					skippedPath, skip, err := pathIsExcluded(req.Root, path, pm)
+					skippedPath, skip, err := pathMatches(req.Root, path, pmExcludes)
 					if err != nil {
 						return err
 					}
@@ -1581,14 +1600,14 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 							// all, we don't need to
 							// descend into this particular
 							// directory if it's a directory
-							if !pm.Exclusions() {
+							if !pmExcludes.Exclusions() {
 								return filepath.SkipDir
 							}
 							// if there are exclusion
 							// patterns for which this
 							// path is a prefix, we
 							// need to keep descending
-							for _, pattern := range pm.Patterns() {
+							for _, pattern := range pmExcludes.Patterns() {
 								if !pattern.Exclusion() {
 									continue
 								}
@@ -1610,6 +1629,16 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 						// something under it might
 						// also be in the excludes list
 						return nil
+					}
+					if pmIncludes != nil && !d.IsDir() {
+						_, included, err := pathMatches(req.Root, path, pmIncludes)
+						if err != nil {
+							return err
+						}
+
+						if !included {
+							return nil
+						}
 					}
 					// if it's a symlink, read its target
 					symlinkTarget := ""
@@ -1656,12 +1685,22 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 				}
 				itemsCopied++
 			} else {
-				_, skip, err := pathIsExcluded(req.Root, item, pm)
+				_, skip, err := pathMatches(req.Root, item, pmExcludes)
 				if err != nil {
 					return err
 				}
 				if skip {
 					continue
+				}
+
+				if pmIncludes != nil {
+					_, included, err := pathMatches(req.Root, item, pmIncludes)
+					if err != nil {
+						return err
+					}
+					if !included {
+						continue
+					}
 				}
 
 				name := filepath.Base(queue[i].glob)

--- a/docs/buildah-add.1.md
+++ b/docs/buildah-add.1.md
@@ -62,7 +62,7 @@ by symbolic links outside of the chroot will fail.
 
 **--exclude** *pattern*
 
-Exclude copying files matching the specified pattern. Option can be specified
+Exclude copying files matching the specified pattern. The option can be specified
 multiple times. Patterns are matched against each file's path relative to the
 context directory (or, with **--from**, relative to the source container or image root).
 See containerignore(5) for supported formats.
@@ -77,6 +77,13 @@ can be used.
 **--ignorefile** *file*
 
 Path to an alternative .containerignore (.dockerignore) file. Requires \-\-contextdir be specified.
+
+**--include** *pattern*
+
+Only copy files matching the specified pattern. The option can be specified multiple times.
+Patterns are matched against each file's path relative to the context directory being copied.
+If a path matches both an **--include** and an **--exclude** pattern, it will be excluded.
+See containerignore(5) for supported formats.
 
 **--link**
 

--- a/docs/buildah-copy.1.md
+++ b/docs/buildah-copy.1.md
@@ -60,7 +60,7 @@ by symbolic links outside of the chroot will fail.
 
 **--exclude** *pattern*
 
-Exclude copying files matching the specified pattern. Option can be specified
+Exclude copying files matching the specified pattern. The option can be specified
 multiple times. Patterns are matched against each file's path relative to the
 context directory (or, with **--from**, relative to the source container or image root).
 See containerignore(5) for supported formats.
@@ -76,6 +76,13 @@ is preserved.
 **--ignorefile** *file*
 
 Path to an alternative .containerignore (.dockerignore) file. Requires \-\-contextdir be specified.
+
+**--include** *pattern*
+
+Only copy files matching the specified pattern. The option can be specified multiple times.
+Patterns are matched against each file's path relative to the context directory being copied.
+If a path matches both an **--include** and an **--exclude** pattern, it will be excluded.
+See containerignore(5) for supported formats.
 
 **--link**
 

--- a/tests/add.bats
+++ b/tests/add.bats
@@ -668,3 +668,89 @@ EOF
   cmp $ubuntu/etc/passwd ${croot}/tmp/passwd
   cmp $ubuntu/etc/passwd ${croot}/tmp/passwd2
 }
+
+@test "add --include" {
+  mytest=${TEST_SCRATCH_DIR}/mytest
+  mkdir -p ${mytest}/subdir
+  touch ${mytest}/source.go
+  touch ${mytest}/readme.md
+  touch ${mytest}/subdir/nested.go
+  touch ${mytest}/subdir/nested.md
+
+expect="
+stuff
+stuff/source.go
+stuff/subdir
+stuff/subdir/nested.go"
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah add --include="**/*.go" $cid ${mytest} /stuff
+
+  run_buildah_mount $cid
+  mnt=$output
+  run find $mnt -printf "%P\n"
+  filelist=$(LC_ALL=C sort <<<"$output")
+  run_buildah_umount $cid
+  expect_output --from="$filelist" "$expect" "add recursive include"
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah add --include="**/*.go" $cid ${mytest}/source.go /stuff2/
+
+  run_buildah_mount $cid
+  mnt=$output
+  run find $mnt -printf "%P\n"
+  filelist=$(LC_ALL=C sort <<<"$output")
+  run_buildah_umount $cid
+  expect_output --from="$filelist" --substring "source.go" "add include single file"
+
+  # include + exclude: exclude wins when both match
+expect="
+stuff
+stuff/source.go
+stuff/subdir"
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah add --include="**/*.go" --exclude="**/nested.go" $cid ${mytest} /stuff
+  run_buildah_mount $cid
+  mnt=$output
+  run find $mnt -printf "%P\n"
+  filelist=$(LC_ALL=C sort <<<"$output")
+  run_buildah_umount $cid
+  expect_output --from="$filelist" "$expect" "include with exclude"
+
+  # negation pattern listed after the include it carves out: match is excluded
+expect="
+stuff
+stuff/source.go
+stuff/subdir"
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah add --include="**/*.go" --include="!**/nested.go" $cid ${mytest} /stuff
+  run_buildah_mount $cid
+  mnt=$output
+  run find $mnt -printf "%P\n"
+  filelist=$(LC_ALL=C sort <<<"$output")
+  run_buildah_umount $cid
+  expect_output --from="$filelist" "$expect" "negation after positive excludes the match"
+
+  # same patterns, reversed order: the later positive pattern overrides the negation
+expect="
+stuff
+stuff/source.go
+stuff/subdir
+stuff/subdir/nested.go"
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah add --include="!**/nested.go" --include="**/*.go" $cid ${mytest} /stuff
+  run_buildah_mount $cid
+  mnt=$output
+  run find $mnt -printf "%P\n"
+  filelist=$(LC_ALL=C sort <<<"$output")
+  run_buildah_umount $cid
+  expect_output --from="$filelist" "$expect" "later positive pattern overrides earlier negation"
+}

--- a/tests/copy.bats
+++ b/tests/copy.bats
@@ -807,3 +807,78 @@ parents/y/b.txt"
   run_buildah 125 copy --allow-empty-wildcard=true $cid ${TEST_SCRATCH_DIR}/no-such-file /dest4/
   expect_output --substring "no such file or directory"
 }
+
+@test "copy --include" {
+  mytest=${TEST_SCRATCH_DIR}/mytest
+  mkdir -p ${mytest}/subdir
+  touch ${mytest}/source.go
+  touch ${mytest}/readme.md
+  touch ${mytest}/subdir/nested.go
+  touch ${mytest}/subdir/nested.md
+
+  # recursive include: **/*.go keeps .go at all depths, drops .md
+expect="
+stuff
+stuff/source.go
+stuff/subdir
+stuff/subdir/nested.go"
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah copy --include="**/*.go" $cid ${mytest} /stuff
+  run_buildah_mount $cid
+  mnt=$output
+  run find $mnt -printf "%P\n"
+  filelist=$(LC_ALL=C sort <<<"$output")
+  run_buildah_umount $cid
+  expect_output --from="$filelist" "$expect" "recursive include"
+
+  # include + exclude: exclude wins when both match
+expect="
+stuff
+stuff/source.go
+stuff/subdir"
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah copy --include="**/*.go" --exclude="**/nested.go" $cid ${mytest} /stuff
+  run_buildah_mount $cid
+  mnt=$output
+  run find $mnt -printf "%P\n"
+  filelist=$(LC_ALL=C sort <<<"$output")
+  run_buildah_umount $cid
+  expect_output --from="$filelist" "$expect" "include with exclude"
+
+  # negation pattern listed after the include it carves out: match is excluded
+expect="
+stuff
+stuff/source.go
+stuff/subdir"
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah copy --include="**/*.go" --include="!**/nested.go" $cid ${mytest} /stuff
+  run_buildah_mount $cid
+  mnt=$output
+  run find $mnt -printf "%P\n"
+  filelist=$(LC_ALL=C sort <<<"$output")
+  run_buildah_umount $cid
+  expect_output --from="$filelist" "$expect" "negation after positive excludes the match"
+
+  # same patterns, reversed order: the later positive pattern overrides the negation
+expect="
+stuff
+stuff/source.go
+stuff/subdir
+stuff/subdir/nested.go"
+
+  run_buildah from $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah copy --include="!**/nested.go" --include="**/*.go" $cid ${mytest} /stuff
+  run_buildah_mount $cid
+  mnt=$output
+  run find $mnt -printf "%P\n"
+  filelist=$(LC_ALL=C sort <<<"$output")
+  run_buildah_umount $cid
+  expect_output --from="$filelist" "$expect" "later positive pattern overrides earlier negation"
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?
<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind feature

#### What this PR does / why we need it:
Adds an `--include` flag to both add and copy cli commands. This is the complement to `--exclude` .
Its purpose is to only copy files with the corresponding pattern. Excludes will take priority when both match

This feature is not usable in Dockerfiles and Containerfiles 

#### How to verify it
`bats --filter "add --include" tests/add.bats`
`bats --filter "copy --include" tests/copy.bats`
#### Which issue(s) this PR fixes:
Part of #6732 
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
This is the precursor to the RequiredPaths flag that will be incoming.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`buildah copy --include` and `buildah add --include ` is the complement to the `buildah copy --exclude` and `buildah add --exclude` commands
```

