### PR TITLE
Run bats tests with -j4 instead of the default -j8

### DIFF
--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -83,7 +83,7 @@ function run_conformance() {
 }
 
 function run_integration() {
-    $SUDO make test-integration
+    $SUDO env OMP_THREAD_LIMIT=4 make test-integration
 }
 
 function run_in_podman() {


### PR DESCRIPTION
Spot-check.  Do not merge.