### PR TITLE
Copier: add Symlink() for creating symlinks with inline target

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -612,6 +612,54 @@ func Remove(root string, item string, options RemoveOptions) error {
 	return nil
 }
 
+// SymlinkOptions controls parts of Symlink()'s behavior.
+type SymlinkOptions struct {
+	UIDMap, GIDMap []idtools.IDMap // map from containerIDs to hostIDs when creating the symlink
+	ChownNew       *idtools.IDPair // set ownership of the newly-created symlink
+	ModTimeNew     *time.Time      // set mtime and atime of the newly-created symlink
+}
+
+// Symlink creates a symlink at the specified path under root
+// pointing to the specified target. It builds a tar archive
+// containing a single entry and passes it to Put().
+func Symlink(root string, target string, link string, options SymlinkOptions) error {
+	uid, gid := 0, 0
+	if options.ChownNew != nil {
+		uid, gid = options.ChownNew.UID, options.ChownNew.GID
+	}
+
+	modTime := time.Now()
+	if options.ModTimeNew != nil {
+		modTime = *options.ModTimeNew
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	hdr := &tar.Header{
+		Name:     cleanerReldirectory(link),
+		Linkname: target,
+		Uid:      uid,
+		Gid:      gid,
+		ModTime:  modTime,
+		Typeflag: tar.TypeSymlink,
+	}
+
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("copier: symlink: error writing tar header: %w", err)
+	}
+
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("copier: symlink: error closing tar writer: %w", err)
+	}
+
+	putOptions := PutOptions{
+		UIDMap: options.UIDMap,
+		GIDMap: options.GIDMap,
+	}
+
+	return Put(root, root, putOptions, &buf)
+}
+
 // cleanerReldirectory resolves relative path candidate lexically, attempting
 // to ensure that when joined as a subdirectory of another directory, it does
 // not reference anything outside of that other directory.

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -3256,3 +3256,97 @@ func testPutCreateDestPath(t *testing.T) {
 		})
 	}
 }
+
+func TestSymlinkNoChroot(t *testing.T) {
+	couldChroot := canChroot
+	canChroot = false
+	testSymlink(t)
+	canChroot = couldChroot
+}
+
+func testSymlink(t *testing.T) {
+	currentOwner := &idtools.IDPair{UID: os.Getuid(), GID: os.Getgid()}
+	symlinkOpts := func(modTime *time.Time) SymlinkOptions {
+		return SymlinkOptions{
+			ModTimeNew: modTime,
+			ChownNew:   currentOwner,
+		}
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		root := t.TempDir()
+		err := Symlink(root, "target", "newlink", symlinkOpts(nil))
+		require.NoError(t, err)
+
+		info, err := os.Lstat(filepath.Join(root, "newlink"))
+		require.NoError(t, err)
+		assert.NotEqual(t, info.Mode()&os.ModeSymlink, 0, "should be a symlink")
+
+		got, err := os.Readlink(filepath.Join(root, "newlink"))
+		require.NoError(t, err)
+		assert.Equal(t, "target", got)
+	})
+
+	t.Run("with-timestamp", func(t *testing.T) {
+		root := t.TempDir()
+		err := Symlink(root, "target", "dated", symlinkOpts(&testDate))
+		require.NoError(t, err)
+
+		info, err := os.Lstat(filepath.Join(root, "dated"))
+		require.NoError(t, err)
+		assert.NotEqual(t, info.Mode()&os.ModeSymlink, 0)
+
+		if !testIgnoreSymlinkDates {
+			assert.Equal(t, testDate.Unix(), info.ModTime().Unix())
+		}
+	})
+
+	t.Run("nested-path", func(t *testing.T) {
+		archive := makeArchive([]tar.Header{
+			{Name: "subdir-a", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+			{Name: "subdir-a/subdir-b", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: testDate},
+		}, nil)
+		root, err := makeContextFromArchive(t, archive, "")
+		require.NoError(t, err)
+
+		err = Symlink(root, "target", "subdir-a/subdir-b/deeplink", symlinkOpts(nil))
+		require.NoError(t, err)
+
+		got, err := os.Readlink(filepath.Join(root, "subdir-a", "subdir-b", "deeplink"))
+		require.NoError(t, err)
+		assert.Equal(t, "target", got)
+	})
+
+	t.Run("path-traversal", func(t *testing.T) {
+		root := t.TempDir()
+		err := Symlink(root, "target", "../../escaped", symlinkOpts(nil))
+		require.NoError(t, err)
+
+		got, err := os.Readlink(filepath.Join(root, "escaped"))
+		require.NoError(t, err)
+		assert.Equal(t, "target", got)
+	})
+
+	t.Run("absolute-path", func(t *testing.T) {
+		root := t.TempDir()
+		err := Symlink(root, "target", "/absolutelink", symlinkOpts(nil))
+		require.NoError(t, err)
+
+		got, err := os.Readlink(filepath.Join(root, "absolutelink"))
+		require.NoError(t, err)
+		assert.Equal(t, "target", got)
+	})
+
+	t.Run("overwrite", func(t *testing.T) {
+		root := t.TempDir()
+		err := Symlink(root, "original-target", "link", symlinkOpts(nil))
+		require.NoError(t, err)
+
+		err = Symlink(root, "new-target", "link", symlinkOpts(nil))
+		require.NoError(t, err)
+
+		got, err := os.Readlink(filepath.Join(root, "link"))
+		require.NoError(t, err)
+		assert.Equal(t, "new-target", got)
+	})
+}

--- a/copier/copier_unix_test.go
+++ b/copier/copier_unix_test.go
@@ -189,3 +189,13 @@ func TestPutCreateDestPathChroot(t *testing.T) {
 	defer func() { canChroot = couldChroot }()
 	testPutCreateDestPath(t)
 }
+
+func TestSymlinkChroot(t *testing.T) {
+	if uid != 0 {
+		t.Skip("chroot() requires root privileges, skipping")
+	}
+	couldChroot := canChroot
+	canChroot = true
+	testSymlink(t)
+	canChroot = couldChroot
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind feature

#### What this PR does / why we need it:
Adds `copier.Symlink()` function and `SymlinkOptions` struct to the copier package.
  The function creates a symlink by building an in-memory tar archive with a single
  symlink entry and passing it to `copier.Put()`, following the same pattern as
  `copier.Mkfile()`.

#### How to verify it
`go test -v -run TestSymlinkNoChroot ./copier/ -v`
`go test -v -run TestSymlinkChroot ./copier/ -v`

#### Which issue(s) this PR fixes:
Closes #6802
Part of #6732 

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
copier: add Symlink() for creating symlinks with inline target
```

