### PR TITLE
docs: fix typo, --policy expects ifnewer instead of newer

### DIFF
--- a/docs/buildah-pull.1.md
+++ b/docs/buildah-pull.1.md
@@ -70,14 +70,14 @@ and can also be found by running `go tool dist list`.
 
 **NOTE:** The `--platform` option may not be used in combination with the `--arch`, `--os`, or `--variant` options.
 
-**--policy**=**always**|**missing**|**never**|**newer**
+**--policy**=**always**|**missing**|**never**|**ifnewer**
 
 Pull image policy. The default is **missing**.
 
 - **always**: Always pull the image and throw an error if the pull fails.
 - **missing**: Pull the image only if it could not be found in the local containers storage.  Throw an error if no image could be found and the pull fails.
 - **never**: Never pull the image but use the one from the local containers storage.  Throw an error if no image could be found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **ifnewer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
 
 **--quiet**, **-q**
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind documentation


#### What this PR does / why we need it:

Fixes wrong flag in the documentation of `buildah pull --policy`.

#### How to verify it

- For details, see:
  #6992 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes #6992 

#### Special notes for your reviewer:

`None.`

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

`None.`