### PR TITLE
honor containers.conf http_proxy and env settings during build

### DIFF
--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -439,7 +439,7 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.StringSliceVar(&flags.DNSSearch, "dns-search", defaultContainerConfig.Containers.DNSSearches.Get(), "set custom DNS search domains")
 	fs.StringSliceVar(&flags.DNSServers, "dns", defaultContainerConfig.Containers.DNSServers.Get(), "set custom DNS servers or disable it completely by setting it to 'none', which prevents the automatic creation of `/etc/resolv.conf`.")
 	fs.StringSliceVar(&flags.DNSOptions, "dns-option", defaultContainerConfig.Containers.DNSOptions.Get(), "set custom DNS options")
-	fs.BoolVar(&flags.HTTPProxy, "http-proxy", true, "pass through HTTP Proxy environment variables")
+	fs.BoolVar(&flags.HTTPProxy, "http-proxy", defaultContainerConfig.Containers.HTTPProxy, "pass through HTTP Proxy environment variables")
 	fs.StringVar(&flags.Isolation, "isolation", DefaultIsolation(), "`type` of process isolation to use. Use BUILDAH_ISOLATION environment variable to override.")
 	fs.StringVarP(&flags.Memory, "memory", "m", "", "memory limit (format: <number>[<unit>], where unit = b, k, m or g)")
 	fs.StringVar(&flags.MemorySwap, "memory-swap", "", "swap limit equal to memory plus swap: '-1' to enable unlimited swap")

--- a/run_common.go
+++ b/run_common.go
@@ -311,8 +311,22 @@ func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, opti
 	return homeDir, nil
 }
 
-func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions, defaultEnv []string) {
+func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions, defaultEnv []string) error {
 	g.ClearProcessEnv()
+
+	conf, err := config.Default()
+	if err != nil {
+		return fmt.Errorf("failed to get container config: %w", err)
+	}
+	for _, envSpec := range conf.Containers.Env.Get() {
+		env := strings.SplitN(envSpec, "=", 2)
+		// Only pass proxy environment variables configured in containers.conf into build RUN steps.
+		// Arbitrary environment variables from containers.conf are excluded to preserve build reproducibility
+		// and avoid subtle build-to-build differences across environments.
+		if len(env) > 1 && slices.Contains(config.ProxyEnv, env[0]) {
+			g.AddProcessEnv(env[0], env[1])
+		}
+	}
 
 	if b.CommonBuildOpts.HTTPProxy {
 		for _, envSpec := range config.ProxyEnv {
@@ -328,6 +342,7 @@ func (b *Builder) configureEnvironment(g *generate.Generator, options RunOptions
 			g.AddProcessEnv(env[0], env[1])
 		}
 	}
+	return nil
 }
 
 // getNetworkInterface creates the network interface

--- a/run_common_test.go
+++ b/run_common_test.go
@@ -2,11 +2,15 @@ package buildah
 
 import (
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
+	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.podman.io/common/pkg/config"
 )
 
 func TestMapContainerNameToHostname(t *testing.T) {
@@ -66,4 +70,90 @@ func TestCheckExitCodeError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildahProxyAndNoLeak(t *testing.T) {
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "containers.conf")
+	confContent := `
+[containers]
+http_proxy = false
+env = [
+  "http_proxy=http://host.containers.internal:1080",
+  "https_proxy=http://host.containers.internal:1080",
+  "CUSTOM_NON_PROXY_VAR=should_be_ignored"
+]
+`
+	err := os.WriteFile(confPath, []byte(confContent), 0o644)
+	require.NoError(t, err)
+
+	// Reset the default container config cache on test cleanup. Register before t.Setenv so that
+	// the cleanups caused by `t.Setenv` calls run before it (because cleanup happens in LIFO order).
+	t.Cleanup(func() { _, _ = config.New(&config.Options{SetDefault: true}) })
+	t.Setenv("CONTAINERS_CONF", confPath)
+	t.Setenv("http_proxy", "http://127.0.0.1:1080")
+
+	_, err = config.New(&config.Options{SetDefault: true})
+	require.NoError(t, err)
+
+	builder := &Builder{}
+	builder.CommonBuildOpts = &CommonBuildOptions{
+		HTTPProxy: false,
+	}
+
+	g, err := generate.New("linux")
+	require.NoError(t, err)
+
+	err = builder.configureEnvironment(&g, RunOptions{}, []string{"PATH=/usr/bin"})
+	require.NoError(t, err)
+
+	procEnv := g.Config.Process.Env
+	t.Logf("Transient process env during RUN: %v", procEnv)
+
+	assert.Contains(t, procEnv, "http_proxy=http://host.containers.internal:1080")
+	assert.NotContains(t, procEnv, "http_proxy=http://127.0.0.1:1080")
+	assert.NotContains(t, procEnv, "CUSTOM_NON_PROXY_VAR=should_be_ignored")
+
+	imageEnv := builder.OCIv1.Config.Env
+	assert.NotContains(t, imageEnv, "http_proxy=http://host.containers.internal:1080")
+}
+
+func TestBuildahProxyPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "containers.conf")
+	confContent := `
+[containers]
+http_proxy = false
+env = [
+  "http_proxy=http://host.containers.internal:1080"
+]
+`
+	err := os.WriteFile(confPath, []byte(confContent), 0o644)
+	require.NoError(t, err)
+
+	// Reset the default container config cache on test cleanup. Register before t.Setenv so that
+	// the cleanups caused by `t.Setenv` calls run before it (because cleanup happens in LIFO order).
+	t.Cleanup(func() { _, _ = config.New(&config.Options{SetDefault: true}) })
+	t.Setenv("CONTAINERS_CONF", confPath)
+	t.Setenv("http_proxy", "http://127.0.0.1:1080")
+
+	_, err = config.New(&config.Options{SetDefault: true})
+	require.NoError(t, err)
+
+	builder := &Builder{}
+
+	// Case 1: HTTPProxy: true (Host env overrides containers.conf)
+	builder.CommonBuildOpts = &CommonBuildOptions{HTTPProxy: true}
+	g1, err := generate.New("linux")
+	require.NoError(t, err)
+	err = builder.configureEnvironment(&g1, RunOptions{}, []string{"PATH=/usr/bin"})
+	require.NoError(t, err)
+	assert.Contains(t, g1.Config.Process.Env, "http_proxy=http://127.0.0.1:1080")
+
+	// Case 2: CLI Options.Env overrides both containers.conf and host env
+	g2, err := generate.New("linux")
+	require.NoError(t, err)
+	err = builder.configureEnvironment(&g2, RunOptions{Env: []string{"http_proxy=http://cli.override:1080"}}, []string{"PATH=/usr/bin"})
+	require.NoError(t, err)
+	assert.Contains(t, g2.Config.Process.Env, "http_proxy=http://cli.override:1080")
 }

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -48,7 +48,8 @@ const (
 func procctl(idtype int, id int, cmd int, arg *byte) error {
 	_, _, e1 := unix.Syscall6(
 		unix.SYS_PROCCTL, uintptr(idtype), uintptr(id),
-		uintptr(cmd), uintptr(unsafe.Pointer(arg)), 0, 0)
+		uintptr(cmd), uintptr(unsafe.Pointer(arg)), 0, 0,
+	)
 	if e1 != 0 {
 		return unix.Errno(e1)
 	}
@@ -122,8 +123,11 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
-	// hardwire the environment to match docker build to avoid subtle and hard-to-debug differences due to containers.conf
-	b.configureEnvironment(g, options, []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"})
+	// Pass a fixed environment to match docker build because passing the whole containers.conf instead would cause
+	// subtle and hard-to-debug differences. Proxy variables are the exception, as they are read from containers.conf in configureEnvironment.
+	if err := b.configureEnvironment(g, options, []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}); err != nil {
+		return err
+	}
 
 	if b.CommonBuildOpts == nil {
 		return fmt.Errorf("invalid format on container you must recreate the container")

--- a/run_linux.go
+++ b/run_linux.go
@@ -230,8 +230,11 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		return err
 	}
 
-	// hardwire the environment to match docker build to avoid subtle and hard-to-debug differences due to containers.conf
-	b.configureEnvironment(g, options, []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"})
+	// Pass a fixed environment to match docker build because passing the whole containers.conf instead would cause
+	// subtle and hard-to-debug differences. Proxy variables are the exception, as they are read from containers.conf in configureEnvironment.
+	if err := b.configureEnvironment(g, options, []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}); err != nil {
+		return err
+	}
 
 	if b.CommonBuildOpts == nil {
 		return fmt.Errorf("invalid format on container you must recreate the container")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

This PR resolves an issue where `podman build` ignored `containers.conf` settings (`http_proxy = false` and `[containers] env`). Please also see the linked issue for more context.

1. Binds the `--http-proxy` CLI flag default in `pkg/cli/common.go` to `Containers.HTTPProxy` from `containers.conf` instead of hardcoding `true`. This makes build proxy flag defaults consistent with `podman run`, allowing `http_proxy = false` in `containers.conf` to disable host environment proxy passthrough by default.
2. Updates `configureEnvironment()` in `run_common.go` to inject environment variables defined under `[containers] env` in `containers.conf` into the transient container process spec (`g.AddProcessEnv`) during `RUN` steps. This fixes the regression from pre-6.0.x where `containers.conf` environment settings applied to build execution commands (e.g. package management and network requests).

#### How to verify it

1. Configure `containers.conf`:

   ```toml
   [containers]
   http_proxy = false
   env = [
     "http_proxy=http://host.containers.internal:1080",
   ]
   ```

2. Export host shell environment variables:

   ```bash
   export http_proxy=http://127.0.0.1:1080
   ```

3. Run build:

   ```bash
   podman build --no-cache -f - . << 'EOF'
   FROM alpine
   RUN env | grep -i proxy
   EOF
   ```

4. Verify output contains `http_proxy=http://host.containers.internal:1080` instead of `http://127.0.0.1:1080`.

#### Which issue(s) this PR fixes

Fixes: https://github.com/podman-container-tools/podman/issues/29299

#### Special notes for your reviewer

`g.AddProcessEnv` in `configureEnvironment()` sets the process spec environment (`g.Config.Process.Env`) for transient container execution during `RUN` steps. It does not touch `builder.OCIv1.Config.Env`, ensuring that environment variables configured in `containers.conf` apply to build execution without polluting committed image layers.

#### Does this PR introduce a user-facing change?

Not sure if a release note is needed for regressions, but this does contain user-facing change:

```release-note
Honor `containers.conf` `http_proxy` and `env` settings during image builds, aligning the behavior with `podman run` and fixed regression introduced in 6.0.x.
```