### PR TITLE
mount: fix panic when parsing malformed --mount option

### DIFF
--- a/run_common.go
+++ b/run_common.go
@@ -1730,7 +1730,7 @@ type secretMountOrEnv struct {
 }
 
 func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secret, idMaps IDMaps, workdir string) (_ secretMountOrEnv, retErr error) {
-	errInvalidSyntax := errors.New("secret should have syntax id=id[,target=path,required=bool,mode=uint,uid=uint,gid=uint,env=dstVarName")
+	errInvalidSyntax := errors.New("secret should have syntax id=id[,target=path,required=bool,mode=uint,uid=uint,gid=uint,env=dstVarName]")
 	if len(tokens) == 0 {
 		return secretMountOrEnv{}, errInvalidSyntax
 	}
@@ -1740,50 +1740,53 @@ func (b *Builder) getSecretMount(tokens []string, secrets map[string]define.Secr
 	var mode uint32 = 0o400
 	var rv secretMountOrEnv
 	for _, val := range tokens {
-		kv := strings.SplitN(val, "=", 2)
-		switch kv[0] {
+		key, value, hasValue := strings.Cut(val, "=")
+		if !hasValue && key != "required" {
+			return secretMountOrEnv{}, errInvalidSyntax
+		}
+		switch key {
 		case "type":
 			// This is already processed
 			continue
 		case "id":
-			id = kv[1]
+			id = value
 		case "target", "dst", "destination":
-			target = kv[1]
+			target = value
 			if !filepath.IsAbs(target) {
 				target = filepath.Join(workdir, target)
 			}
 		case "required":
 			required = true
-			if len(kv) > 1 {
+			if hasValue {
 				var err error
-				required, err = strconv.ParseBool(kv[1])
+				required, err = strconv.ParseBool(value)
 				if err != nil {
 					return secretMountOrEnv{}, errInvalidSyntax
 				}
 			}
 		case "mode":
-			mode64, err := strconv.ParseUint(kv[1], 8, 32)
+			mode64, err := strconv.ParseUint(value, 8, 32)
 			if err != nil {
 				return secretMountOrEnv{}, errInvalidSyntax
 			}
 			mode = uint32(mode64)
 		case "uid":
-			uid64, err := strconv.ParseUint(kv[1], 10, 32)
+			uid64, err := strconv.ParseUint(value, 10, 32)
 			if err != nil {
 				return secretMountOrEnv{}, errInvalidSyntax
 			}
 			uid = uint32(uid64)
 		case "gid":
-			gid64, err := strconv.ParseUint(kv[1], 10, 32)
+			gid64, err := strconv.ParseUint(value, 10, 32)
 			if err != nil {
 				return secretMountOrEnv{}, errInvalidSyntax
 			}
 			gid = uint32(gid64)
 		case "env":
-			if kv[1] == "" {
+			if value == "" {
 				return secretMountOrEnv{}, errInvalidSyntax
 			}
-			env = kv[1]
+			env = value
 		default:
 			return secretMountOrEnv{}, errInvalidSyntax
 		}

--- a/run_common_test.go
+++ b/run_common_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.podman.io/buildah/define"
 )
 
 func TestMapContainerNameToHostname(t *testing.T) {
@@ -66,4 +67,78 @@ func TestCheckExitCodeError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSecretMount(t *testing.T) {
+	const invalidSyntax = "secret should have syntax id=id[,target=path,required=bool,mode=uint,uid=uint,gid=uint,env=dstVarName]"
+
+	t.Run("valid-options", func(t *testing.T) {
+		validOptions := []struct {
+			name   string
+			tokens []string
+		}{
+			{"id-only", []string{"type=secret", "id=example"}},
+			{"absolute-target", []string{"type=secret", "id=example", "target=/run/secrets/example"}},
+			{"relative-target", []string{"type=secret", "id=example", "target=secret"}},
+			{"mode", []string{"type=secret", "id=example", "mode=0400"}},
+			{"ownership-and-required", []string{"type=secret", "id=example", "uid=1000", "gid=1000", "required=false"}},
+			{"environment", []string{"type=secret", "id=example", "env=SECRET"}},
+		}
+		for i := range validOptions {
+			t.Run(validOptions[i].name, func(t *testing.T) {
+				_, err := (&Builder{}).getSecretMount(validOptions[i].tokens, map[string]define.Secret{}, IDMaps{}, "/work")
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("bare-required", func(t *testing.T) {
+		_, err := (&Builder{}).getSecretMount([]string{"type=secret", "id=example", "required"}, map[string]define.Secret{}, IDMaps{}, "/work")
+		require.EqualError(t, err, `secret required but no secret with id "example" found`)
+	})
+
+	t.Run("target-provides-id", func(t *testing.T) {
+		_, err := (&Builder{}).getSecretMount([]string{"type=secret", "target=secret", "required=true"}, map[string]define.Secret{}, IDMaps{}, "/work")
+		require.EqualError(t, err, `secret required but no secret with id "secret" found`)
+	})
+
+	t.Run("required-true", func(t *testing.T) {
+		t.Setenv("BUILDAH_TEST_SECRET", "secret-value")
+		secrets := map[string]define.Secret{
+			"example": {
+				ID:         "example",
+				Source:     "BUILDAH_TEST_SECRET",
+				SourceType: "env",
+			},
+		}
+		result, err := (&Builder{}).getSecretMount([]string{"type=secret", "id=example", "required=true", "env=SECRET_VALUE"}, secrets, IDMaps{}, "/work")
+		require.NoError(t, err)
+		require.Equal(t, "SECRET_VALUE=secret-value", result.EnvVariable)
+	})
+
+	t.Run("invalid-options", func(t *testing.T) {
+		invalidOptions := []string{
+			"type",
+			"id",
+			"target",
+			"dst",
+			"destination",
+			"mode",
+			"uid",
+			"gid",
+			"env",
+			"id=",
+			"env=",
+			"required=invalid",
+			"mode=invalid",
+			"uid=invalid",
+			"gid=invalid",
+		}
+		for i := range invalidOptions {
+			t.Run(invalidOptions[i], func(t *testing.T) {
+				_, err := (&Builder{}).getSecretMount([]string{"type=secret", invalidOptions[i]}, map[string]define.Secret{}, IDMaps{}, "/work")
+				require.EqualError(t, err, invalidSyntax)
+			})
+		}
+	})
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

#### What this PR does / why we need it:

Fixes panic when `buildah build` parses a malformed `--mount` option.

#### How to verify it

- For details see: 
#6997 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

Fixes #6997 

#### Special notes for your reviewer:

`none.`

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reject malformed mount options when running buildah build.
```

