### PR TITLE
Add context-aware versions of several functions and some methods

### DIFF
--- a/add.go
+++ b/add.go
@@ -26,7 +26,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
-	"github.com/tonistiigi/dchapes-mode"
+	mode "github.com/tonistiigi/dchapes-mode"
 	"go.podman.io/buildah/copier"
 	"go.podman.io/buildah/define"
 	"go.podman.io/buildah/internal/tmpdir"
@@ -129,7 +129,13 @@ type AddAndCopyOptions struct {
 }
 
 // getURL writes a tar archive containing the named content
-func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, writer io.Writer, chmod string, srcDigest digest.Digest, certPath string, insecureSkipTLSVerify types.OptionalBool, timestamp *time.Time) error {
+func getURL(ctx context.Context, src string, chown *idtools.IDPair, mountpoint, renameTarget string, writer io.Writer, chmod string, srcDigest digest.Digest, certPath string, insecureSkipTLSVerify types.OptionalBool, timestamp *time.Time) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	url, err := url.Parse(src)
 	if err != nil {
 		return err
@@ -152,7 +158,11 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 		Proxy:           http.ProxyFromEnvironment,
 	}
 	httpClient := &http.Client{Transport: tr}
-	response, err := httpClient.Get(src)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, src, nil)
+	if err != nil {
+		return err
+	}
+	response, err := httpClient.Do(request)
 	if err != nil {
 		return err
 	}
@@ -184,7 +194,7 @@ func getURL(src string, chown *idtools.IDPair, mountpoint, renameTarget string, 
 	}
 	// Figure out the size of the content.
 	size := response.ContentLength
-	var responseBody io.Reader = response.Body
+	responseBody := io.Reader(response.Body)
 	if size < 0 {
 		// Create a temporary file and copy the content to it, so that
 		// we can figure out how much content there is.
@@ -307,10 +317,23 @@ func getParentsPrefixToRemoveAndParentsToSkip(pattern string, contextDir string)
 	return prefix, out
 }
 
-// Add copies the contents of the specified sources into the container's root
+// Add() calls AddContext() with context.TODO().
+//
+//go:fix inline
+func (b *Builder) Add(destination string, extract bool, options AddAndCopyOptions, sources ...string) error {
+	return b.AddContext(context.TODO(), destination, extract, options, sources...)
+}
+
+// AddContext copies the contents of the specified sources into the container's root
 // filesystem, optionally extracting contents of local files that look like
 // non-empty archives.
-func (b *Builder) Add(destination string, extract bool, options AddAndCopyOptions, sources ...string) error {
+func (b *Builder) AddContext(ctx context.Context, destination string, extract bool, options AddAndCopyOptions, sources ...string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	mountPoint, err := b.Mount(b.MountLabel)
 	if err != nil {
 		return err
@@ -374,7 +397,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			DisallowWildcard:   options.AllowWildcard == types.OptionalBoolFalse,
 			AllowEmptyWildcard: options.AllowEmptyWildcard == types.OptionalBoolTrue,
 		}
-		localSourceStats, err = copier.Stat(contextDir, contextDir, statOptions, localSources)
+		localSourceStats, err = copier.StatContext(ctx, contextDir, contextDir, statOptions, localSources)
 		if err != nil {
 			return fmt.Errorf("checking on sources under %q: %w", contextDir, err)
 		}
@@ -466,7 +489,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	statOptions := copier.StatOptions{
 		CheckForArchives: extract,
 	}
-	destStats, err := copier.Stat(mountPoint, filepath.Join(mountPoint, b.WorkDir()), statOptions, []string{extractDirectory})
+	destStats, err := copier.StatContext(ctx, mountPoint, filepath.Join(mountPoint, b.WorkDir()), statOptions, []string{extractDirectory})
 	if err != nil {
 		return fmt.Errorf("checking on destination %v: %w", extractDirectory, err)
 	}
@@ -496,7 +519,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 	// Make sure that, if it's a symlink, we'll chroot to the target of the link;
 	// knowing that target requires that we resolve it within the chroot.
 	evalOptions := copier.EvalOptions{}
-	evaluated, err := copier.Eval(mountPoint, extractDirectory, evalOptions)
+	evaluated, err := copier.EvalContext(ctx, mountPoint, extractDirectory, evalOptions)
 	if err != nil {
 		return fmt.Errorf("checking on destination %v: %w", extractDirectory, err)
 	}
@@ -559,7 +582,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		if !strings.HasPrefix(putDirAbs, stagingDirAbs+string(os.PathSeparator)) && putDirAbs != stagingDirAbs {
 			return fmt.Errorf("destination path %q escapes staging directory", destination)
 		}
-		if err := copier.Mkdir(putRoot, putDirAbs, mkdirOptions); err != nil {
+		if err := copier.MkdirContext(ctx, putRoot, putDirAbs, mkdirOptions); err != nil {
 			return fmt.Errorf("ensuring target directory exists: %w", err)
 		}
 		tempPath := putDir
@@ -570,7 +593,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			tempPath = filepath.Dir(tempPath)
 		}
 	} else {
-		if err := copier.Mkdir(mountPoint, extractDirectory, mkdirOptions); err != nil {
+		if err := copier.MkdirContext(ctx, mountPoint, extractDirectory, mkdirOptions); err != nil {
 			return fmt.Errorf("ensuring target directory exists: %w", err)
 		}
 
@@ -599,7 +622,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					defer wg.Done()
 					defer pipeWriter.Close()
 					var cloneDir, subdir string
-					cloneDir, subdir, getErr = define.TempDirForURL(tmpdir.GetTempDir(), "", src)
+					cloneDir, subdir, getErr = define.TempDirForURLContext(ctx, tmpdir.GetTempDir(), "", src)
 					if getErr != nil {
 						return
 					}
@@ -621,12 +644,12 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					}
 					writer := io.WriteCloser(pipeWriter)
 					repositoryDir := filepath.Join(cloneDir, subdir)
-					getErr = copier.Get(repositoryDir, repositoryDir, getOptions, []string{"."}, writer)
+					getErr = copier.GetContext(ctx, repositoryDir, repositoryDir, getOptions, []string{"."}, writer)
 				}()
 			} else {
 				go func() {
-					getErr = retry.IfNecessary(context.TODO(), func() error {
-						return getURL(src, chownFiles, mountPoint, renameTarget, pipeWriter, options.Chmod, srcDigest, options.CertPath, options.InsecureSkipTLSVerify, options.Timestamp)
+					getErr = retry.IfNecessary(ctx, func() error {
+						return getURL(ctx, src, chownFiles, mountPoint, renameTarget, pipeWriter, options.Chmod, srcDigest, options.CertPath, options.InsecureSkipTLSVerify, options.Timestamp)
 					}, &retry.Options{
 						MaxRetry: options.MaxRetries,
 						Delay:    options.RetryDelay,
@@ -656,7 +679,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						IgnoreDevices: userns.RunningInUserNS(),
 						Timestamp:     options.Timestamp,
 					}
-					putErr = copier.Put(putRoot, putDir, putOptions, io.TeeReader(pipeReader, hasher))
+					putErr = copier.PutContext(ctx, putRoot, putDir, putOptions, io.TeeReader(pipeReader, hasher))
 				}
 				hashCloser.Close()
 				pipeReader.Close()
@@ -788,7 +811,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 					AllowEmptyWildcard: options.AllowEmptyWildcard == types.OptionalBoolTrue,
 					NoDerefSymlinks:    options.FollowSymlink == types.OptionalBoolFalse,
 				}
-				getErr = copier.Get(contextDir, contextDir, getOptions, []string{globbedToGlobbable(globbed)}, writer)
+				getErr = copier.GetContext(ctx, contextDir, contextDir, getOptions, []string{globbedToGlobbable(globbed)}, writer)
 				closeErr = writer.Close()
 				if renameTarget != "" && renamedItems > 1 {
 					renameErr = fmt.Errorf("internal error: renamed %d items when we expected to only rename 1", renamedItems)
@@ -820,7 +843,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 						IgnoreDevices:   userns.RunningInUserNS(),
 						Timestamp:       options.Timestamp,
 					}
-					putErr = copier.Put(putRoot, putDir, putOptions, io.TeeReader(pipeReader, hasher))
+					putErr = copier.PutContext(ctx, putRoot, putDir, putOptions, io.TeeReader(pipeReader, hasher))
 				}
 				hashCloser.Close()
 				pipeReader.Close()

--- a/buildah_test.go
+++ b/buildah_test.go
@@ -1,7 +1,6 @@
 package buildah
 
 import (
-	"context"
 	"flag"
 	"os"
 	"testing"
@@ -46,7 +45,7 @@ func TestOpenBuilderCommonBuildOpts(t *testing.T) {
 	// or builder must enable sometime of locking mechanism i.e if
 	// routine is creating Builder other's must wait for it.
 	// Tracked here: https://github.com/containers/buildah/issues/5967
-	ctx := context.TODO()
+	ctx := t.Context()
 	store, err := storage.GetStore(types.StoreOptions{
 		RunRoot:         t.TempDir(),
 		GraphRoot:       t.TempDir(),

--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -4,6 +4,7 @@ package chroot
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -51,10 +52,23 @@ type runUsingChrootExecSubprocOptions struct {
 	NoPivot    bool
 }
 
-// RunUsingChroot runs a chrooted process, using some of the settings from the
+// RunUsingChroot() calls RunUsingChrootContext() with context.TODO().
+//
+//go:fix inline
+func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reader, stdout, stderr io.Writer, noPivot bool) (err error) {
+	return RunUsingChrootContext(context.TODO(), spec, bundlePath, homeDir, stdin, stdout, stderr, noPivot)
+}
+
+// RunUsingChrootContext runs a chrooted process, using some of the settings from the
 // passed-in spec, and using the specified bundlePath to hold temporary files,
 // directories, and mountpoints.
-func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reader, stdout, stderr io.Writer, noPivot bool) (err error) {
+func RunUsingChrootContext(ctx context.Context, spec *specs.Spec, bundlePath, homeDir string, stdin io.Reader, stdout, stderr io.Writer, noPivot bool) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	var confwg sync.WaitGroup
 	var homeFound bool
 	for _, env := range spec.Process.Env {
@@ -127,6 +141,7 @@ func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reade
 
 	// Start the grandparent subprocess.
 	cmd := unshare.Command(runUsingChrootCommand)
+	cmd.Cmd = reexec.CommandContext(ctx, runUsingChrootCommand) // TODO: add an unshare.CommandContext()
 	setPdeathsig(cmd.Cmd)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
 	cmd.Dir = "/"

--- a/chroot/unsupported.go
+++ b/chroot/unsupported.go
@@ -3,6 +3,7 @@
 package chroot
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -10,6 +11,19 @@ import (
 )
 
 // RunUsingChroot is not supported.
+//
+//go:fix inline
 func RunUsingChroot(spec *specs.Spec, bundlePath, homeDir string, stdin io.Reader, stdout, stderr io.Writer) (err error) {
+	return RunUsingChrootContext(context.TODO(), spec, bundlePath, homeDir, stdin, stdout, stderr)
+}
+
+// RunUsingChrootContext is not supported.
+func RunUsingChrootContext(ctx context.Context, spec *specs.Spec, bundlePath, homeDir string, stdin io.Reader, stdout, stderr io.Writer) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	return fmt.Errorf("--isolation chroot is not supported on this platform")
 }

--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -322,7 +322,7 @@ func addAndCopyCmd(c *cobra.Command, args []string, verb string, iopts addCopyRe
 	}
 
 	extractLocalArchives := verb == "ADD"
-	err = builder.Add(dest, extractLocalArchives, options, args...)
+	err = builder.AddContext(getContext(), dest, extractLocalArchives, options, args...)
 	if err != nil {
 		return fmt.Errorf("adding content to container %q: %w", builder.Container, err)
 	}

--- a/cmd/buildah/common.go
+++ b/cmd/buildah/common.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -157,10 +159,30 @@ func openImage(ctx context.Context, sc *types.SystemContext, store storage.Store
 	return builder, nil
 }
 
-// getContext returns a context.TODO
+// getContext returns a context that may have a timeout, and which cancels if
+// it receives os.Interrupt
 func getContext() context.Context {
-	return context.TODO()
+	ctx, _ := getContextWithCancel()
+	return ctx
 }
+
+func getContextCancel() context.CancelFunc {
+	_, cancel := getContextWithCancel()
+	return cancel
+}
+
+var getContextWithCancel = sync.OnceValues(func() (context.Context, context.CancelFunc) {
+	var ctx context.Context
+	var cancel1, cancel2 func()
+	if rootCmd.PersistentFlags().Changed("experimental-timeout") {
+		ctx, cancel1 = context.WithTimeout(context.Background(), globalFlagResults.ExperimentalTimeout)
+	} else {
+		ctx = context.Background()
+		cancel1 = func() {}
+	}
+	ctx, cancel2 = signal.NotifyContext(ctx, os.Interrupt)
+	return ctx, func() { cancel1(); cancel2() }
+})
 
 func getUserFlags() pflag.FlagSet {
 	fs := pflag.FlagSet{}

--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -110,7 +111,7 @@ newer: only pull images when newer images exist on the registry than those in th
 	rootCmd.AddCommand(fromCommand)
 }
 
-func onBuild(builder *buildah.Builder, quiet bool) error {
+func onBuild(ctx context.Context, builder *buildah.Builder, quiet bool) error {
 	ctr := 0
 	for _, onBuildSpec := range builder.OnBuild() {
 		ctr = ctr + 1
@@ -129,7 +130,7 @@ func onBuild(builder *buildah.Builder, quiet bool) error {
 				dest = args[size-1]
 				args = args[:size-1]
 			}
-			if err := builder.Add(dest, command == "ADD", buildah.AddAndCopyOptions{}, args...); err != nil {
+			if err := builder.AddContext(ctx, dest, command == "ADD", buildah.AddAndCopyOptions{}, args...); err != nil {
 				return err
 			}
 		case "ANNOTATION":
@@ -170,7 +171,7 @@ func onBuild(builder *buildah.Builder, quiet bool) error {
 			if quiet {
 				stdout = io.Discard
 			}
-			if err := builder.Run(args, buildah.RunOptions{Stdout: stdout}); err != nil {
+			if err := builder.RunContext(ctx, args, buildah.RunOptions{Stdout: stdout}); err != nil {
 				return err
 			}
 		case "SHELL":
@@ -305,7 +306,7 @@ func fromCmd(c *cobra.Command, args []string, iopts fromReply) error {
 		return err
 	}
 
-	if err := onBuild(builder, iopts.quiet); err != nil {
+	if err := onBuild(getContext(), builder, iopts.quiet); err != nil {
 		return err
 	}
 

--- a/cmd/buildah/images.go
+++ b/cmd/buildah/images.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -133,7 +132,7 @@ func imagesCmd(c *cobra.Command, args []string, iopts *imageResults) error {
 		return err
 	}
 
-	ctx := context.Background()
+	ctx := getContext()
 
 	options := &libimage.ListImagesOptions{}
 	if len(iopts.filter) > 0 {

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime/pprof"
 	"strings"
 	"syscall"
+	"time"
 
 	ispecs "github.com/opencontainers/image-spec/specs-go"
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
@@ -58,6 +59,7 @@ type globalFlags struct {
 	MemoryProfile              string
 	UserShortNameAliasConfPath string
 	CgroupManager              string
+	ExperimentalTimeout        time.Duration
 }
 
 var rootCmd = &cobra.Command{
@@ -107,6 +109,7 @@ func mainInit() {
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 	// rootCmd.TraverseChildren = true
 	rootCmd.Version = fmt.Sprintf("%s (image-spec %s, runtime-spec %s)", define.Version, ispecs.Version, rspecs.Version)
+	rootCmd.PersistentFlags().DurationVar(&globalFlagResults.ExperimentalTimeout, "experimental-timeout", 0, "global timeout") // maybe rename this at some point?
 	rootCmd.PersistentFlags().BoolVar(&globalFlagResults.Debug, "debug", false, "print debugging information")
 	// TODO Need to allow for environment variable
 	rootCmd.PersistentFlags().StringVar(&globalFlagResults.RegistriesConf, "registries-conf", "", "path to registries.conf file (not usually used)")
@@ -137,6 +140,9 @@ func mainInit() {
 	}
 	if err := rootCmd.PersistentFlags().MarkHidden("memory-profile"); err != nil {
 		logrus.Fatalf("unable to mark memory-profile flag as hidden: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().MarkHidden("experimental-timeout"); err != nil {
+		logrus.Fatalf("unable to mark experimental-timeout flag as hidden: %v", err)
 	}
 	rootCmd.AddGroup(commandGroups...)
 }
@@ -293,7 +299,9 @@ func main() {
 	// Hard code TMPDIR functions to use $TMPDIR or /var/tmp
 	os.Setenv("TMPDIR", parse.GetTempDir())
 
-	if err := rootCmd.Execute(); err != nil {
+	err := rootCmd.Execute()
+	getContextCancel()()
+	if err != nil {
 		if logrus.IsLevelEnabled(logrus.TraceLevel) {
 			fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
 		} else {

--- a/cmd/buildah/manifest.go
+++ b/cmd/buildah/manifest.go
@@ -741,7 +741,7 @@ func manifestRmCmd(c *cobra.Command, args []string) error {
 		Filters:        []string{"readonly=false"},
 		LookupManifest: true,
 	}
-	rmiReports, rmiErrors := runtime.RemoveImages(context.Background(), args, options)
+	rmiReports, rmiErrors := runtime.RemoveImages(getContext(), args, options)
 	for _, r := range rmiReports {
 		for _, u := range r.Untagged {
 			fmt.Printf("untagged: %s\n", u)

--- a/cmd/buildah/prune.go
+++ b/cmd/buildah/prune.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
@@ -78,7 +77,7 @@ func pruneCmd(c *cobra.Command, args []string, iopts pruneOptions) error {
 	}
 	options.Force = iopts.force
 
-	rmiReports, rmiErrors := runtime.RemoveImages(context.Background(), args, options)
+	rmiReports, rmiErrors := runtime.RemoveImages(getContext(), args, options)
 	for _, r := range rmiReports {
 		for _, u := range r.Untagged {
 			fmt.Printf("untagged: %s\n", u)

--- a/cmd/buildah/rmi.go
+++ b/cmd/buildah/rmi.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -89,7 +88,7 @@ func rmiCmd(c *cobra.Command, args []string, iopts rmiOptions) error {
 	}
 	options.Force = iopts.force
 
-	rmiReports, rmiErrors := runtime.RemoveImages(context.Background(), args, options)
+	rmiReports, rmiErrors := runtime.RemoveImages(getContext(), args, options)
 	for _, r := range rmiReports {
 		for _, u := range r.Untagged {
 			fmt.Printf("untagged: %s\n", u)

--- a/cmd/buildah/rpc.go
+++ b/cmd/buildah/rpc.go
@@ -77,7 +77,7 @@ func rpcCmd(c *cobra.Command, args []string) error {
 			logrus.Errorf("while waiting for rpc service to shut down: %v", err)
 		}
 	}()
-	cmd := exec.Command(args[0], args[1:]...)
+	cmd := exec.CommandContext(getContext(), args[0], args[1:]...)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	envVar := c.Flag("env").Value.String()
 	if envVar != "" {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -244,7 +244,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 	options.Mounts = mounts
 	options.CgroupManager = globalFlagResults.CgroupManager
 
-	runerr := builder.Run(args, options)
+	runerr := builder.RunContext(getContext(), args, options)
 
 	if runerr != nil {
 		logrus.Debugf("error running %v in container %q: %v", args, builder.Container, runerr)

--- a/cmd/buildah/source.go
+++ b/cmd/buildah/source.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"go.podman.io/buildah/internal/source"
 )
@@ -35,7 +33,7 @@ var (
 		Long:    sourceCreateDescription,
 		Example: "buildah source create /tmp/fedora:latest-source",
 		RunE: func(_ *cobra.Command, args []string) error {
-			return source.Create(context.Background(), args[0], sourceCreateOptions)
+			return source.Create(getContext(), args[0], sourceCreateOptions)
 		},
 	}
 
@@ -52,7 +50,7 @@ var (
 		Long:    sourceAddDescription,
 		Example: "buildah source add /tmp/fedora sources.tar.gz",
 		RunE: func(_ *cobra.Command, args []string) error {
-			return source.Add(context.Background(), args[0], args[1], sourceAddOptions)
+			return source.Add(getContext(), args[0], args[1], sourceAddOptions)
 		},
 	}
 
@@ -69,7 +67,7 @@ var (
 		Long:    sourcePullDescription,
 		Example: "buildah source pull quay.io/sourceimage/example:latest /tmp/sourceimage:latest",
 		RunE: func(_ *cobra.Command, args []string) error {
-			return source.Pull(context.Background(), args[0], args[1], sourcePullOptions)
+			return source.Pull(getContext(), args[0], args[1], sourcePullOptions)
 		},
 	}
 
@@ -86,7 +84,7 @@ var (
 		Long:    sourcePushDescription,
 		Example: "buildah source push /tmp/sourceimage:latest quay.io/sourceimage/example:latest",
 		RunE: func(_ *cobra.Command, args []string) error {
-			return source.Push(context.Background(), args[0], args[1], sourcePushOptions)
+			return source.Push(getContext(), args[0], args[1], sourcePushOptions)
 		},
 	}
 )

--- a/cmd/buildah/unshare.go
+++ b/cmd/buildah/unshare.go
@@ -114,7 +114,7 @@ func unshareCmd(c *cobra.Command, args []string) error {
 		}
 		args = []string{shell}
 	}
-	cmd := exec.Command(args[0], args[1:]...)
+	cmd := exec.CommandContext(getContext(), args[0], args[1:]...)
 	cmd.Env = unshare.RootlessEnv()
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/commit.go
+++ b/commit.go
@@ -269,6 +269,12 @@ func checkRegistrySourcesAllows(forWhat string, dest types.ImageReference) (inse
 }
 
 func (b *Builder) addManifest(ctx context.Context, manifestName string, imageSpec string) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
 	var create bool
 	systemContext := &types.SystemContext{}
 	var list manifests.List
@@ -348,6 +354,12 @@ func (b *Builder) Commit(ctx context.Context, dest types.ImageReference, options
 // add any additional tags that were specified.  Returns a CommitResults
 // structure.
 func (b *Builder) CommitResults(ctx context.Context, dest types.ImageReference, options CommitOptions) (*CommitResults, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	var (
 		imgID                string
 		src                  types.ImageReference
@@ -455,7 +467,7 @@ func (b *Builder) CommitResults(ctx context.Context, dest types.ImageReference, 
 	}
 
 	// Build an image reference from which we can copy the finished image.
-	src, err = b.makeContainerImageRef(options)
+	src, err = b.makeContainerImageRef(ctx, options)
 	if err != nil {
 		return nil, fmt.Errorf("computing layer digests and building metadata for container %q: %w", b.ContainerID, err)
 	}

--- a/commit_test.go
+++ b/commit_test.go
@@ -2,7 +2,6 @@ package buildah
 
 import (
 	"archive/tar"
-	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -48,7 +47,7 @@ func TestCommitLinkedLayers(t *testing.T) {
 	// or builder must enable sometime of locking mechanism i.e if
 	// routine is creating Builder other's must wait for it.
 	// Tracked here: https://github.com/containers/buildah/issues/5967
-	ctx := context.TODO()
+	ctx := t.Context()
 	now := time.Now()
 
 	graphDriverName := os.Getenv("STORAGE_DRIVER")
@@ -106,7 +105,7 @@ func TestCommitLinkedLayers(t *testing.T) {
 	require.NoError(t, err, "creating builder")
 	b.SetCreatedBy(imageName(layerNumber))
 	firstFile := makeFile("file0", 0)
-	err = b.Add("/", false, AddAndCopyOptions{}, firstFile)
+	err = b.AddContext(t.Context(), "/", false, AddAndCopyOptions{}, firstFile)
 	require.NoError(t, err, "adding", firstFile)
 	commitOptions := CommitOptions{
 		SystemContext: &testSystemContext,
@@ -123,7 +122,7 @@ func TestCommitLinkedLayers(t *testing.T) {
 	require.NoError(t, err, "creating builder")
 	b.SetCreatedBy(imageName(layerNumber))
 	secondFile := makeFile("file1", 0)
-	err = b.Add("/", false, AddAndCopyOptions{}, secondFile)
+	err = b.AddContext(t.Context(), "/", false, AddAndCopyOptions{}, secondFile)
 	require.NoError(t, err, "adding", secondFile)
 	commitOptions = CommitOptions{
 		SystemContext: &testSystemContext,
@@ -145,7 +144,7 @@ func TestCommitLinkedLayers(t *testing.T) {
 	seventhArchiveFile := makeArchive("file6", 0)
 	eighthFile := makeFile("file7", 0)
 	ninthArchiveFile := makeArchive("file8", 0)
-	err = b.Add("/", false, AddAndCopyOptions{}, sixthFile)
+	err = b.AddContext(t.Context(), "/", false, AddAndCopyOptions{}, sixthFile)
 	require.NoError(t, err, "adding", sixthFile)
 	b.SetCreatedBy(imageName(layerNumber + 3))
 	b.AddPrependedLinkedLayer(nil, imageName(layerNumber), "", "", filepath.Dir(thirdFile))
@@ -197,7 +196,7 @@ func TestCommitLinkedLayers(t *testing.T) {
 	require.NoError(t, err, "creating builder")
 	b.SetCreatedBy(imageName(layerNumber))
 	tenthFile := makeFile("file9", 0)
-	err = b.Add("/", false, AddAndCopyOptions{}, tenthFile)
+	err = b.AddContext(t.Context(), "/", false, AddAndCopyOptions{}, tenthFile)
 	require.NoError(t, err, "adding", tenthFile)
 	commitOptions = CommitOptions{
 		SystemContext: &testSystemContext,
@@ -262,7 +261,7 @@ func TestCommitCompression(t *testing.T) {
 	// or builder must enable sometime of locking mechanism i.e if
 	// routine is creating Builder other's must wait for it.
 	// Tracked here: https://github.com/containers/buildah/issues/5967
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	graphDriverName := os.Getenv("STORAGE_DRIVER")
 	if graphDriverName == "" {
@@ -289,7 +288,7 @@ func TestCommitCompression(t *testing.T) {
 	require.NoError(t, err, "creating builder")
 	payload := makeFile(t, "file0", 0)
 	b.SetCreatedBy("ADD file0 in /")
-	err = b.Add("/", false, AddAndCopyOptions{}, payload)
+	err = b.AddContext(t.Context(), "/", false, AddAndCopyOptions{}, payload)
 	require.NoError(t, err, "adding", payload)
 	for _, compressor := range []struct {
 		compression    archive.Compression
@@ -365,7 +364,7 @@ func TestCommitEmpty(t *testing.T) {
 	// or builder must enable sometime of locking mechanism i.e if
 	// routine is creating Builder other's must wait for it.
 	// Tracked here: https://github.com/containers/buildah/issues/5967
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	graphDriverName := os.Getenv("STORAGE_DRIVER")
 	if graphDriverName == "" {
@@ -577,7 +576,7 @@ func TestCommitEmpty(t *testing.T) {
 }
 
 func TestCommitChmod(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	graphDriverName := os.Getenv("STORAGE_DRIVER")
 	if graphDriverName == "" {
 		graphDriverName = "vfs"
@@ -624,7 +623,7 @@ func TestCommitChmod(t *testing.T) {
 			err = os.Chmod(f, v.startMode)
 			require.NoError(t, err, "chmod", f)
 		}
-		err = b.Add("/", false, AddAndCopyOptions{Chmod: v.chmod}, f)
+		err = b.AddContext(t.Context(), "/", false, AddAndCopyOptions{Chmod: v.chmod}, f)
 		require.NoError(t, err, "adding", f)
 	}
 

--- a/common.go
+++ b/common.go
@@ -80,6 +80,12 @@ func retryCopyImageWithOptions(ctx context.Context, policyContext *signature.Pol
 		err           error
 	)
 	err = retry.IfNecessary(ctx, func() error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
 		manifestBytes, err = cp.Image(ctx, policyContext, maybeWrappedDest, maybeWrappedSrc, copyOptions)
 		return err
 	}, &retry.RetryOptions{MaxRetry: maxRetries, Delay: retryDelay, IsErrorRetryable: func(err error) bool {

--- a/common_test.go
+++ b/common_test.go
@@ -3,7 +3,6 @@ package buildah
 import (
 	"archive/tar"
 	"bytes"
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -42,7 +41,7 @@ func (ts *testRetryCopyImageWrappedStore) CreateImage(id string, names []string,
 
 func TestRetryCopyImage(t *testing.T) {
 	t.Parallel()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	graphDriverName := os.Getenv("STORAGE_DRIVER")
 	if graphDriverName == "" {

--- a/config.go
+++ b/config.go
@@ -27,6 +27,12 @@ import (
 // (either as it exists, or converting the image if necessary), and unmarshals it into dest.
 // NOTE: The MIME type is of the _manifest_, not of the _config_ that is returned.
 func unmarshalConvertedConfig(ctx context.Context, dest any, img types.Image, wantedManifestMIMEType string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	_, actualManifestMIMEType, err := img.Manifest(ctx)
 	if err != nil {
 		return fmt.Errorf("getting manifest MIME type for %q: %w", transports.ImageName(img.Reference()), err)
@@ -62,6 +68,12 @@ func unmarshalConvertedConfig(ctx context.Context, dest any, img types.Image, wa
 }
 
 func (b *Builder) initConfig(ctx context.Context, sys *types.SystemContext, img types.Image, options *BuilderOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if img != nil { // A pre-existing image, as opposed to a "FROM scratch" new one.
 		rawManifest, manifestMIMEType, err := img.Manifest(ctx)
 		if err != nil {

--- a/convertcw.go
+++ b/convertcw.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/buildah/define"
+	"go.podman.io/buildah/internal/ctxreader"
 	"go.podman.io/buildah/internal/mkcw"
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/types"
@@ -68,6 +69,12 @@ type CWConvertImageOptions struct {
 // Returns the new image's ID and digest on success, along with a canonical
 // reference for it if a repository name was specified.
 func CWConvertImage(ctx context.Context, systemContext *types.SystemContext, store storage.Store, options CWConvertImageOptions) (string, reference.Canonical, digest.Digest, error) {
+	select {
+	case <-ctx.Done():
+		return "", nil, "", ctx.Err()
+	default:
+	}
+
 	// Apply our defaults if some options aren't set.
 	logger := options.Logger
 	if logger == nil {
@@ -172,11 +179,11 @@ func CWConvertImage(ctx context.Context, systemContext *types.SystemContext, sto
 		GraphOptions:             store.GraphOptions(),
 		ExtraImageContent:        options.ExtraImageContent,
 	}
-	rc, workloadConfig, err := mkcw.Archive(sourceDir, &source.OCIv1, archiveOptions)
+	rc, workloadConfig, err := mkcw.Archive(ctx, sourceDir, &source.OCIv1, archiveOptions)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("generating encrypted image content: %w", err)
 	}
-	if err = archive.Untar(rc, targetDir, &archive.TarOptions{}); err != nil {
+	if err = archive.Untar(ctxreader.NewCancelableReader(ctx, rc), targetDir, &archive.TarOptions{}); err != nil {
 		if err = rc.Close(); err != nil {
 			logger.Warnf("cleaning up: %v", err)
 		}

--- a/convertcw_test.go
+++ b/convertcw_test.go
@@ -2,7 +2,6 @@ package buildah
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -72,7 +71,7 @@ func TestCWConvertImage(t *testing.T) {
 	// or builder must enable sometime of locking mechanism i.e if
 	// routine is creating Builder other's must wait for it.
 	// Tracked here: https://github.com/containers/buildah/issues/5967
-	ctx := context.TODO()
+	ctx := t.Context()
 	for _, status := range []int{http.StatusOK, http.StatusInternalServerError} {
 		for _, ignoreChainRetrievalErrors := range []bool{false, true} {
 			for _, ignoreAttestationErrors := range []bool{false, true} {

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -3,6 +3,7 @@ package copier
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	mode "github.com/tonistiigi/dchapes-mode"
+	"go.podman.io/buildah/internal/ctxreader"
 	"go.podman.io/image/v5/pkg/compression"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/archive"
@@ -320,20 +322,27 @@ type conditionalRemoveResponse struct {
 // EvalOptions controls parts of Eval()'s behavior.
 type EvalOptions struct{}
 
-// Eval evaluates the directory's path, including any intermediate symbolic
-// links.
+// Eval calls EvalContext with context.TODO().
+//
+//go:fix inline
+func Eval(root, directory string, e EvalOptions) (string, error) {
+	return EvalContext(context.TODO(), root, directory, e)
+}
+
+// EvalContext evaluates the directory's path, including any intermediate
+// symbolic links.
 // If root is specified and the current OS supports it, and the calling process
 // has the necessary privileges, evaluation is performed in a chrooted context.
 // If the directory is specified as an absolute path, it should either be the
 // root directory or a subdirectory of the root directory.  Otherwise, the
 // directory is treated as a path relative to the root directory.
-func Eval(root string, directory string, _ EvalOptions) (string, error) {
+func EvalContext(ctx context.Context, root, directory string, _ EvalOptions) (string, error) {
 	req := request{
 		Request:   requestEval,
 		Root:      root,
 		Directory: directory,
 	}
-	resp, err := copier(nil, nil, req)
+	resp, err := copier(ctx, nil, nil, req)
 	if err != nil {
 		return "", err
 	}
@@ -352,8 +361,15 @@ type StatOptions struct {
 	AllowEmptyWildcard bool            // don't error when glob patterns match nothing
 }
 
-// Stat globs the specified pattern in the specified directory and returns its
-// results.
+// Stat calls StatContext with context.TODO().
+//
+//go:fix inline
+func Stat(root, directory string, options StatOptions, globs []string) ([]*StatsForGlob, error) {
+	return StatContext(context.TODO(), root, directory, options, globs)
+}
+
+// StatContext globs the specified pattern in the specified directory and
+// returns its results.
 // If root and directory are both not specified, the current root directory is
 // used, and relative names in the globs list are treated as being relative to
 // the current working directory.
@@ -364,7 +380,7 @@ type StatOptions struct {
 // directory is treated as a path relative to the root directory.
 // Relative names in the glob list are treated as being relative to the
 // directory.
-func Stat(root string, directory string, options StatOptions, globs []string) ([]*StatsForGlob, error) {
+func StatContext(ctx context.Context, root, directory string, options StatOptions, globs []string) ([]*StatsForGlob, error) {
 	req := request{
 		Request:     requestStat,
 		Root:        root,
@@ -372,7 +388,7 @@ func Stat(root string, directory string, options StatOptions, globs []string) ([
 		Globs:       slices.Clone(globs),
 		StatOptions: options,
 	}
-	resp, err := copier(nil, nil, req)
+	resp, err := copier(ctx, nil, nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -407,8 +423,15 @@ type GetOptions struct {
 	AllowEmptyWildcard bool              // don't error when glob patterns match nothing
 }
 
-// Get produces an archive containing items that match the specified glob
-// patterns and writes it to bulkWriter.
+// Get calls GetContext with context.TODO().
+//
+//go:fix inline
+func Get(root, directory string, options GetOptions, globs []string, bulkWriter io.Writer) error {
+	return GetContext(context.TODO(), root, directory, options, globs, bulkWriter)
+}
+
+// GetContext produces an archive containing items that match the specified
+// glob patterns and writes it to bulkWriter.
 // If root and directory are both not specified, the current root directory is
 // used, and relative names in the globs list are treated as being relative to
 // the current working directory.
@@ -419,7 +442,7 @@ type GetOptions struct {
 // directory is treated as a path relative to the root directory.
 // Relative names in the glob list are treated as being relative to the
 // directory.
-func Get(root string, directory string, options GetOptions, globs []string, bulkWriter io.Writer) error {
+func GetContext(ctx context.Context, root, directory string, options GetOptions, globs []string, bulkWriter io.Writer) error {
 	req := request{
 		Request:   requestGet,
 		Root:      root,
@@ -432,12 +455,15 @@ func Get(root string, directory string, options GetOptions, globs []string, bulk
 		},
 		GetOptions: options,
 	}
-	resp, err := copier(nil, bulkWriter, req)
+	resp, err := copier(ctx, nil, bulkWriter, req)
 	if err != nil {
+		_, werr := bulkWriter.Write([]byte("123456789abcdef0")) // add some trash to trigger an error in a tar reader
+		err = errors.Join(err, werr)
 		return err
 	}
 	if resp.Error != "" {
-		return errors.New(resp.Error)
+		_, werr := bulkWriter.Write([]byte("123456789abcdef0")) // add some trash to trigger an error in a tar reader
+		return fmt.Errorf("from subprocess: %v", errors.Join(errors.New(resp.Error), werr))
 	}
 	return nil
 }
@@ -465,23 +491,30 @@ type PutOptions struct {
 	CreateDestPath       types.OptionalBool // create the destination path if it doesn't already exist, default is true
 }
 
-// Put extracts an archive from the bulkReader at the specified directory.
-// If root and directory are both not specified, the current root directory is
-// used.
+// Put calls PutContext with context.TODO().
+//
+//go:fix inline
+func Put(root, directory string, options PutOptions, bulkReader io.Reader) error {
+	return PutContext(context.TODO(), root, directory, options, bulkReader)
+}
+
+// PutContext extracts an archive from the bulkReader at the specified
+// directory.  If root and directory are both not specified, the current root
+// directory is used.
 // If root is specified and the current OS supports it, and the calling process
 // has the necessary privileges, the contents are written in a chrooted
 // context.  If the directory is specified as an absolute path, it should
 // either be the root directory or a subdirectory of the root directory.
 // Otherwise, the directory is treated as a path relative to the root
 // directory.
-func Put(root string, directory string, options PutOptions, bulkReader io.Reader) error {
+func PutContext(ctx context.Context, root, directory string, options PutOptions, bulkReader io.Reader) error {
 	req := request{
 		Request:    requestPut,
 		Root:       root,
 		Directory:  directory,
 		PutOptions: options,
 	}
-	resp, err := copier(bulkReader, nil, req)
+	resp, err := copier(ctx, bulkReader, nil, req)
 	if err != nil {
 		return err
 	}
@@ -500,24 +533,31 @@ type MkdirOptions struct {
 	ChmodNew       *os.FileMode       // set permissions on newly-created directories
 }
 
-// Mkdir ensures that the specified directory exists.  Any directories which
-// need to be created will be given the specified ownership and permissions.
-// If root and directory are both not specified, the current root directory is
-// used.
+// Mkdir calls MkdirContext with context.TODO().
+//
+//go:fix inline
+func Mkdir(root, directory string, options MkdirOptions) error {
+	return MkdirContext(context.TODO(), root, directory, options)
+}
+
+// MkdirContext ensures that the specified directory exists.  Any directories
+// which need to be created will be given the specified ownership and
+// permissions.  If root and directory are both not specified, the current root
+// directory is used.
 // If root is specified and the current OS supports it, and the calling process
 // has the necessary privileges, the directory is created in a chrooted
 // context.  If the directory is specified as an absolute path, it should
 // either be the root directory or a subdirectory of the root directory.
 // Otherwise, the directory is treated as a path relative to the root
 // directory.
-func Mkdir(root string, directory string, options MkdirOptions) error {
+func MkdirContext(ctx context.Context, root, directory string, options MkdirOptions) error {
 	req := request{
 		Request:      requestMkdir,
 		Root:         root,
 		Directory:    directory,
 		MkdirOptions: options,
 	}
-	resp, err := copier(nil, nil, req)
+	resp, err := copier(ctx, nil, nil, req)
 	if err != nil {
 		return err
 	}
@@ -527,7 +567,7 @@ func Mkdir(root string, directory string, options MkdirOptions) error {
 	return nil
 }
 
-// MkfileOptions controls parts of Mkfile()'s behavior.
+// MkfileOptions controls parts of MkfileContext()'s behavior.
 type MkfileOptions struct {
 	UIDMap, GIDMap []idtools.IDMap // map from containerIDs to hostIDs when creating the file
 	ModTimeNew     *time.Time      // set mtime and atime of the newly-created file
@@ -535,10 +575,17 @@ type MkfileOptions struct {
 	ChmodNew       *os.FileMode    // set permissions on the newly-created file
 }
 
-// Mkfile creates a file at the specified path under root with the given
-// content, permissions, and ownership.  It builds a tar archive containing
-// a single entry and passes it to Put().
-func Mkfile(root string, path string, options MkfileOptions, content []byte) error {
+// Mkfile calls MkfileContext with context.TODO().
+//
+//go:fix inline
+func Mkfile(root, path string, options MkfileOptions, content []byte) error {
+	return MkfileContext(context.TODO(), root, path, options, content)
+}
+
+// MkfileContext creates a file at the specified path under root with the given
+// content, permissions, and ownership.  It builds a tar archive containing a
+// single entry and passes it to Put().
+func MkfileContext(ctx context.Context, root, path string, options MkfileOptions, content []byte) error {
 	uid, gid := 0, 0
 	if options.ChownNew != nil {
 		uid, gid = options.ChownNew.UID, options.ChownNew.GID
@@ -577,7 +624,7 @@ func Mkfile(root string, path string, options MkfileOptions, content []byte) err
 		UIDMap: options.UIDMap,
 		GIDMap: options.GIDMap,
 	}
-	return Put(root, root, putOptions, &buf)
+	return PutContext(ctx, root, root, putOptions, &buf)
 }
 
 // RemoveOptions controls parts of Remove()'s behavior.
@@ -587,22 +634,29 @@ type RemoveOptions struct {
 	AllowWildcard bool // expand the path as a glob pattern, removing each match. All must be set to remove matched non-empty directories
 }
 
-// Remove removes the specified directory or item, traversing any intermediate
-// symbolic links.
+// Remove calls RemoveContext with context.TODO().
+//
+//go:fix inline
+func Remove(root, item string, options RemoveOptions) error {
+	return RemoveContext(context.TODO(), root, item, options)
+}
+
+// RemoveContext removes the specified directory or item, traversing any
+// intermediate symbolic links.
 // If the root directory is not specified, the current root directory is used.
 // If root is specified and the current OS supports it, and the calling process
 // has the necessary privileges, the remove() is performed in a chrooted context.
 // If the item to remove is specified as an absolute path, it should either be
 // in the root directory or in a subdirectory of the root directory.  Otherwise,
 // the directory is treated as a path relative to the root directory.
-func Remove(root string, item string, options RemoveOptions) error {
+func RemoveContext(ctx context.Context, root, item string, options RemoveOptions) error {
 	req := request{
 		Request:       requestRemove,
 		Root:          root,
 		Directory:     item,
 		RemoveOptions: options,
 	}
-	resp, err := copier(nil, nil, req)
+	resp, err := copier(ctx, nil, nil, req)
 	if err != nil {
 		return err
 	}
@@ -619,10 +673,17 @@ type SymlinkOptions struct {
 	ModTimeNew     *time.Time      // set mtime and atime of the newly-created symlink
 }
 
-// Symlink creates a symlink at the specified path under root
-// pointing to the specified target. It builds a tar archive
-// containing a single entry and passes it to Put().
+// Symlink calls SymlinkContext with context.TODO().
+//
+//go:fix inline
 func Symlink(root string, target string, link string, options SymlinkOptions) error {
+	return SymlinkContext(context.TODO(), root, target, link, options)
+}
+
+// SymlinkContext creates a symlink at the specified path under root pointing
+// to the specified target. It builds a tar archive containing a single entry
+// and passes it to Put().
+func SymlinkContext(ctx context.Context, root string, target string, link string, options SymlinkOptions) error {
 	uid, gid := 0, 0
 	if options.ChownNew != nil {
 		uid, gid = options.ChownNew.UID, options.ChownNew.GID
@@ -657,7 +718,7 @@ func Symlink(root string, target string, link string, options SymlinkOptions) er
 		GIDMap: options.GIDMap,
 	}
 
-	return Put(root, root, putOptions, &buf)
+	return PutContext(ctx, root, root, putOptions, &buf)
 }
 
 // cleanerReldirectory resolves relative path candidate lexically, attempting
@@ -712,7 +773,7 @@ func looksLikeAbs(candidate string) bool {
 	return candidate[0] == os.PathSeparator && (len(candidate) == 1 || candidate[1] != os.PathSeparator)
 }
 
-func copier(bulkReader io.Reader, bulkWriter io.Writer, req request) (*response, error) {
+func copier(ctx context.Context, bulkReader io.Reader, bulkWriter io.Writer, req request) (*response, error) {
 	if req.Directory == "" {
 		if req.Root == "" {
 			wd, err := os.Getwd()
@@ -742,12 +803,12 @@ func copier(bulkReader io.Reader, bulkWriter io.Writer, req request) (*response,
 		return nil, fmt.Errorf("checking if %q is a root directory: %w", req.Root, err)
 	}
 	if !isAlreadyRoot && canChroot {
-		return copierWithSubprocess(bulkReader, bulkWriter, req)
+		return copierWithSubprocess(ctx, bulkReader, bulkWriter, req)
 	}
-	return copierWithoutSubprocess(bulkReader, bulkWriter, req)
+	return copierWithoutSubprocess(ctx, bulkReader, bulkWriter, req)
 }
 
-func copierWithoutSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req request) (*response, error) {
+func copierWithoutSubprocess(ctx context.Context, bulkReader io.Reader, bulkWriter io.Writer, req request) (*response, error) {
 	req.preservedRoot = req.Root
 	req.rootPrefix = string(os.PathSeparator)
 	req.preservedDirectory = req.Directory
@@ -769,7 +830,7 @@ func copierWithoutSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req req
 		}
 	}
 	req.Globs = absoluteGlobs
-	resp, cb, err := copierHandler(bulkReader, bulkWriter, req)
+	resp, cb, err := copierHandler(ctx, bulkReader, bulkWriter, req)
 	if err != nil {
 		return nil, err
 	}
@@ -791,14 +852,14 @@ func closeIfNotNilYet(f **os.File, what string) {
 	}
 }
 
-func copierWithSubprocess(bulkReader io.Reader, bulkWriter io.Writer, req request) (resp *response, err error) {
+func copierWithSubprocess(ctx context.Context, bulkReader io.Reader, bulkWriter io.Writer, req request) (resp *response, err error) {
 	if bulkReader == nil {
 		bulkReader = bytes.NewReader([]byte{})
 	}
 	if bulkWriter == nil {
 		bulkWriter = io.Discard
 	}
-	cmd := reexec.Command(copierCommand)
+	cmd := reexec.CommandContext(ctx, copierCommand)
 	stdinRead, stdinWrite, err := os.Pipe()
 	if err != nil {
 		return nil, fmt.Errorf("pipe: %w", err)
@@ -932,6 +993,7 @@ func copierMain() {
 	decoder := json.NewDecoder(os.Stdin)
 	encoder := json.NewEncoder(os.Stdout)
 	previousRequestRoot := ""
+	ctx := context.Background()
 
 	// Attempt a user and host lookup to force libc (glibc, and possibly others that use dynamic
 	// modules to handle looking up user and host information) to load modules that match the libc
@@ -1047,7 +1109,7 @@ func copierMain() {
 			}
 			req.Globs = absoluteGlobs
 		}
-		resp, cb, err := copierHandler(bulkReader, bulkWriter, *req)
+		resp, cb, err := copierHandler(ctx, bulkReader, bulkWriter, *req)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error handling request %#v from copier parent process: %v", *req, err)
 			os.Exit(1)
@@ -1068,7 +1130,7 @@ func copierMain() {
 	}
 }
 
-func copierHandler(bulkReader io.Reader, bulkWriter io.Writer, req request) (*response, func() error, error) {
+func copierHandler(ctx context.Context, bulkReader io.Reader, bulkWriter io.Writer, req request) (*response, func() error, error) {
 	// NewPatternMatcher splits patterns into components using
 	// os.PathSeparator, implying that it expects OS-specific naming
 	// conventions.
@@ -1088,25 +1150,25 @@ func copierHandler(bulkReader io.Reader, bulkWriter io.Writer, req request) (*re
 	default:
 		return nil, nil, fmt.Errorf("not an implemented request type: %q", req.Request)
 	case requestEval:
-		resp := copierHandlerEval(req)
+		resp := copierHandlerEval(ctx, req)
 		return resp, nil, nil
 	case requestStat:
-		resp := copierHandlerStat(req, pm, idMappings)
+		resp := copierHandlerStat(ctx, req, pm, idMappings)
 		return resp, nil, nil
 	case requestGet:
-		return copierHandlerGet(bulkWriter, req, pm, idMappings)
+		return copierHandlerGet(ctx, bulkWriter, req, pm, idMappings)
 	case requestPut:
-		return copierHandlerPut(bulkReader, req, idMappings)
+		return copierHandlerPut(ctx, bulkReader, req, idMappings)
 	case requestMkdir:
-		return copierHandlerMkdir(req, idMappings)
+		return copierHandlerMkdir(ctx, req, idMappings)
 	case requestRemove:
-		resp := copierHandlerRemove(req)
+		resp := copierHandlerRemove(ctx, req)
 		return resp, nil, nil
 	case requestEnsure:
-		resp := copierHandlerEnsure(req, idMappings)
+		resp := copierHandlerEnsure(ctx, req, idMappings)
 		return resp, nil, nil
 	case requestConditionalRemove:
-		resp := copierHandlerConditionalRemove(req, idMappings)
+		resp := copierHandlerConditionalRemove(ctx, req, idMappings)
 		return resp, nil, nil
 	case requestQuit:
 		return nil, nil, nil
@@ -1207,9 +1269,14 @@ func resolvePath(root, path string, evaluateFinalComponent bool, pm *fileutils.P
 	return workingPath, nil
 }
 
-func copierHandlerEval(req request) *response {
+func copierHandlerEval(ctx context.Context, req request) *response {
 	errorResponse := func(fmtspec string, args ...any) *response {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Eval: evalResponse{}}
+	}
+	select {
+	case <-ctx.Done():
+		return errorResponse("%v", ctx.Err())
+	default:
 	}
 	resolvedTarget, err := resolvePath(req.Root, req.Directory, true, nil)
 	if err != nil {
@@ -1222,15 +1289,25 @@ func containsWildcards(path string) bool {
 	return strings.ContainsAny(path, "*?[")
 }
 
-func copierHandlerStat(req request, pm *fileutils.PatternMatcher, idMappings *idtools.IDMappings) *response {
+func copierHandlerStat(ctx context.Context, req request, pm *fileutils.PatternMatcher, idMappings *idtools.IDMappings) *response {
 	errorResponse := func(fmtspec string, args ...any) *response {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Stat: statResponse{}}
+	}
+	select {
+	case <-ctx.Done():
+		return errorResponse("%v", ctx.Err())
+	default:
 	}
 	if len(req.Globs) == 0 {
 		return errorResponse("copier: stat: expected at least one glob pattern, got none")
 	}
 	var stats []*StatsForGlob
 	for i, glob := range req.Globs {
+		select {
+		case <-ctx.Done():
+			return errorResponse("%v", ctx.Err())
+		default:
+		}
 		s := StatsForGlob{
 			Glob: req.preservedGlobs[i],
 		}
@@ -1251,6 +1328,11 @@ func copierHandlerStat(req request, pm *fileutils.PatternMatcher, idMappings *id
 		s.Globbed = make([]string, 0, len(globMatched))
 		s.Results = make(map[string]*StatForItem)
 		for _, globbed := range globMatched {
+			select {
+			case <-ctx.Done():
+				return errorResponse("%v", ctx.Err())
+			default:
+			}
 			rel, excluded, err := pathIsExcluded(req.Root, globbed, pm)
 			if err != nil {
 				return errorResponse("copier: stat: %v", err)
@@ -1345,6 +1427,11 @@ func copierHandlerStat(req request, pm *fileutils.PatternMatcher, idMappings *id
 		}
 		stats = append(stats, &s)
 	}
+	select {
+	case <-ctx.Done():
+		return errorResponse("%v", ctx.Err())
+	default:
+	}
 	if len(stats) == 0 && !req.StatOptions.AllowEmptyWildcard {
 		s := StatsForGlob{
 			Error: fmt.Sprintf("copier: stat: globs %v matched nothing", req.Globs),
@@ -1404,8 +1491,18 @@ func checkLinks(item string, req request, info os.FileInfo) (string, os.FileInfo
 	return item, info, nil
 }
 
-func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMatcher, idMappings *idtools.IDMappings) (*response, func() error, error) {
-	statResponse := copierHandlerStat(req, pm, idMappings)
+func copierHandlerGet(ctx context.Context, bulkWriter io.Writer, req request, pm *fileutils.PatternMatcher, idMappings *idtools.IDMappings) (*response, func() error, error) {
+	statRequest := req
+	statRequest.Request = requestStat
+	statRequest.StatOptions = StatOptions{
+		UIDMap:             req.GetOptions.UIDMap,
+		GIDMap:             req.GetOptions.GIDMap,
+		CheckForArchives:   false, // not really necessary at this point
+		Excludes:           req.GetOptions.Excludes,
+		DisallowWildcard:   req.GetOptions.DisallowWildcard,
+		AllowEmptyWildcard: req.GetOptions.AllowEmptyWildcard,
+	}
+	statResponse := copierHandlerStat(ctx, statRequest, pm, idMappings)
 	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Stat: statResponse.Stat, Get: getResponse{}}, nil, nil
 	}
@@ -1415,6 +1512,11 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 	if len(req.Globs) == 0 {
 		return errorResponse("copier: get: expected at least one glob pattern, got 0")
 	}
+	select {
+	case <-ctx.Done():
+		return errorResponse("%v", ctx.Err())
+	default:
+	}
 	// build a queue of items by globbing
 	type queueItem struct {
 		glob    string
@@ -1423,6 +1525,11 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 	var queue []queueItem
 	globMatchedCount := 0
 	for _, glob := range req.Globs {
+		select {
+		case <-ctx.Done():
+			return errorResponse("%v", ctx.Err())
+		default:
+		}
 		hasWildcards := containsWildcards(glob)
 		if req.GetOptions.DisallowWildcard && hasWildcards {
 			return errorResponse("copier: get: %q: wildcards are not allowed", glob)
@@ -1446,6 +1553,11 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 			queue = append(queue, queueItem{glob: path, parents: parents})
 		}
 	}
+	select {
+	case <-ctx.Done():
+		return errorResponse("%v", ctx.Err())
+	default:
+	}
 	if len(queue) == 0 {
 		if req.GetOptions.AllowEmptyWildcard {
 			return &response{Stat: statResponse.Stat, Get: getResponse{}}, nil, nil
@@ -1465,12 +1577,21 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 		chmod = &p
 	}
 	cb := func() error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		tw := tar.NewWriter(bulkWriter)
-		defer tw.Close()
 		hardlinkChecker := new(hardlinkChecker)
 		itemsCopied := 0
 		addedParents := map[string]struct{}{}
 		for i, qItem := range queue {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			item := qItem.glob
 			// if we're not discarding the names of individual directories, keep track of this one
 			relNamePrefix := ""
@@ -1517,7 +1638,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 					return fmt.Errorf("copier: get: %w", err)
 				}
 
-				if err := copierHandlerGetOne(parentInfo, parentSymlinkTarget, parentName, parent, req.GetOptions, tw, hardlinkChecker, idMappings, chmod); err != nil {
+				if err := copierHandlerGetOne(ctx, parentInfo, parentSymlinkTarget, parentName, parent, req.GetOptions, tw, hardlinkChecker, idMappings, chmod); err != nil {
 					if req.GetOptions.IgnoreUnreadable && errorIsPermission(err) {
 						continue
 					} else if errors.Is(err, os.ErrNotExist) {
@@ -1640,7 +1761,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 						}
 					}
 					// add the item to the outgoing tar stream
-					if err := copierHandlerGetOne(info, symlinkTarget, rel, path, options, tw, hardlinkChecker, idMappings, chmod); err != nil {
+					if err := copierHandlerGetOne(ctx, info, symlinkTarget, rel, path, options, tw, hardlinkChecker, idMappings, chmod); err != nil {
 						if req.GetOptions.IgnoreUnreadable && errorIsPermission(err) {
 							return ok
 						} else if errors.Is(err, os.ErrNotExist) {
@@ -1682,7 +1803,7 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 					return fmt.Errorf("copier: get: %w", err)
 				}
 
-				if err := copierHandlerGetOne(info, symlinkTarget, name, item, req.GetOptions, tw, hardlinkChecker, idMappings, chmod); err != nil {
+				if err := copierHandlerGetOne(ctx, info, symlinkTarget, name, item, req.GetOptions, tw, hardlinkChecker, idMappings, chmod); err != nil {
 					if req.GetOptions.IgnoreUnreadable && errorIsPermission(err) {
 						continue
 					}
@@ -1694,7 +1815,14 @@ func copierHandlerGet(bulkWriter io.Writer, req request, pm *fileutils.PatternMa
 		if itemsCopied == 0 && !req.GetOptions.AllowEmptyWildcard {
 			return fmt.Errorf("copier: get: copied no items: %w", syscall.ENOENT)
 		}
-		return nil
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		// only write the trailer if everything before it succeeded, to hopefully give the
+		// reader a chance at detecting an error if we hit an error while writing
+		return tw.Close()
 	}
 	return &response{Stat: statResponse.Stat, Get: getResponse{}}, cb, nil
 }
@@ -1753,7 +1881,12 @@ func getTargetIfSymlink(path string, info os.FileInfo) (string, error) {
 	return "", nil
 }
 
-func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath string, options GetOptions, tw *tar.Writer, hardlinkChecker *hardlinkChecker, idMappings *idtools.IDMappings, chmod *mode.Set) error {
+func copierHandlerGetOne(ctx context.Context, srcfi os.FileInfo, symlinkTarget, name, contentPath string, options GetOptions, tw *tar.Writer, hardlinkChecker *hardlinkChecker, idMappings *idtools.IDMappings, chmod *mode.Set) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 	// build the header using the name provided
 	hdr, err := tar.FileInfoHeader(srcfi, symlinkTarget)
 	if err != nil {
@@ -1795,11 +1928,12 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 		// inlined the whole file, we'd also be inlining the EOF marker
 		// it contains)
 		if options.ExpandArchives && isArchivePath(contentPath) {
-			f, err := os.Open(contentPath)
+			content, err := os.Open(contentPath)
 			if err != nil {
 				return fmt.Errorf("opening file for reading archive contents: %w", err)
 			}
-			defer f.Close()
+			defer content.Close()
+			f := ctxreader.NewCancelableReader(ctx, content)
 			rc, _, err := compression.AutoDecompress(f)
 			if err != nil {
 				return fmt.Errorf("decompressing %s: %w", contentPath, err)
@@ -1807,7 +1941,12 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 			defer rc.Close()
 			tr := tar.NewReader(rc)
 			hdr, err := tr.Next()
-			for err == nil {
+			for hdr != nil {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+				}
 				if options.Rename != nil {
 					hdr.Name = handleRename(options.Rename, hdr.Name)
 				}
@@ -1821,22 +1960,25 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 						hdr.ChangeTime = timestamp
 					}
 				}
-				if err = tw.WriteHeader(hdr); err != nil {
-					return fmt.Errorf("writing tar header from %q to pipe: %w", contentPath, err)
+				if whErr := tw.WriteHeader(hdr); whErr != nil {
+					return fmt.Errorf("writing tar header from %q to pipe: %w", contentPath, whErr)
 				}
 				if hdr.Size != 0 {
-					n, err := io.Copy(tw, tr)
-					if err != nil {
-						return fmt.Errorf("extracting content from archive %s: %s: %w", contentPath, hdr.Name, err)
+					n, cErr := io.Copy(tw, tr)
+					if cErr != nil {
+						return fmt.Errorf("extracting content from archive %s: %s: %w", contentPath, hdr.Name, cErr)
 					}
 					if n != hdr.Size {
 						return fmt.Errorf("extracting contents of archive %s: incorrect length for %q", contentPath, hdr.Name)
 					}
 					tw.Flush()
 				}
+				if err != nil {
+					break
+				}
 				hdr, err = tr.Next()
 			}
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				return fmt.Errorf("extracting contents of archive %s: %w", contentPath, err)
 			}
 			return nil
@@ -1915,13 +2057,18 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 			hdr.ChangeTime = timestamp
 		}
 	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 	// output the header
 	if err = tw.WriteHeader(hdr); err != nil {
 		return fmt.Errorf("writing header for %s (%s): %w", contentPath, hdr.Name, err)
 	}
 	if hdr.Typeflag == tar.TypeReg {
 		// output the content
-		n, err := io.Copy(tw, f)
+		n, err := io.Copy(tw, ctxreader.NewCancelableReader(ctx, f))
 		if err != nil {
 			return fmt.Errorf("copying %s: %w", contentPath, err)
 		}
@@ -1933,9 +2080,14 @@ func copierHandlerGetOne(srcfi os.FileInfo, symlinkTarget, name, contentPath str
 	return nil
 }
 
-func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDMappings) (*response, func() error, error) {
+func copierHandlerPut(ctx context.Context, bulkReader io.Reader, req request, idMappings *idtools.IDMappings) (*response, func() error, error) {
 	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Put: putResponse{}}, nil, nil
+	}
+	select {
+	case <-ctx.Done():
+		return errorResponse("%v", ctx.Err())
+	default:
 	}
 	dirUID, dirGID, defaultDirUID, defaultDirGID := 0, 0, 0, 0
 	if req.PutOptions.ChownDirs != nil {
@@ -2117,13 +2269,16 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 			osRoot.Close()
 		}()
 		ignoredItems := make(map[string]struct{})
-		tr := tar.NewReader(bulkReader)
+		tr := tar.NewReader(ctxreader.NewCancelableReader(ctx, bulkReader))
 		hdr, err := tr.Next()
-		for err == nil {
+		for hdr != nil {
 			nameBeforeRenaming := hdr.Name
 			if len(hdr.Name) == 0 {
 				// no name -> ignore the entry
 				ignoredItems[nameBeforeRenaming] = struct{}{}
+				if err != nil {
+					break
+				}
 				hdr, err = tr.Next()
 				continue
 			}
@@ -2326,6 +2481,11 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				goto nextHeader
 			}
 			// check for errors
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			if err != nil {
 				return fmt.Errorf("copier: put: error creating %q: %w", path, err)
 			}
@@ -2387,9 +2547,12 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 				return fmt.Errorf("copier: put: error setting fflags on %q: %w", path, err)
 			}
 		nextHeader:
+			if err != nil {
+				break
+			}
 			hdr, err = tr.Next()
 		}
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			return fmt.Errorf("reading tar stream: expected EOF: %w", err)
 		}
 		// Drain any remaining data from bulkReader to prevent broken pipe errors.
@@ -2406,9 +2569,14 @@ func copierHandlerPut(bulkReader io.Reader, req request, idMappings *idtools.IDM
 	return &response{Error: "", Put: putResponse{}}, cb, nil
 }
 
-func copierHandlerMkdir(req request, idMappings *idtools.IDMappings) (*response, func() error, error) {
+func copierHandlerMkdir(ctx context.Context, req request, idMappings *idtools.IDMappings) (*response, func() error, error) {
 	errorResponse := func(fmtspec string, args ...any) (*response, func() error, error) {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Mkdir: mkdirResponse{}}, nil, nil
+	}
+	select {
+	case <-ctx.Done():
+		return errorResponse("%v", ctx.Err())
+	default:
 	}
 	dirUID, dirGID := 0, 0
 	if req.MkdirOptions.ChownNew != nil {
@@ -2482,9 +2650,14 @@ func copierHandlerMkdir(req request, idMappings *idtools.IDMappings) (*response,
 	return &response{Error: "", Mkdir: mkdirResponse{}}, nil, nil
 }
 
-func copierHandlerRemove(req request) *response {
+func copierHandlerRemove(ctx context.Context, req request) *response {
 	errorResponse := func(fmtspec string, args ...any) *response {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Remove: removeResponse{}}
+	}
+	select {
+	case <-ctx.Done():
+		return errorResponse("%v", ctx.Err())
+	default:
 	}
 	targets := []string{req.Directory}
 	if req.RemoveOptions.AllowWildcard {
@@ -2495,6 +2668,11 @@ func copierHandlerRemove(req request) *response {
 		}
 	}
 	for _, target := range targets {
+		select {
+		case <-ctx.Done():
+			return errorResponse("%v", ctx.Err())
+		default:
+		}
 		resolvedTarget, err := resolvePath(req.Root, target, false, nil)
 		if err != nil {
 			return errorResponse("copier: remove: %v", err)
@@ -2537,21 +2715,28 @@ type EnsureOptions struct {
 // up, and it was not actually changed.
 type EnsureParentPath = ConditionalRemovePath
 
-// Ensure ensures that the specified mount point targets exist under the root.
-// If the root directory is not specified, the current root directory is used.
-// If root is specified and the current OS supports it, and the calling process
-// has the necessary privileges, the operation is performed in a chrooted
-// context.
+// Ensure calls EnsureContext with context.TODO().
+//
+//go:fix inline
+func Ensure(root, directory string, options EnsureOptions) ([]string, []EnsureParentPath, error) {
+	return EnsureContext(context.TODO(), root, directory, options)
+}
+
+// EnsureContext ensures that the specified mount point targets exist under the
+// root.  If the root directory is not specified, the current root directory is
+// used.  If root is specified and the current OS supports it, and the calling
+// process has the necessary privileges, the operation is performed in a
+// chrooted context.
 // Returns a slice with the pathnames of items that needed to be created and a
 // slice of affected parent directories and information about them.
-func Ensure(root, directory string, options EnsureOptions) ([]string, []EnsureParentPath, error) {
+func EnsureContext(ctx context.Context, root, directory string, options EnsureOptions) ([]string, []EnsureParentPath, error) {
 	req := request{
 		Request:       requestEnsure,
 		Root:          root,
 		Directory:     directory,
 		EnsureOptions: options,
 	}
-	resp, err := copier(nil, nil, req)
+	resp, err := copier(ctx, nil, nil, req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2561,7 +2746,7 @@ func Ensure(root, directory string, options EnsureOptions) ([]string, []EnsurePa
 	return resp.Ensure.Created, resp.Ensure.Noted, nil
 }
 
-func copierHandlerEnsure(req request, idMappings *idtools.IDMappings) *response {
+func copierHandlerEnsure(ctx context.Context, req request, idMappings *idtools.IDMappings) *response {
 	errorResponse := func(fmtspec string, args ...any) *response {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), Ensure: ensureResponse{}}
 	}
@@ -2569,6 +2754,11 @@ func copierHandlerEnsure(req request, idMappings *idtools.IDMappings) *response 
 	var created []string
 	notedByName := map[string]EnsureParentPath{}
 	for _, item := range req.EnsureOptions.Paths {
+		select {
+		case <-ctx.Done():
+			return errorResponse("%v", ctx.Err())
+		default:
+		}
 		uid, gid := 0, 0
 		if item.Chown != nil {
 			uid, gid = item.Chown.UID, item.Chown.GID
@@ -2696,18 +2886,25 @@ type ConditionalRemoveOptions struct {
 	Paths          []ConditionalRemovePath
 }
 
-// ConditionalRemove removes the set of named items if they're present and
-// currently match the additional conditions, returning the list of items it
-// removed.  Directories will also only be removed if they have no contents,
-// and will be left in place otherwise.
+// ConditionalRemove calls ConditionalRemoveContext with context.TODO().
+//
+//go:fix inline
 func ConditionalRemove(root, directory string, options ConditionalRemoveOptions) ([]string, error) {
+	return ConditionalRemoveContext(context.TODO(), root, directory, options)
+}
+
+// ConditionalRemoveContext removes the set of named items if they're present
+// and currently match the additional conditions, returning the list of items
+// it removed.  Directories will also only be removed if they have no contents,
+// and will be left in place otherwise.
+func ConditionalRemoveContext(ctx context.Context, root, directory string, options ConditionalRemoveOptions) ([]string, error) {
 	req := request{
 		Request:                  requestConditionalRemove,
 		Root:                     root,
 		Directory:                directory,
 		ConditionalRemoveOptions: options,
 	}
-	resp, err := copier(nil, nil, req)
+	resp, err := copier(ctx, nil, nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -2717,13 +2914,18 @@ func ConditionalRemove(root, directory string, options ConditionalRemoveOptions)
 	return resp.ConditionalRemove.Removed, nil
 }
 
-func copierHandlerConditionalRemove(req request, idMappings *idtools.IDMappings) *response {
+func copierHandlerConditionalRemove(ctx context.Context, req request, idMappings *idtools.IDMappings) *response {
 	errorResponse := func(fmtspec string, args ...any) *response {
 		return &response{Error: fmt.Sprintf(fmtspec, args...), ConditionalRemove: conditionalRemoveResponse{}}
 	}
 	slices.SortFunc(req.ConditionalRemoveOptions.Paths, func(a, b ConditionalRemovePath) int { return strings.Compare(b.Path, a.Path) })
 	var removed []string
 	for _, item := range req.ConditionalRemoveOptions.Paths {
+		select {
+		case <-ctx.Done():
+			return errorResponse("%v", ctx.Err())
+		default:
+		}
 		uid, gid := 0, 0
 		if item.Owner != nil {
 			uid, gid = item.Owner.UID, item.Owner.GID

--- a/copier/copier_linux_test.go
+++ b/copier/copier_linux_test.go
@@ -3,6 +3,7 @@ package copier
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,7 +31,7 @@ type getWrappedOptions struct {
 	DropCaps        []capability.Cap
 }
 
-func getWrapped(root string, directory string, getOptions GetOptions, globs []string, dropCaps []capability.Cap, bulkWriter io.Writer) error {
+func getWrapped(ctx context.Context, root string, directory string, getOptions GetOptions, globs []string, dropCaps []capability.Cap, bulkWriter io.Writer) error {
 	options := getWrappedOptions{
 		Root:       root,
 		Directory:  directory,
@@ -42,7 +43,7 @@ func getWrapped(root string, directory string, getOptions GetOptions, globs []st
 	if err != nil {
 		return fmt.Errorf("marshalling options: %w", err)
 	}
-	cmd := reexec.Command("get")
+	cmd := reexec.CommandContext(ctx, "get")
 	cmd.Env = append(cmd.Env, "OPTIONS="+string(encoded))
 	cmd.Stdout = bulkWriter
 	stderrBuf := bytes.Buffer{}
@@ -132,7 +133,7 @@ func testGetPermissionError(t *testing.T) {
 	for _, ignore := range []bool{false, true} {
 		t.Run(fmt.Sprintf("ignore=%v", ignore), func(t *testing.T) {
 			var buf bytes.Buffer
-			err = getWrapped(tmp, tmp, GetOptions{IgnoreUnreadable: ignore}, []string{"."}, dropCaps, &buf)
+			err = getWrapped(t.Context(), tmp, tmp, GetOptions{IgnoreUnreadable: ignore}, []string{"."}, dropCaps, &buf)
 			if ignore {
 				assert.NoError(t, err, "expected no errors")
 				tr := tar.NewReader(&buf)
@@ -142,7 +143,7 @@ func testGetPermissionError(t *testing.T) {
 					items++
 					_, err = tr.Next()
 				}
-				assert.True(t, errors.Is(err, io.EOF), "expected EOF to finish read contents")
+				assert.ErrorIs(t, err, io.EOF, "expected EOF to finish read contents")
 				assert.Equalf(t, 2, items, "expected two readable items, got %d", items)
 			} else {
 				assert.Error(t, err, "expected an error")

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -26,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tonistiigi/dchapes-mode"
+	mode "github.com/tonistiigi/dchapes-mode"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/idtools"
 	"go.podman.io/storage/pkg/reexec"
@@ -112,7 +113,9 @@ func makeArchive(headers []tar.Header, contents map[string][]byte) io.ReadCloser
 				}
 			}
 		}
-		tw.Close()
+		if err == nil {
+			err = tw.Close()
+		}
 		buffered.Flush()
 		if err != nil {
 			pipeWriter.CloseWithError(err)
@@ -130,12 +133,12 @@ func makeContextFromArchive(t *testing.T, archive io.ReadCloser, subdir string) 
 	tmp := t.TempDir()
 	uidMap := []idtools.IDMap{{HostID: os.Getuid(), ContainerID: 0, Size: 1}}
 	gidMap := []idtools.IDMap{{HostID: os.Getgid(), ContainerID: 0, Size: 1}}
-	err := Put(tmp, path.Join(tmp, subdir), PutOptions{UIDMap: uidMap, GIDMap: gidMap}, archive)
+	err := PutContext(t.Context(), tmp, path.Join(tmp, subdir), PutOptions{UIDMap: uidMap, GIDMap: gidMap}, archive)
 	archive.Close()
 	if err != nil {
 		return "", err
 	}
-	return tmp, err
+	return tmp, nil
 }
 
 // enumerateFiles walks a directory, returning the items it contains as a slice
@@ -424,14 +427,24 @@ var (
 	}
 )
 
-func TestPutNoChroot(t *testing.T) {
+func TestPutNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
-	testPut(t)
+	testPut(t.Context(), t, nil)
 	canChroot = couldChroot
 }
 
-func testPut(t *testing.T) {
+func TestPutNoChrootCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(1 * time.Millisecond)
+	couldChroot := canChroot
+	canChroot = false
+	testPut(ctx, t, context.DeadlineExceeded)
+	canChroot = couldChroot
+}
+
+func testPut(ctx context.Context, t *testing.T, expectedError error) {
 	uidMap := []idtools.IDMap{{HostID: os.Getuid(), ContainerID: 0, Size: 1}}
 	gidMap := []idtools.IDMap{{HostID: os.Getgid(), ContainerID: 0, Size: 1}}
 
@@ -506,7 +519,11 @@ func testPut(t *testing.T) {
 				tmp := t.TempDir()
 
 				archive := makeArchive(testArchives[i].headers, testArchives[i].contents)
-				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Rename: renames.renames}, archive)
+				err := PutContext(ctx, tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Rename: renames.renames}, archive)
+				if expectedError != nil {
+					require.ErrorContains(t, err, expectedError.Error())
+					return
+				}
 				require.NoErrorf(t, err, "error extracting archive %q to directory %q", testArchives[i].name, tmp)
 
 				var found []string
@@ -548,7 +565,11 @@ func testPut(t *testing.T) {
 					{Name: "test", Typeflag: typeFlag, Size: 0, Mode: 0o755, Linkname: "target", ModTime: testDate},
 				})
 				tmp := t.TempDir()
-				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteDirNonDir: !overwrite}, bytes.NewReader(archive))
+				err := PutContext(ctx, tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteDirNonDir: !overwrite}, bytes.NewReader(archive))
+				if expectedError != nil {
+					require.ErrorContains(t, err, expectedError.Error())
+					return
+				}
 				if overwrite {
 					if !errors.Is(err, syscall.EPERM) {
 						assert.Nilf(t, err, "expected to overwrite directory with type %c: %v", typeFlag, err)
@@ -574,7 +595,11 @@ func testPut(t *testing.T) {
 					{Name: "test/content", Typeflag: tar.TypeReg, Size: 0, Mode: 0o755, ModTime: testDate},
 				})
 				tmp := t.TempDir()
-				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteNonDirDir: !overwrite}, bytes.NewReader(archive))
+				err := PutContext(ctx, tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, NoOverwriteNonDirDir: !overwrite}, bytes.NewReader(archive))
+				if expectedError != nil {
+					require.ErrorContains(t, err, expectedError.Error())
+					return
+				}
 				if overwrite {
 					if !errors.Is(err, syscall.EPERM) {
 						assert.Nilf(t, err, "expected to overwrite file with type %c: %v", typeFlag, err)
@@ -597,7 +622,11 @@ func testPut(t *testing.T) {
 					{Name: "unrelated", Typeflag: tar.TypeReg, Size: 0, Mode: 0o600, ModTime: testDate},
 				})
 				tmp := t.TempDir()
-				err := Put(tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, IgnoreDevices: ignoreDevices}, bytes.NewReader(archive))
+				err := PutContext(ctx, tmp, tmp, PutOptions{UIDMap: uidMap, GIDMap: gidMap, IgnoreDevices: ignoreDevices}, bytes.NewReader(archive))
+				if expectedError != nil {
+					require.ErrorContains(t, err, expectedError.Error())
+					return
+				}
 				require.Nilf(t, err, "expected to extract content with typeflag %c without an error: %v", typeFlag, err)
 				fileList, err := enumerateFiles(tmp)
 				require.Nilf(t, err, "unexpected error scanning the contents of extraction directory for typeflag %c: %v", typeFlag, err)
@@ -626,8 +655,12 @@ func testPut(t *testing.T) {
 						StripSetgidBit: stripSetgidBit,
 						StripStickyBit: stripStickyBit,
 					}
-					err := Put(tmp, tmp, putOptions, bytes.NewReader(archive))
-					require.Nilf(t, err, "unexpected error writing sample file", err)
+					err := PutContext(ctx, tmp, tmp, putOptions, bytes.NewReader(archive))
+					if expectedError != nil {
+						require.ErrorContains(t, err, expectedError.Error())
+						return
+					}
+					require.Nil(t, err, "unexpected error writing sample file", err)
 					st, err := os.Stat(filepath.Join(tmp, "test"))
 					require.Nil(t, err, "unexpected error checking permissions of file", err)
 					assert.Equal(t, stripSetuidBit, st.Mode()&os.ModeSetuid == 0, "setuid bit was not set/stripped correctly")
@@ -658,7 +691,7 @@ func isExpectedError(err error, inSubdir bool, name string, expectedErrors []exp
 	return false
 }
 
-func TestStatNoChroot(t *testing.T) {
+func TestStatNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testStat(t)
@@ -694,7 +727,7 @@ func testStat(t *testing.T) {
 							CheckForArchives: false,
 							Excludes:         excludes,
 						}
-						stats, err := Stat(root, topdir, options, []string{name})
+						stats, err := StatContext(t.Context(), root, topdir, options, []string{name})
 						require.NoErrorf(t, err, "error statting %q: %v", name, err)
 						for _, st := range stats {
 							// should not have gotten an error
@@ -746,14 +779,24 @@ func testStat(t *testing.T) {
 	}
 }
 
-func TestGetSingleNoChroot(t *testing.T) {
+func TestGetSingleNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
-	testGetSingle(t)
+	testGetSingle(t.Context(), t, nil)
 	canChroot = couldChroot
 }
 
-func testGetSingle(t *testing.T) {
+func TestGetSingleNoChrootCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(1 * time.Millisecond)
+	couldChroot := canChroot
+	canChroot = false
+	testGetSingle(ctx, t, context.DeadlineExceeded)
+	canChroot = couldChroot
+}
+
+func testGetSingle(ctx context.Context, t *testing.T, expectedError error) {
 	for _, absolute := range []bool{false, true} {
 		for _, topdir := range []string{"", ".", "top"} {
 			for _, testArchive := range testArchives {
@@ -784,7 +827,11 @@ func testGetSingle(t *testing.T) {
 					}
 					t.Run(fmt.Sprintf("absolute=%t,topdir=%s,archive=%s,item=%s", absolute, topdir, testArchive.name, name), func(t *testing.T) {
 						// check if we can get this one item
-						err := Get(root, topdir, getOptions, []string{name}, io.Discard)
+						err := GetContext(ctx, root, topdir, getOptions, []string{name}, io.Discard)
+						if expectedError != nil {
+							require.ErrorContains(t, err, expectedError.Error())
+							return
+						}
 						// if we couldn't read that content, check if it's one of the expected failures
 						if err != nil && isExpectedError(err, topdir != "" && topdir != ".", testItem.Name, testArchive.expectedGetErrors) {
 							return
@@ -799,13 +846,16 @@ func testGetSingle(t *testing.T) {
 						var getErr error
 						var wg sync.WaitGroup
 						wg.Go(func() {
-							getErr = Get(root, topdir, getOptions, []string{name}, pipeWriter)
+							getErr = GetContext(ctx, root, topdir, getOptions, []string{name}, pipeWriter)
 							pipeWriter.Close()
 						})
 						tr := tar.NewReader(pipeReader)
 						hdr, err := tr.Next()
-						for err == nil {
-							assert.Equal(t, filepath.Base(name), filepath.FromSlash(hdr.Name), "expected item named %q, got %q", filepath.Base(name), filepath.FromSlash(hdr.Name))
+						for hdr != nil {
+							assert.Equalf(t, filepath.Base(name), filepath.FromSlash(hdr.Name), "expected item named %q, got %q", filepath.Base(name), filepath.FromSlash(hdr.Name))
+							if err != nil {
+								break
+							}
 							hdr, err = tr.Next()
 						}
 						assert.ErrorIs(t, err, io.EOF, "expected EOF at end of archive")
@@ -822,12 +872,12 @@ func testGetSingle(t *testing.T) {
 											getOptions.StripStickyBit = stripStickyBit
 											pipeReader, pipeWriter := io.Pipe()
 											wg.Go(func() {
-												getErr = Get(root, topdir, getOptions, []string{name}, pipeWriter)
+												getErr = GetContext(t.Context(), root, topdir, getOptions, []string{name}, pipeWriter)
 												pipeWriter.Close()
 											})
 											tr := tar.NewReader(pipeReader)
 											hdr, err := tr.Next()
-											for err == nil {
+											for hdr != nil {
 												expectedMode := testItem.Mode
 												modifier := ""
 												if stripSetuidBit {
@@ -846,6 +896,9 @@ func testGetSingle(t *testing.T) {
 													logrus.Warnf("chmod() lost some bits: expected 0%o, got 0%o", expectedMode, hdr.Mode)
 												} else {
 													assert.Equalf(t, expectedMode, hdr.Mode, "expected item named %q %sto have mode 0%o, got 0%o", hdr.Name, modifier, expectedMode, hdr.Mode)
+												}
+												if err != nil {
+													break
 												}
 												hdr, err = tr.Next()
 											}
@@ -869,14 +922,24 @@ func testGetSingle(t *testing.T) {
 	}
 }
 
-func TestGetMultipleNoChroot(t *testing.T) {
+func TestGetMultipleNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
-	testGetMultiple(t)
+	testGetMultiple(t.Context(), t, nil)
 	canChroot = couldChroot
 }
 
-func testGetMultiple(t *testing.T) {
+func TestGetMultipleNoChrootCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(1 * time.Millisecond)
+	couldChroot := canChroot
+	canChroot = false
+	testGetMultiple(ctx, t, context.DeadlineExceeded)
+	canChroot = couldChroot
+}
+
+func testGetMultiple(ctx context.Context, t *testing.T, expectedGetError error) {
 	type getTestArchiveCase struct {
 		name               string
 		pattern            string
@@ -1592,7 +1655,7 @@ func testGetMultiple(t *testing.T) {
 
 				t.Run(fmt.Sprintf("topdir=%s,archive=%s,case=%s,pattern=%s", topdir, testArchive.name, testCase.name, testCase.pattern), func(t *testing.T) {
 					// ensure that we can get stuff using this spec
-					err := Get(root, topdir, getOptions, []string{testCase.pattern}, io.Discard)
+					err := GetContext(t.Context(), root, topdir, getOptions, []string{testCase.pattern}, io.Discard)
 					if err != nil && isExpectedError(err, topdir != "" && topdir != ".", testCase.pattern, testArchive.expectedGetErrors) {
 						return
 					}
@@ -1602,7 +1665,7 @@ func testGetMultiple(t *testing.T) {
 					var getErr error
 					var wg sync.WaitGroup
 					wg.Go(func() {
-						getErr = Get(root, topdir, getOptions, []string{testCase.pattern}, pipeWriter)
+						getErr = GetContext(ctx, root, topdir, getOptions, []string{testCase.pattern}, pipeWriter)
 						pipeWriter.Close()
 					})
 					tr := tar.NewReader(pipeReader)
@@ -1628,6 +1691,12 @@ func testGetMultiple(t *testing.T) {
 						hdr, err = tr.Next()
 					}
 					pipeReader.Close()
+					wg.Wait()
+					if expectedGetError != nil {
+						require.ErrorContains(t, getErr, expectedGetError.Error())
+						require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+						return
+					}
 					sort.Strings(actualContents)
 					// compare it to what we were supposed to get
 					expectedContents := make([]string, 0, len(testCase.items))
@@ -1636,7 +1705,6 @@ func testGetMultiple(t *testing.T) {
 					}
 					sort.Strings(expectedContents)
 					assert.ErrorIs(t, err, io.EOF, "expected EOF at end of archive")
-					wg.Wait()
 					assert.NoErrorf(t, getErr, "unexpected error from Get(%q)", testCase.pattern)
 					assert.Equalf(t, expectedContents, actualContents, "Get(%q,excludes=%v) didn't produce the right set of items", testCase.pattern, excludes)
 
@@ -1651,7 +1719,7 @@ func testGetMultiple(t *testing.T) {
 	}
 }
 
-func TestEvalNoChroot(t *testing.T) {
+func TestEvalNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testEval(t)
@@ -1698,14 +1766,14 @@ func testEval(t *testing.T) {
 				err = os.Symlink(vector.linkTarget, linkname)
 			}
 			require.NoErrorf(t, err, "error creating link from %q to %q", linkname, vector.linkTarget)
-			evaluated, err := Eval(tmp, filepath.Join(tmp, vector.inputPath), options)
+			evaluated, err := EvalContext(t.Context(), tmp, filepath.Join(tmp, vector.inputPath), options)
 			require.NoErrorf(t, err, "error evaluating %q: %v", vector.inputPath, err)
 			require.Equalf(t, filepath.Join(tmp, vector.evaluatedPath), evaluated, "evaluation of %q with %q pointing to %q failed", vector.inputPath, linkname, vector.linkTarget)
 		})
 	}
 }
 
-func TestMkdirNoChroot(t *testing.T) {
+func TestMkdirNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testMkdir(t)
@@ -1861,7 +1929,7 @@ func testMkdir(t *testing.T) {
 						return nil
 					})
 					require.NoErrorf(t, err, "error walking directory to catalog pre-Mkdir contents: %v", err)
-					err = Mkdir(root, testCase.create, options)
+					err = MkdirContext(t.Context(), root, testCase.create, options)
 					if testCase.fail {
 						require.Errorf(t, err, "expected error creating directory %q under %q with Mkdir", testCase.create, root)
 						return
@@ -1892,7 +1960,7 @@ func testMkdir(t *testing.T) {
 	}
 }
 
-func TestMkfileNoChroot(t *testing.T) {
+func TestMkfileNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testMkfile(t)
@@ -2053,7 +2121,7 @@ func TestHandleRename(t *testing.T) {
 	}
 }
 
-func TestRemoveNoChroot(t *testing.T) {
+func TestRemoveNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testRemove(t)
@@ -2299,7 +2367,7 @@ func testRemove(t *testing.T) {
 						return nil
 					})
 					require.NoErrorf(t, err, "error walking directory to catalog pre-Remove contents: %v", err)
-					err = Remove(root, testCase.remove, options)
+					err = RemoveContext(t.Context(), root, testCase.remove, options)
 					if testCase.fail {
 						require.Errorf(t, err, "did not expect to succeed removing item %q under %q with Remove", testCase.remove, root)
 						return
@@ -2499,14 +2567,14 @@ func testEnsure(t *testing.T) {
 			testStarted := time.Now()
 			tmpdir := t.TempDir()
 			for _, mkdir := range testCases[i].mkdirs {
-				err := Mkdir(tmpdir, mkdir, MkdirOptions{
+				err := MkdirContext(t.Context(), tmpdir, mkdir, MkdirOptions{
 					ModTimeNew: &zero,
 					ChmodNew:   &ugReadable,
 					ChownNew:   &idtools.IDPair{UID: 1, GID: 1},
 				})
 				require.NoError(t, err, "unexpected error ensuring")
 			}
-			created, noted, err := Ensure(tmpdir, testCases[i].subdir, testCases[i].options)
+			created, noted, err := EnsureContext(t.Context(), tmpdir, testCases[i].subdir, testCases[i].options)
 			require.NoError(t, err, "unexpected error ensuring")
 			require.EqualValues(t, testCases[i].expectCreated, created, "did not expect to create these")
 			require.Equal(t, len(testCases[i].expectNoted), len(noted), "noticed the wrong number of things")
@@ -2563,7 +2631,7 @@ func testStatDisallowWildcard(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("wildcard-allowed-glob-matches", func(t *testing.T) {
-		stats, err := Stat(dir, dir, StatOptions{}, []string{"file-*"})
+		stats, err := StatContext(t.Context(), dir, dir, StatOptions{}, []string{"file-*"})
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 		require.Empty(t, stats[0].Error)
@@ -2571,7 +2639,7 @@ func testStatDisallowWildcard(t *testing.T) {
 	})
 
 	t.Run("disallow-wildcard-literal", func(t *testing.T) {
-		stats, err := Stat(dir, dir, StatOptions{DisallowWildcard: true}, []string{"file-a"})
+		stats, err := StatContext(t.Context(), dir, dir, StatOptions{DisallowWildcard: true}, []string{"file-a"})
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 		require.Empty(t, stats[0].Error)
@@ -2579,7 +2647,7 @@ func testStatDisallowWildcard(t *testing.T) {
 	})
 
 	t.Run("disallow-wildcard-glob-chars-rejected", func(t *testing.T) {
-		stats, err := Stat(dir, dir, StatOptions{DisallowWildcard: true}, []string{"file-*"})
+		stats, err := StatContext(t.Context(), dir, dir, StatOptions{DisallowWildcard: true}, []string{"file-*"})
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 		require.NotEmpty(t, stats[0].Error, "file-* should be rejected when DisallowWildcard is true")
@@ -2587,7 +2655,7 @@ func testStatDisallowWildcard(t *testing.T) {
 	})
 }
 
-func TestStatAllowEmptyWildcardNoChroot(t *testing.T) {
+func TestStatAllowEmptyWildcardNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testStatAllowEmptyWildcard(t)
@@ -2602,20 +2670,20 @@ func testStatAllowEmptyWildcard(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("empty-wildcard-true-no-error", func(t *testing.T) {
-		stats, err := Stat(dir, dir, StatOptions{AllowEmptyWildcard: true}, []string{"nonexistent-*"})
+		stats, err := StatContext(t.Context(), dir, dir, StatOptions{AllowEmptyWildcard: true}, []string{"nonexistent-*"})
 		require.NoError(t, err)
 		require.Empty(t, stats)
 	})
 
 	t.Run("empty-wildcard-false-error", func(t *testing.T) {
-		stats, err := Stat(dir, dir, StatOptions{}, []string{"nonexistent-*"})
+		stats, err := StatContext(t.Context(), dir, dir, StatOptions{}, []string{"nonexistent-*"})
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 		require.Contains(t, stats[0].Error, "matched nothing")
 	})
 
 	t.Run("empty-wildcard-true-with-existing", func(t *testing.T) {
-		stats, err := Stat(dir, dir, StatOptions{AllowEmptyWildcard: true}, []string{"file-*"})
+		stats, err := StatContext(t.Context(), dir, dir, StatOptions{AllowEmptyWildcard: true}, []string{"file-*"})
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 		require.Empty(t, stats[0].Error)
@@ -2623,14 +2691,14 @@ func testStatAllowEmptyWildcard(t *testing.T) {
 	})
 
 	t.Run("empty-wildcard-true-literal-missing", func(t *testing.T) {
-		stats, err := Stat(dir, dir, StatOptions{AllowEmptyWildcard: true}, []string{"nonexistent-file"})
+		stats, err := StatContext(t.Context(), dir, dir, StatOptions{AllowEmptyWildcard: true}, []string{"nonexistent-file"})
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 		require.Contains(t, stats[0].Error, "no such file or directory")
 	})
 }
 
-func TestGetDisallowWildcardNoChroot(t *testing.T) {
+func TestGetDisallowWildcardNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testGetDisallowWildcard(t)
@@ -2646,17 +2714,17 @@ func testGetDisallowWildcard(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("wildcard-allowed-glob-matches", func(t *testing.T) {
-		err := Get(dir, dir, GetOptions{}, []string{"file-*"}, io.Discard)
+		err := GetContext(t.Context(), dir, dir, GetOptions{}, []string{"file-*"}, io.Discard)
 		require.NoError(t, err)
 	})
 
 	t.Run("disallow-wildcard-literal", func(t *testing.T) {
-		err := Get(dir, dir, GetOptions{DisallowWildcard: true}, []string{"file-a"}, io.Discard)
+		err := GetContext(t.Context(), dir, dir, GetOptions{DisallowWildcard: true}, []string{"file-a"}, io.Discard)
 		require.NoError(t, err)
 	})
 
 	t.Run("disallow-wildcard-glob-chars-rejected", func(t *testing.T) {
-		err := Get(dir, dir, GetOptions{DisallowWildcard: true}, []string{"file-*"}, io.Discard)
+		err := GetContext(t.Context(), dir, dir, GetOptions{DisallowWildcard: true}, []string{"file-*"}, io.Discard)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "wildcards are not allowed")
 	})
@@ -2677,29 +2745,29 @@ func testGetAllowEmptyWildcard(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("empty-wildcard-true-no-error", func(t *testing.T) {
-		err := Get(dir, dir, GetOptions{AllowEmptyWildcard: true}, []string{"nonexistent-*"}, io.Discard)
+		err := GetContext(t.Context(), dir, dir, GetOptions{AllowEmptyWildcard: true}, []string{"nonexistent-*"}, io.Discard)
 		require.NoError(t, err)
 	})
 
 	t.Run("empty-wildcard-false-error", func(t *testing.T) {
-		err := Get(dir, dir, GetOptions{}, []string{"nonexistent-*"}, io.Discard)
+		err := GetContext(t.Context(), dir, dir, GetOptions{}, []string{"nonexistent-*"}, io.Discard)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "matched nothing")
 	})
 
 	t.Run("empty-wildcard-true-literal-missing", func(t *testing.T) {
-		err := Get(dir, dir, GetOptions{AllowEmptyWildcard: true}, []string{"nonexistent-file"}, io.Discard)
+		err := GetContext(t.Context(), dir, dir, GetOptions{AllowEmptyWildcard: true}, []string{"nonexistent-file"}, io.Discard)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
 	t.Run("empty-wildcard-true-with-existing", func(t *testing.T) {
-		err := Get(dir, dir, GetOptions{AllowEmptyWildcard: true}, []string{"file-*"}, io.Discard)
+		err := GetContext(t.Context(), dir, dir, GetOptions{AllowEmptyWildcard: true}, []string{"file-*"}, io.Discard)
 		require.NoError(t, err)
 	})
 }
 
-func TestEnsureNoChroot(t *testing.T) {
+func TestEnsureNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testEnsure(t)
@@ -2856,7 +2924,7 @@ func testConditionalRemove(t *testing.T) {
 					Chmod:    what.mode,
 				})
 			}
-			created, _, err := Ensure(tmpdir, testCases[i].subdir, create)
+			created, _, err := EnsureContext(t.Context(), tmpdir, testCases[i].subdir, create)
 			require.NoErrorf(t, err, "unexpected error creating %#v", create)
 			remove := testCases[i].remove
 			for _, what := range created {
@@ -2864,7 +2932,7 @@ func testConditionalRemove(t *testing.T) {
 					Path: what,
 				})
 			}
-			removed, err := ConditionalRemove(tmpdir, testCases[i].subdir, testCases[i].remove)
+			removed, err := ConditionalRemoveContext(t.Context(), tmpdir, testCases[i].subdir, testCases[i].remove)
 			require.NoError(t, err, "unexpected error removing")
 			expectedRemoved := slices.Clone(testCases[i].expectedRemoved)
 			slices.Sort(expectedRemoved)
@@ -2893,7 +2961,7 @@ func testConditionalRemove(t *testing.T) {
 	}
 }
 
-func TestConditionalRemoveNoChroot(t *testing.T) {
+func TestConditionalRemoveNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testConditionalRemove(t)
@@ -2915,14 +2983,24 @@ func TestSortedExtendedGlob(t *testing.T) {
 	require.ElementsMatch(t, expect, matched, "sorted globbing")
 }
 
-func TestTarPutNoChroot(t *testing.T) {
+func TestTarPutNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	defer func() { canChroot = couldChroot }()
-	testTarPut(t)
+	testTarPut(t.Context(), t, nil)
 }
 
-func testTarPut(t *testing.T) {
+func TestTarPutNoChrootCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(1 * time.Millisecond)
+	couldChroot := canChroot
+	canChroot = false
+	defer func() { canChroot = couldChroot }()
+	testTarPut(ctx, t, context.DeadlineExceeded)
+}
+
+func testTarPut(ctx context.Context, t *testing.T, expectedError error) {
 	testCases := []struct {
 		name               string
 		trailingNullsBytes int
@@ -2968,7 +3046,11 @@ func testTarPut(t *testing.T) {
 				tarBuf.Write(extraNulls)
 			}
 
-			err = Put(testDir, testDir, PutOptions{}, &tarBuf)
+			err = PutContext(ctx, testDir, testDir, PutOptions{}, &tarBuf)
+			if expectedError != nil {
+				require.ErrorContains(t, err, expectedError.Error())
+				return
+			}
 			require.NoError(t, err, "Put returned error")
 
 			extractedFile := filepath.Join(testDir, "testfile.txt")
@@ -2998,7 +3080,7 @@ func TestCannotChangeMultipleRequestsWithDifferentChroot(t *testing.T) {
 
 	stderr := bytes.Buffer{}
 
-	cmd := reexec.Command(copierCommand)
+	cmd := reexec.CommandContext(t.Context(), copierCommand)
 	cmd.Stdin = stdinR
 	cmd.Stdout = stdoutW
 	cmd.Stderr = &stderr
@@ -3034,7 +3116,7 @@ func TestCannotChangeMultipleRequestsWithDifferentChroot(t *testing.T) {
 	require.NoError(t, cmd.Wait())
 }
 
-func TestChmodNoChroot(t *testing.T) {
+func TestChmodNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	testChmod(t)
@@ -3092,21 +3174,26 @@ func testChmod(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Go(func() {
 				opts := GetOptions{Chmod: v.chmod, ChmodDirs: v.chmodDirs, ChmodFiles: v.chmodFiles}
-				err = Get(testDir, "", opts, []string{name}, pipeWriter)
+				err = GetContext(t.Context(), testDir, "", opts, []string{name}, pipeWriter)
 				pipeWriter.Close()
 			})
 			tr := tar.NewReader(pipeReader)
 			hdr, tarErr := tr.Next()
-			for tarErr == nil {
+			for hdr != nil {
 				assert.Equal(t, int64(v.endMode), hdr.Mode)
+				if tarErr != nil {
+					break
+				}
 				hdr, tarErr = tr.Next()
 			}
-			assert.ErrorIs(t, tarErr, io.EOF, "expected EOF at end of archive")
 			wg.Wait()
+			pipeReader.Close()
 			if v.err != nil {
 				require.ErrorContains(t, err, v.err.Error())
+				require.ErrorIs(t, tarErr, io.ErrUnexpectedEOF, "expected trash at end of archive")
+			} else {
+				require.ErrorIs(t, tarErr, io.EOF, "expected EOF at end of archive")
 			}
-			pipeReader.Close()
 		})
 
 		t.Run(fmt.Sprintf("put chmod=%v,chmodDirs=%v,chmodFiles=%v,startMode=%O,endMode=%O,isDir=%v", v.chmod, v.chmodDirs, v.chmodFiles, v.startMode, v.endMode, v.isDir), func(t *testing.T) {
@@ -3125,7 +3212,7 @@ func testChmod(t *testing.T) {
 				ChmodDirs:  v.chmodDirs,
 				ChmodFiles: v.chmodFiles,
 			}
-			err := Put(testDir, "", opts, bytes.NewReader(archive))
+			err := PutContext(t.Context(), testDir, "", opts, bytes.NewReader(archive))
 			if err != nil {
 				require.ErrorContains(t, err, v.err.Error())
 				return
@@ -3141,7 +3228,7 @@ func testChmod(t *testing.T) {
 	}
 }
 
-func TestPutTimestampNoChroot(t *testing.T) {
+func TestPutTimestampNoChrootNoCancel(t *testing.T) {
 	couldChroot := canChroot
 	canChroot = false
 	defer func() { canChroot = couldChroot }()
@@ -3160,7 +3247,7 @@ func testPutTimestamp(t *testing.T) {
 			{Name: "subdir/", Typeflag: tar.TypeDir, Mode: 0o755, ModTime: originalTime},
 			{Name: "subdir/file.txt", Typeflag: tar.TypeReg, Size: 3, Mode: 0o644, ModTime: originalTime},
 		}, map[string][]byte{"subdir/file.txt": []byte("abc")})
-		err := Put(root, root, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Timestamp: &override}, archive)
+		err := PutContext(t.Context(), root, root, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Timestamp: &override}, archive)
 		require.NoError(t, err)
 
 		for _, name := range []string{"subdir", "subdir/file.txt"} {
@@ -3176,7 +3263,7 @@ func testPutTimestamp(t *testing.T) {
 		archive := makeArchive([]tar.Header{
 			{Name: "a/b/file.txt", Typeflag: tar.TypeReg, Size: 2, Mode: 0o644, ModTime: originalTime},
 		}, map[string][]byte{"a/b/file.txt": []byte("hi")})
-		err := Put(root, target, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Timestamp: &override}, archive)
+		err := PutContext(t.Context(), root, target, PutOptions{UIDMap: uidMap, GIDMap: gidMap, Timestamp: &override}, archive)
 		require.NoError(t, err)
 
 		for _, name := range []string{"dest", "dest/nested", "dest/nested/a", "dest/nested/a/b", "dest/nested/a/b/file.txt"} {
@@ -3191,7 +3278,7 @@ func testPutTimestamp(t *testing.T) {
 		archive := makeArchive([]tar.Header{
 			{Name: "file.txt", Typeflag: tar.TypeReg, Size: 5, Mode: 0o644, ModTime: originalTime},
 		}, map[string][]byte{"file.txt": []byte("hello")})
-		err := Put(root, root, PutOptions{UIDMap: uidMap, GIDMap: gidMap}, archive)
+		err := PutContext(t.Context(), root, root, PutOptions{UIDMap: uidMap, GIDMap: gidMap}, archive)
 		require.NoError(t, err)
 
 		info, err := os.Lstat(filepath.Join(root, "file.txt"))
@@ -3238,7 +3325,7 @@ func testPutCreateDestPath(t *testing.T) {
 			}
 
 			opts := PutOptions{UIDMap: uidMap, GIDMap: gidMap, CreateDestPath: tc.createDestPath}
-			err := Put(root, dest, opts, archive())
+			err := PutContext(t.Context(), root, dest, opts, archive())
 
 			if tc.fail {
 				require.ErrorContains(t, err, "does not exist and CreateDestPath is false",
@@ -3275,7 +3362,7 @@ func testSymlink(t *testing.T) {
 
 	t.Run("basic", func(t *testing.T) {
 		root := t.TempDir()
-		err := Symlink(root, "target", "newlink", symlinkOpts(nil))
+		err := SymlinkContext(t.Context(), root, "target", "newlink", symlinkOpts(nil))
 		require.NoError(t, err)
 
 		info, err := os.Lstat(filepath.Join(root, "newlink"))
@@ -3289,7 +3376,7 @@ func testSymlink(t *testing.T) {
 
 	t.Run("with-timestamp", func(t *testing.T) {
 		root := t.TempDir()
-		err := Symlink(root, "target", "dated", symlinkOpts(&testDate))
+		err := SymlinkContext(t.Context(), root, "target", "dated", symlinkOpts(&testDate))
 		require.NoError(t, err)
 
 		info, err := os.Lstat(filepath.Join(root, "dated"))
@@ -3309,7 +3396,7 @@ func testSymlink(t *testing.T) {
 		root, err := makeContextFromArchive(t, archive, "")
 		require.NoError(t, err)
 
-		err = Symlink(root, "target", "subdir-a/subdir-b/deeplink", symlinkOpts(nil))
+		err = SymlinkContext(t.Context(), root, "target", "subdir-a/subdir-b/deeplink", symlinkOpts(nil))
 		require.NoError(t, err)
 
 		got, err := os.Readlink(filepath.Join(root, "subdir-a", "subdir-b", "deeplink"))
@@ -3319,7 +3406,7 @@ func testSymlink(t *testing.T) {
 
 	t.Run("path-traversal", func(t *testing.T) {
 		root := t.TempDir()
-		err := Symlink(root, "target", "../../escaped", symlinkOpts(nil))
+		err := SymlinkContext(t.Context(), root, "target", "../../escaped", symlinkOpts(nil))
 		require.NoError(t, err)
 
 		got, err := os.Readlink(filepath.Join(root, "escaped"))
@@ -3329,7 +3416,7 @@ func testSymlink(t *testing.T) {
 
 	t.Run("absolute-path", func(t *testing.T) {
 		root := t.TempDir()
-		err := Symlink(root, "target", "/absolutelink", symlinkOpts(nil))
+		err := SymlinkContext(t.Context(), root, "target", "/absolutelink", symlinkOpts(nil))
 		require.NoError(t, err)
 
 		got, err := os.Readlink(filepath.Join(root, "absolutelink"))
@@ -3339,10 +3426,10 @@ func testSymlink(t *testing.T) {
 
 	t.Run("overwrite", func(t *testing.T) {
 		root := t.TempDir()
-		err := Symlink(root, "original-target", "link", symlinkOpts(nil))
+		err := SymlinkContext(t.Context(), root, "original-target", "link", symlinkOpts(nil))
 		require.NoError(t, err)
 
-		err = Symlink(root, "new-target", "link", symlinkOpts(nil))
+		err = SymlinkContext(t.Context(), root, "new-target", "link", symlinkOpts(nil))
 		require.NoError(t, err)
 
 		got, err := os.Readlink(filepath.Join(root, "link"))

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -492,7 +492,7 @@ func testPut(t *testing.T) {
 				if !reflect.DeepEqual(expected, fileList) && reflect.DeepEqual(moddedEnumeratedFiles(expected), moddedEnumeratedFiles(fileList)) {
 					logrus.Warn("chmod() lost some bits and possibly timestamps on symlinks, otherwise we match the source archive")
 				} else {
-					require.Equal(t, expected, fileList, "list of files in context directory for archive %q under topdir %q should match the archived used to populate it", testArchives[i].name, topdir)
+					require.Equalf(t, expected, fileList, "list of files in context directory for archive %q under topdir %q should match the archived used to populate it", testArchives[i].name, topdir)
 				}
 			})
 		}
@@ -629,10 +629,10 @@ func testPut(t *testing.T) {
 					err := Put(tmp, tmp, putOptions, bytes.NewReader(archive))
 					require.Nilf(t, err, "unexpected error writing sample file", err)
 					st, err := os.Stat(filepath.Join(tmp, "test"))
-					require.Nilf(t, err, "unexpected error checking permissions of file", err)
-					assert.Equalf(t, stripSetuidBit, st.Mode()&os.ModeSetuid == 0, "setuid bit was not set/stripped correctly")
-					assert.Equalf(t, stripSetgidBit, st.Mode()&os.ModeSetgid == 0, "setgid bit was not set/stripped correctly")
-					assert.Equalf(t, stripStickyBit, st.Mode()&os.ModeSticky == 0, "sticky bit was not set/stripped correctly")
+					require.Nil(t, err, "unexpected error checking permissions of file", err)
+					assert.Equal(t, stripSetuidBit, st.Mode()&os.ModeSetuid == 0, "setuid bit was not set/stripped correctly")
+					assert.Equal(t, stripSetgidBit, st.Mode()&os.ModeSetgid == 0, "setgid bit was not set/stripped correctly")
+					assert.Equal(t, stripStickyBit, st.Mode()&os.ModeSticky == 0, "sticky bit was not set/stripped correctly")
 				})
 			}
 		}
@@ -704,8 +704,8 @@ func testStat(t *testing.T) {
 							matches := 0
 							for _, glob := range st.Globbed {
 								matches++
-								require.Equal(t, st.Glob, glob, "expected entry for %q", st.Glob)
-								require.NotNil(t, st.Results[glob], "%q globbed %q, but there are no results for it", st.Glob, glob)
+								require.Equalf(t, st.Glob, glob, "expected entry for %q", st.Glob)
+								require.NotNilf(t, st.Results[glob], "%q globbed %q, but there are no results for it", st.Glob, glob)
 								toStat := glob
 								if !absolute {
 									toStat = filepath.Join(root, topdir, name)
@@ -720,24 +720,24 @@ func testStat(t *testing.T) {
 										testItem.Size = int64(len(actualContent))
 									}
 									checkStatInfoOwnership(t, result)
-									require.Equal(t, testItem.Size, result.Size, "unexpected size difference for %q", name)
-									require.True(t, result.IsRegular, "expected %q.IsRegular to be true", glob)
-									require.False(t, result.IsDir, "expected %q.IsDir to be false", glob)
-									require.False(t, result.IsSymlink, "expected %q.IsSymlink to be false", glob)
+									require.Equalf(t, testItem.Size, result.Size, "unexpected size difference for %q", name)
+									require.Truef(t, result.IsRegular, "expected %q.IsRegular to be true", glob)
+									require.Falsef(t, result.IsDir, "expected %q.IsDir to be false", glob)
+									require.Falsef(t, result.IsSymlink, "expected %q.IsSymlink to be false", glob)
 								case tar.TypeDir:
-									require.False(t, result.IsRegular, "expected %q.IsRegular to be false", glob)
-									require.True(t, result.IsDir, "expected %q.IsDir to be true", glob)
-									require.False(t, result.IsSymlink, "expected %q.IsSymlink to be false", glob)
+									require.Falsef(t, result.IsRegular, "expected %q.IsRegular to be false", glob)
+									require.Truef(t, result.IsDir, "expected %q.IsDir to be true", glob)
+									require.Falsef(t, result.IsSymlink, "expected %q.IsSymlink to be false", glob)
 								case tar.TypeSymlink:
-									require.True(t, result.IsSymlink, "%q is supposed to be a symbolic link, but is not", name)
-									require.Equal(t, filepath.FromSlash(testItem.Linkname), result.ImmediateTarget, "%q is supposed to point to %q, but points to %q", glob, testItem.Linkname, result.ImmediateTarget)
+									require.Truef(t, result.IsSymlink, "%q is supposed to be a symbolic link, but is not", name)
+									require.Equalf(t, filepath.FromSlash(testItem.Linkname), result.ImmediateTarget, "%q is supposed to point to %q, but points to %q", glob, testItem.Linkname, result.ImmediateTarget)
 								case tar.TypeBlock, tar.TypeChar:
-									require.False(t, result.IsRegular, "%q is a regular file, but is not supposed to be", name)
-									require.False(t, result.IsDir, "%q is a directory, but is not supposed to be", name)
-									require.False(t, result.IsSymlink, "%q is not supposed to be a symbolic link, but appears to be one", name)
+									require.Falsef(t, result.IsRegular, "%q is a regular file, but is not supposed to be", name)
+									require.Falsef(t, result.IsDir, "%q is a directory, but is not supposed to be", name)
+									require.Falsef(t, result.IsSymlink, "%q is not supposed to be a symbolic link, but appears to be one", name)
 								}
 							}
-							require.Equal(t, 1, matches, "non-glob %q matched %d items, not exactly one", name, matches)
+							require.Equalf(t, 1, matches, "non-glob %q matched %d items, not exactly one", name, matches)
 						}
 					})
 				}
@@ -845,7 +845,7 @@ func testGetSingle(t *testing.T) {
 												if expectedMode != hdr.Mode && expectedMode&testModeMask == hdr.Mode&testModeMask {
 													logrus.Warnf("chmod() lost some bits: expected 0%o, got 0%o", expectedMode, hdr.Mode)
 												} else {
-													assert.Equal(t, expectedMode, hdr.Mode, "expected item named %q %sto have mode 0%o, got 0%o", hdr.Name, modifier, expectedMode, hdr.Mode)
+													assert.Equalf(t, expectedMode, hdr.Mode, "expected item named %q %sto have mode 0%o, got 0%o", hdr.Name, modifier, expectedMode, hdr.Mode)
 												}
 												hdr, err = tr.Next()
 											}
@@ -1638,7 +1638,7 @@ func testGetMultiple(t *testing.T) {
 					assert.ErrorIs(t, err, io.EOF, "expected EOF at end of archive")
 					wg.Wait()
 					assert.NoErrorf(t, getErr, "unexpected error from Get(%q)", testCase.pattern)
-					assert.Equal(t, expectedContents, actualContents, "Get(%q,excludes=%v) didn't produce the right set of items", testCase.pattern, excludes)
+					assert.Equalf(t, expectedContents, actualContents, "Get(%q,excludes=%v) didn't produce the right set of items", testCase.pattern, excludes)
 
 					expectedSymlinks := testCase.expectedSymlinks
 					if expectedSymlinks == nil {
@@ -2024,7 +2024,7 @@ func TestCleanerSubdirectory(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase[0], func(t *testing.T) {
 			cleaner := cleanerReldirectory(filepath.FromSlash(testCase[0]))
-			assert.Equal(t, testCase[1], filepath.ToSlash(cleaner), "expected to get %q, got %q", testCase[1], cleaner)
+			assert.Equalf(t, testCase[1], filepath.ToSlash(cleaner), "expected to get %q, got %q", testCase[1], cleaner)
 		})
 	}
 }
@@ -2048,7 +2048,7 @@ func TestHandleRename(t *testing.T) {
 	for i, testCase := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			renamed := handleRename(renames, testCase[0])
-			assert.Equal(t, testCase[1], renamed, "expected to get %q, got %q", testCase[1], renamed)
+			assert.Equalf(t, testCase[1], renamed, "expected to get %q, got %q", testCase[1], renamed)
 		})
 	}
 }
@@ -2358,7 +2358,7 @@ func TestExtendedGlob(t *testing.T) {
 	expected2 = append(expected2, filepath.Join(tmpdir, "d", "d.dat"))
 	matched, err := extendedGlob(filepath.Join(tmpdir, "**", "*.dat"))
 	require.NoError(t, err, "globbing")
-	require.ElementsMatchf(t, expected1, matched, "**/*.dat")
+	require.ElementsMatch(t, expected1, matched, "**/*.dat")
 	matched, err = extendedGlob(filepath.Join(tmpdir, "**", "d", "*.dat"))
 	require.NoError(t, err, "globbing")
 	require.ElementsMatch(t, expected2, matched, "**/d/*.dat")
@@ -2525,7 +2525,7 @@ func testEnsure(t *testing.T) {
 			for _, item := range testCases[i].options.Paths {
 				target := filepath.Join(tmpdir, testCases[i].subdir, item.Path)
 				st, err := os.Stat(target)
-				require.NoError(t, err, "we supposedly created %q", item.Path)
+				require.NoErrorf(t, err, "we supposedly created %q", item.Path)
 				if item.Chmod != nil {
 					assert.Equalf(t, *item.Chmod, st.Mode().Perm(), "permissions look wrong on %q", item.Path)
 				}
@@ -2538,7 +2538,7 @@ func testEnsure(t *testing.T) {
 				if item.ModTime != nil {
 					assert.Equalf(t, item.ModTime.Unix(), st.ModTime().Unix(), "datestamp looks wrong on %q", item.Path)
 				} else {
-					assert.True(t, !testStarted.After(st.ModTime()), "datestamp is too old on %q: %v < %v", st.ModTime(), testStarted)
+					assert.Truef(t, !testStarted.After(st.ModTime()), "datestamp is too old on %q: %v < %v", target, st.ModTime(), testStarted)
 				}
 			}
 		})
@@ -3024,11 +3024,11 @@ func TestCannotChangeMultipleRequestsWithDifferentChroot(t *testing.T) {
 
 	require.NoError(t, encoder.Encode(&req), "failed to send first request to copier")
 	resp := receiveResponse()
-	require.Empty(t, resp.Error, "first request returned an error: %s", resp.Error)
+	require.Emptyf(t, resp.Error, "first request returned an error: %s", resp.Error)
 
 	require.NoError(t, encoder.Encode(&req), "failed to send second request to copier")
 	resp = receiveResponse()
-	require.Empty(t, resp.Error, "second request returned an error: %s", resp.Error)
+	require.Emptyf(t, resp.Error, "second request returned an error: %s", resp.Error)
 
 	require.NoError(t, encoder.Encode(&request{Request: requestQuit}))
 	require.NoError(t, cmd.Wait())
@@ -3166,7 +3166,7 @@ func testPutTimestamp(t *testing.T) {
 		for _, name := range []string{"subdir", "subdir/file.txt"} {
 			info, err := os.Lstat(filepath.Join(root, name))
 			require.NoError(t, err)
-			assert.Equal(t, override.Unix(), info.ModTime().Unix(), "%q should have overridden timestamp", name)
+			assert.Equalf(t, override.Unix(), info.ModTime().Unix(), "%q should have overridden timestamp", name)
 		}
 	})
 
@@ -3182,7 +3182,7 @@ func testPutTimestamp(t *testing.T) {
 		for _, name := range []string{"dest", "dest/nested", "dest/nested/a", "dest/nested/a/b", "dest/nested/a/b/file.txt"} {
 			info, err := os.Lstat(filepath.Join(root, name))
 			require.NoError(t, err)
-			assert.Equal(t, override.Unix(), info.ModTime().Unix(), "%q should have overridden timestamp", name)
+			assert.Equalf(t, override.Unix(), info.ModTime().Unix(), "%q should have overridden timestamp", name)
 		}
 	})
 

--- a/copier/copier_unix_test.go
+++ b/copier/copier_unix_test.go
@@ -3,8 +3,10 @@
 package copier
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -14,13 +16,26 @@ const (
 	testIgnoreSymlinkDates = false
 )
 
-func TestPutChroot(t *testing.T) {
+func TestPutChrootNoCancel(t *testing.T) {
 	if uid != 0 {
 		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true
-	testPut(t)
+	testPut(t.Context(), t, nil)
+	canChroot = couldChroot
+}
+
+func TestPutChrootCancel(t *testing.T) {
+	if uid != 0 {
+		t.Skip("chroot() requires root privileges, skipping")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(1 * time.Millisecond)
+	couldChroot := canChroot
+	canChroot = true
+	testPut(ctx, t, context.DeadlineExceeded)
 	canChroot = couldChroot
 }
 
@@ -34,23 +49,49 @@ func TestStatChroot(t *testing.T) {
 	canChroot = couldChroot
 }
 
-func TestGetSingleChroot(t *testing.T) {
+func TestGetSingleChrootNoCancel(t *testing.T) {
 	if uid != 0 {
 		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true
-	testGetSingle(t)
+	testGetSingle(t.Context(), t, nil)
 	canChroot = couldChroot
 }
 
-func TestGetMultipleChroot(t *testing.T) {
+func TestGetSingleChrootCancel(t *testing.T) {
+	if uid != 0 {
+		t.Skip("chroot() requires root privileges, skipping")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(1 * time.Millisecond)
+	couldChroot := canChroot
+	canChroot = true
+	testGetSingle(ctx, t, context.DeadlineExceeded)
+	canChroot = couldChroot
+}
+
+func TestGetMultipleChrootNoCancel(t *testing.T) {
 	if uid != 0 {
 		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true
-	testGetMultiple(t)
+	testGetMultiple(t.Context(), t, nil)
+	canChroot = couldChroot
+}
+
+func TestGetMultipleChrootCancel(t *testing.T) {
+	if uid != 0 {
+		t.Skip("chroot() requires root privileges, skipping")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(1 * time.Millisecond)
+	couldChroot := canChroot
+	canChroot = true
+	testGetMultiple(ctx, t, context.DeadlineExceeded)
 	canChroot = couldChroot
 }
 
@@ -170,14 +211,27 @@ func TestPutTimestampChroot(t *testing.T) {
 	testPutTimestamp(t)
 }
 
-func TestTarPutChroot(t *testing.T) {
+func TestTarPutChrootNoCancel(t *testing.T) {
 	if uid != 0 {
 		t.Skip("chroot() requires root privileges, skipping")
 	}
 	couldChroot := canChroot
 	canChroot = true
 	defer func() { canChroot = couldChroot }()
-	testTarPut(t)
+	testTarPut(t.Context(), t, nil)
+}
+
+func TestTarPutChrootCancel(t *testing.T) {
+	if uid != 0 {
+		t.Skip("chroot() requires root privileges, skipping")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(1 * time.Millisecond)
+	couldChroot := canChroot
+	canChroot = true
+	defer func() { canChroot = couldChroot }()
+	testTarPut(ctx, t, context.DeadlineExceeded)
 }
 
 func TestPutCreateDestPathChroot(t *testing.T) {

--- a/copier/xattrs_test.go
+++ b/copier/xattrs_test.go
@@ -56,7 +56,7 @@ func TestXattrs(t *testing.T) {
 	for attribute, value := range testValues {
 		t.Run(fmt.Sprintf("attribute=%s", attribute), func(t *testing.T) {
 			f, err := os.CreateTemp(tmp, "copier-xattr-test-")
-			if !assert.Nil(t, err, "error creating test file: %v", err) {
+			if !assert.Nilf(t, err, "error creating test file: %v", err) {
 				t.FailNow()
 			}
 			defer os.Remove(f.Name())
@@ -65,19 +65,19 @@ func TestXattrs(t *testing.T) {
 			if errors.Is(err, syscall.ENOTSUP) {
 				t.Skipf("extended attributes not supported on %q, skipping", tmp)
 			}
-			if !assert.Nil(t, err, "error setting attribute on file: %v", err) {
+			if !assert.Nilf(t, err, "error setting attribute on file: %v", err) {
 				t.FailNow()
 			}
 
 			xattrs, err := Lgetxattrs(f.Name())
-			if !assert.Nil(t, err, "error reading attributes of file: %v", err) {
+			if !assert.Nilf(t, err, "error reading attributes of file: %v", err) {
 				t.FailNow()
 			}
 			xvalue, ok := xattrs[attribute]
-			if !assert.True(t, ok, "did not read back attribute %q for file", attribute) {
+			if !assert.Truef(t, ok, "did not read back attribute %q for file", attribute) {
 				t.FailNow()
 			}
-			if !assert.Equal(t, value, xvalue, "read back different value for attribute %q", attribute) {
+			if !assert.Equalf(t, value, xvalue, "read back different value for attribute %q", attribute) {
 				t.FailNow()
 			}
 		})

--- a/define/types.go
+++ b/define/types.go
@@ -3,6 +3,7 @@ package define
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +19,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/buildah/internal/ctxreader"
 	"go.podman.io/buildah/internal/urlsource"
 	"go.podman.io/image/v5/manifest"
 	"go.podman.io/storage/pkg/archive"
@@ -188,14 +190,27 @@ type SBOMScanOptions struct {
 	MergeStrategy   SBOMMergeStrategy // how to merge the outputs of multiple scans
 }
 
-// TempDirForURL checks if the passed-in string looks like a URL or "-".  If it
+// TempDirForURL() calls TempDirForURLContext() with context.TODO().
+//
+//go:fix inline
+func TempDirForURL(dir, prefix, url string) (tempDir string, relativeContextDir string, err error) {
+	return TempDirForURLContext(context.TODO(), dir, prefix, url)
+}
+
+// TempDirForURLContext checks if the passed-in string looks like a URL or "-".  If it
 // is, TempDirForURL creates a temporary directory, arranges for its contents
 // to be the contents of that URL, and returns the temporary directory's path
 // (for cleanup) and a relative subdirectory to the build context within it.
 // Removal of the temporary directory is the responsibility of the caller.
 // If the string doesn't look like a URL or "-", TempDirForURL returns empty
 // strings and a nil error code.
-func TempDirForURL(dir, prefix, url string) (tempDir string, relativeContextDir string, err error) {
+func TempDirForURLContext(ctx context.Context, dir, prefix, url string) (tempDir string, relativeContextDir string, err error) {
+	select {
+	case <-ctx.Done():
+		return "", "", ctx.Err()
+	default:
+	}
+
 	if !urlsource.IsHTTPOrHTTPS(url) &&
 		!strings.HasPrefix(url, "git://") &&
 		!strings.HasPrefix(url, "github.com/") &&
@@ -229,13 +244,13 @@ func TempDirForURL(dir, prefix, url string) (tempDir string, relativeContextDir 
 	isGitURL := urlParsed.Scheme == "git" || strings.HasSuffix(urlParsed.Path, ".git")
 	switch {
 	case isGitURL:
-		combinedOutput, gitSubDir, cloneErr := cloneToDirectory(url, downloadDir)
+		combinedOutput, gitSubDir, cloneErr := cloneToDirectory(ctx, url, downloadDir)
 		if cloneErr != nil {
 			return "", "", fmt.Errorf("cloning %q to %q:\n%s: %w", url, tempDir, string(combinedOutput), cloneErr)
 		}
 		contentSubdir = gitSubDir
 	case urlsource.IsHTTPOrHTTPS(url):
-		if err = downloadToDirectory(url, downloadDir); err != nil {
+		if err = downloadToDirectory(ctx, url, downloadDir); err != nil {
 			return "", "", err
 		}
 	case strings.HasPrefix(url, "github.com/"):
@@ -243,11 +258,11 @@ func TempDirForURL(dir, prefix, url string) (tempDir string, relativeContextDir 
 		contentSubdir = path.Base(ghURL) + "-master"
 		downloadURL := fmt.Sprintf("https://%s/archive/master.tar.gz", ghURL)
 		logrus.Debugf("resolving url %q to %q", ghURL, downloadURL)
-		if err = downloadToDirectory(downloadURL, downloadDir); err != nil {
+		if err = downloadToDirectory(ctx, downloadURL, downloadDir); err != nil {
 			return "", "", err
 		}
 	case url == "-":
-		if err = stdinToDirectory(downloadDir); err != nil {
+		if err = stdinToDirectory(ctx, downloadDir); err != nil {
 			return "", "", err
 		}
 	}
@@ -283,11 +298,17 @@ func parseGitBuildContext(url string) (string, string, string) {
 	return gitBranchPart[0], gitSubdir, gitBranch
 }
 
-func cloneToDirectory(url, dir string) ([]byte, string, error) {
+func cloneToDirectory(ctx context.Context, url, dir string) ([]byte, string, error) {
+	select {
+	case <-ctx.Done():
+		return nil, "", ctx.Err()
+	default:
+	}
+
 	var cmd *exec.Cmd
 	gitRepo, gitSubdir, gitRef := parseGitBuildContext(url)
 	// init repo
-	cmd = exec.Command("git", "init", dir)
+	cmd = exec.CommandContext(ctx, "git", "init", dir)
 	combinedOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		// Return err.Error() instead of err as we want buildah to override error code with more predictable
@@ -295,7 +316,7 @@ func cloneToDirectory(url, dir string) ([]byte, string, error) {
 		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git init`: %s", err.Error())
 	}
 	// add origin
-	cmd = exec.Command("git", "remote", "add", "origin", gitRepo)
+	cmd = exec.CommandContext(ctx, "git", "remote", "add", "origin", gitRepo)
 	cmd.Dir = dir
 	combinedOutput, err = cmd.CombinedOutput()
 	if err != nil {
@@ -306,7 +327,7 @@ func cloneToDirectory(url, dir string) ([]byte, string, error) {
 
 	logrus.Debugf("fetching repo %q and branch (or commit ID) %q to %q", gitRepo, gitRef, dir)
 	args := []string{"fetch", "-u", "--depth=1", "origin", "--", gitRef}
-	cmd = exec.Command("git", args...)
+	cmd = exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	combinedOutput, err = cmd.CombinedOutput()
 	if err != nil {
@@ -315,7 +336,7 @@ func cloneToDirectory(url, dir string) ([]byte, string, error) {
 		return combinedOutput, gitSubdir, fmt.Errorf("failed while performing `git fetch`: %s", err.Error())
 	}
 
-	cmd = exec.Command("git", "checkout", "FETCH_HEAD")
+	cmd = exec.CommandContext(ctx, "git", "checkout", "FETCH_HEAD")
 	cmd.Dir = dir
 	combinedOutput, err = cmd.CombinedOutput()
 	if err != nil {
@@ -326,9 +347,19 @@ func cloneToDirectory(url, dir string) ([]byte, string, error) {
 	return combinedOutput, gitSubdir, nil
 }
 
-func downloadToDirectory(url, dir string) error {
+func downloadToDirectory(ctx context.Context, url, dir string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	logrus.Debugf("extracting %q to %q", url, dir)
-	resp, err := http.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -342,7 +373,11 @@ func downloadToDirectory(url, dir string) error {
 	// Try to extract the response as a tar archive; if that fails,
 	// assume it is a raw Dockerfile and write it as such.
 	if err := chrootarchive.Untar(resp.Body, dir, nil); err != nil {
-		resp1, err := http.Get(url)
+		req1, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp1, err := http.DefaultClient.Do(req1)
 		if err != nil {
 			return err
 		}
@@ -358,7 +393,13 @@ func downloadToDirectory(url, dir string) error {
 	return nil
 }
 
-func stdinToDirectory(dir string) error {
+func stdinToDirectory(ctx context.Context, dir string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	logrus.Debugf("extracting stdin to %q", dir)
 	r := bufio.NewReader(os.Stdin)
 	b, err := io.ReadAll(r)
@@ -368,7 +409,7 @@ func stdinToDirectory(dir string) error {
 	// Try to extract the buffered input as a tar archive; if that fails,
 	// assume it is a raw Dockerfile and write it as such.
 	reader := bytes.NewReader(b)
-	if err := chrootarchive.Untar(reader, dir, nil); err != nil {
+	if err := chrootarchive.Untar(ctxreader.NewCancelableReader(ctx, reader), dir, nil); err != nil {
 		if err := writeFileInRoot(dir, "Dockerfile", b, 0o600); err != nil {
 			return fmt.Errorf("failed to write bytes to %q: %w", filepath.Join(dir, "Dockerfile"), err)
 		}

--- a/image.go
+++ b/image.go
@@ -25,6 +25,7 @@ import (
 	"go.podman.io/buildah/define"
 	"go.podman.io/buildah/docker"
 	"go.podman.io/buildah/internal/config"
+	"go.podman.io/buildah/internal/ctxreader"
 	"go.podman.io/buildah/internal/mkcw"
 	"go.podman.io/buildah/internal/tmpdir"
 	"go.podman.io/image/v5/docker/reference"
@@ -93,9 +94,9 @@ const (
 	winSecurityDescriptorFile = "AQAEgBQAAAAkAAAAAAAAADAAAAABAgAAAAAABSAAAAAgAgAAAQEAAAAAAAUSAAAAAgBMAAMAAAAAABgA/wEfAAECAAAAAAAFIAAAACACAAAAABQA/wEfAAEBAAAAAAAFEgAAAAAAGACpABIAAQIAAAAAAAUgAAAAIQIAAA=="
 )
 
-// ExtractRootfsOptions is consumed by ExtractRootfs() which allows users to
-// control whether various information like the like setuid and setgid bits and
-// xattrs are preserved when extracting file system objects.
+// ExtractRootfsOptions is consumed by ExtractRootfsContext() which allows
+// users to control whether various information like the like setuid and setgid
+// bits and xattrs are preserved when extracting file system objects.
 type ExtractRootfsOptions struct {
 	StripSetuidBit bool       // strip the setuid bit off of items being extracted.
 	StripSetgidBit bool       // strip the setgid bit off of items being extracted.
@@ -178,6 +179,12 @@ type containerImageSource struct {
 }
 
 func (i *containerImageRef) NewImage(ctx context.Context, sc *types.SystemContext) (types.ImageCloser, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	src, err := i.NewImageSource(ctx, sc)
 	if err != nil {
 		return nil, err
@@ -207,7 +214,13 @@ func expectedDockerDiffIDs(image docker.V2Image) int {
 
 // Extract the container's whole filesystem as a filesystem image, wrapped
 // in LUKS-compatible encryption.
-func (i *containerImageRef) extractConfidentialWorkloadFS(options ConfidentialWorkloadOptions) (io.ReadCloser, error) {
+func (i *containerImageRef) extractConfidentialWorkloadFS(ctx context.Context, options ConfidentialWorkloadOptions) (io.ReadCloser, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	var image v1.Image
 	if err := json.Unmarshal(i.oconfig, &image); err != nil {
 		return nil, fmt.Errorf("recreating OCI configuration for %q: %w", i.containerID, err)
@@ -246,7 +259,7 @@ func (i *containerImageRef) extractConfidentialWorkloadFS(options ConfidentialWo
 		GraphOptions:             i.store.GraphOptions(),
 		ExtraImageContent:        i.extraImageContent,
 	}
-	rc, _, err := mkcw.Archive(mountPoint, &image, archiveOptions)
+	rc, _, err := mkcw.Archive(ctx, mountPoint, &image, archiveOptions)
 	if err != nil {
 		if _, err2 := i.store.Unmount(i.containerID, false); err2 != nil {
 			logrus.Debugf("unmounting container %q: %v", i.containerID, err2)
@@ -272,7 +285,7 @@ func (i *containerImageRef) extractConfidentialWorkloadFS(options ConfidentialWo
 // Extract the container's whole filesystem as if it were a single layer.
 // The ExtractRootfsOptions control whether or not to preserve setuid and
 // setgid bits and extended attributes on contents.
-func (i *containerImageRef) extractRootfs(opts ExtractRootfsOptions) (io.ReadCloser, chan error, error) {
+func (i *containerImageRef) extractRootfs(ctx context.Context, opts ExtractRootfsOptions) (io.ReadCloser, chan error, error) {
 	var uidMap, gidMap []idtools.IDMap
 	mountPoint, err := i.store.Mount(i.containerID, i.mountLabel)
 	if err != nil {
@@ -299,7 +312,7 @@ func (i *containerImageRef) extractRootfs(opts ExtractRootfsOptions) (io.ReadClo
 				return
 			}
 			defer file.Close()
-			if _, err = io.Copy(pipeWriter, file); err != nil {
+			if _, err = io.Copy(pipeWriter, ctxreader.NewCancelableReader(ctx, file)); err != nil {
 				errChan <- fmt.Errorf("writing contents of %q: %w", filename, err)
 				return
 			}
@@ -315,7 +328,7 @@ func (i *containerImageRef) extractRootfs(opts ExtractRootfsOptions) (io.ReadClo
 			StripXattrs:    opts.StripXattrs,
 			Timestamp:      opts.ForceTimestamp,
 		}
-		err := copier.Get(mountPoint, mountPoint, copierOptions, []string{"."}, pipeWriter)
+		err := copier.GetContext(ctx, mountPoint, mountPoint, copierOptions, []string{"."}, pipeWriter)
 		errChan <- err
 	}()
 	return ioutils.NewReadCloserWrapper(pipeReader, func() error {
@@ -822,6 +835,12 @@ func (mb *ociManifestBuilder) manifestAndConfig() ([]byte, []byte, error) {
 
 // filterExclusionsByImage returns a slice of the members of "exclusions" which are present in the image with the specified ID
 func (i *containerImageRef) filterExclusionsByImage(ctx context.Context, exclusions []copier.EnsureParentPath, imageID string) ([]copier.EnsureParentPath, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	if len(exclusions) == 0 || imageID == "" {
 		return nil, nil
 	}
@@ -857,7 +876,7 @@ func (i *containerImageRef) filterExclusionsByImage(ctx context.Context, exclusi
 		globs = append(globs, exclusion.Path)
 	}
 	options := copier.StatOptions{}
-	stats, err := copier.Stat(mountPoint, mountPoint, options, globs)
+	stats, err := copier.StatContext(ctx, mountPoint, mountPoint, options, globs)
 	if err != nil {
 		return nil, fmt.Errorf("checking for potential exclusion items in image %q: %w", imageID, err)
 	}
@@ -887,6 +906,12 @@ func (i *containerImageRef) filterExclusionsByImage(ctx context.Context, exclusi
 }
 
 func (i *containerImageRef) NewImageSource(ctx context.Context, _ *types.SystemContext) (src types.ImageSource, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// These maps will let us check if a layer ID is part of one group or another.
 	parentLayerIDs := make(map[string]bool)
 	apiLayerIDs := make(map[string]bool)
@@ -1053,13 +1078,13 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, _ *types.SystemC
 		var layerExclusions []copier.ConditionalRemovePath
 		if i.confidentialWorkload.Convert {
 			// Convert the root filesystem into an encrypted disk image.
-			rc, err = i.extractConfidentialWorkloadFS(i.confidentialWorkload)
+			rc, err = i.extractConfidentialWorkloadFS(ctx, i.confidentialWorkload)
 			if err != nil {
 				return nil, err
 			}
 		} else if i.squash {
 			// Extract the root filesystem as a single layer.
-			rc, errChan, err = i.extractRootfs(ExtractRootfsOptions{})
+			rc, errChan, err = i.extractRootfs(ctx, ExtractRootfsOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -1144,7 +1169,7 @@ func (i *containerImageRef) NewImageSource(ctx context.Context, _ *types.SystemC
 		writer = writeCloser
 		// Okay, copy from the raw diff through the filter, compressor, and counter and
 		// digesters.
-		size, err := io.Copy(writer, rc)
+		size, err := io.Copy(writer, ctxreader.NewCancelableReader(ctx, rc))
 		if err != nil {
 			writeCloser.Close()
 			layerFile.Close()
@@ -1535,7 +1560,13 @@ func makeFilteredLayerWriteCloser(wc io.WriteCloser, layerModTime, layerLatestMo
 
 // makeLinkedLayerInfos calculates the size and digest information for a layer
 // we intend to add to the image that we're committing.
-func (b *Builder) makeLinkedLayerInfos(layers []LinkedLayer, layerType string, layerModTime, layerLatestModTime *time.Time) ([]commitLinkedLayerInfo, error) {
+func (b *Builder) makeLinkedLayerInfos(ctx context.Context, layers []LinkedLayer, layerType string, layerModTime, layerLatestModTime *time.Time) ([]commitLinkedLayerInfo, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	if layers == nil {
 		return nil, nil
 	}
@@ -1592,7 +1623,7 @@ func (b *Builder) makeLinkedLayerInfos(layers []LinkedLayer, layerType string, l
 			if err != nil {
 				return err
 			}
-			_, copyErr := io.Copy(wc, rc)
+			_, copyErr := io.Copy(wc, ctxreader.NewCancelableReader(ctx, rc))
 			wcErr := wc.Close()
 			if err := rc.Close(); err != nil {
 				return fmt.Errorf("storing a copy of %s %q: closing reader: %w", what, info.linkedLayer.BlobPath, err)
@@ -1619,7 +1650,13 @@ func (b *Builder) makeLinkedLayerInfos(layers []LinkedLayer, layerType string, l
 // which is mainly used for representing the working container as a source
 // image that can be copied, which is how we commit the container to create the
 // image.
-func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageRef, error) {
+func (b *Builder) makeContainerImageRef(ctx context.Context, options CommitOptions) (*containerImageRef, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	if (len(options.PrependedLinkedLayers) > 0 || len(options.AppendedLinkedLayers) > 0) &&
 		(options.ConfidentialWorkloadOptions.Convert || options.Squash) {
 		return nil, errors.New("can't add prebuilt layers and produce an image with only one layer, at the same time")
@@ -1743,11 +1780,11 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 		}
 	}
 
-	preLayerInfos, err := b.makeLinkedLayerInfos(append(slices.Clone(b.PrependedLinkedLayers), slices.Clone(options.PrependedLinkedLayers)...), "prepended layer", layerModTime, layerLatestModTime)
+	preLayerInfos, err := b.makeLinkedLayerInfos(ctx, append(slices.Clone(b.PrependedLinkedLayers), slices.Clone(options.PrependedLinkedLayers)...), "prepended layer", layerModTime, layerLatestModTime)
 	if err != nil {
 		return nil, err
 	}
-	postLayerInfos, err := b.makeLinkedLayerInfos(append(slices.Clone(options.AppendedLinkedLayers), slices.Clone(b.AppendedLinkedLayers)...), "appended layer", layerModTime, layerLatestModTime)
+	postLayerInfos, err := b.makeLinkedLayerInfos(ctx, append(slices.Clone(options.AppendedLinkedLayers), slices.Clone(b.AppendedLinkedLayers)...), "appended layer", layerModTime, layerLatestModTime)
 	if err != nil {
 		return nil, err
 	}
@@ -1813,11 +1850,18 @@ func (b *Builder) makeContainerImageRef(options CommitOptions) (*containerImageR
 	return ref, nil
 }
 
-// Extract the container's whole filesystem as if it were a single layer from current builder instance
+// ExtractRootfs() calls ExtractRootfsContext() with context.TODO().
+//
+//go:fix inline
 func (b *Builder) ExtractRootfs(options CommitOptions, opts ExtractRootfsOptions) (io.ReadCloser, chan error, error) {
-	src, err := b.makeContainerImageRef(options)
+	return b.ExtractRootfsContext(context.TODO(), options, opts)
+}
+
+// ExtractRootfsContext extracts the container's whole filesystem, as if it were a single layer, from the current builder instance.
+func (b *Builder) ExtractRootfsContext(ctx context.Context, options CommitOptions, opts ExtractRootfsOptions) (io.ReadCloser, chan error, error) {
+	src, err := b.makeContainerImageRef(ctx, options)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating image reference for container %q to extract its contents: %w", b.ContainerID, err)
 	}
-	return src.extractRootfs(opts)
+	return src.extractRootfs(ctx, opts)
 }

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -29,6 +29,7 @@ import (
 	"go.podman.io/buildah"
 	"go.podman.io/buildah/define"
 	"go.podman.io/buildah/internal"
+	"go.podman.io/buildah/internal/ctxreader"
 	internalUtil "go.podman.io/buildah/internal/util"
 	"go.podman.io/buildah/pkg/parse"
 	"go.podman.io/buildah/util"
@@ -71,6 +72,12 @@ type BuildOptions = define.BuildOptions
 // returns the ID of the built image, and if a name was assigned to it, a
 // canonical reference for that image.
 func BuildDockerfiles(ctx context.Context, store storage.Store, options define.BuildOptions, paths ...string) (id string, ref reference.Canonical, err error) {
+	select {
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	default:
+	}
+
 	if options.CommonBuildOpts == nil {
 		options.CommonBuildOpts = &define.CommonBuildOptions{}
 	}
@@ -119,7 +126,11 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 
 		if strings.HasPrefix(dfile, "http://") || strings.HasPrefix(dfile, "https://") {
 			logger.Debugf("reading remote Dockerfile %q", dfile)
-			resp, err := http.Get(dfile)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, dfile, nil)
+			if err != nil {
+				return "", nil, err
+			}
+			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				return "", nil, err
 			}
@@ -159,12 +170,12 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 			if dinfo.Mode().IsRegular() && dinfo.Size() == 0 {
 				return "", nil, fmt.Errorf("no contents in %q", dfile)
 			}
-			data = contents
+			data = ctxreader.NewCancelableReader(ctx, contents)
 		}
 
 		// pre-process Dockerfiles with ".in" suffix
 		if strings.HasSuffix(dfile, ".in") {
-			pData, err := preprocessContainerfileContents(logger, dfile, data, options.ContextDirectory, options.CPPFlags)
+			pData, err := preprocessContainerfileContents(ctx, logger, dfile, data, options.ContextDirectory, options.CPPFlags)
 			if err != nil {
 				return "", nil, err
 			}
@@ -172,6 +183,12 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 		}
 
 		dockerfiles = append(dockerfiles, data)
+
+		select {
+		case <-ctx.Done():
+			return "", nil, ctx.Err()
+		default:
+		}
 	}
 
 	var files [][]byte
@@ -425,6 +442,12 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 }
 
 func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logrus.Logger, logPrefix string, options define.BuildOptions, containerFiles []string, dockerfilecontents [][]byte, processLabel, mountLabel string, usingContextOverlay bool) (string, reference.Canonical, error) {
+	select {
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	default:
+	}
+
 	mainNode, err := imagebuilder.ParseDockerfile(bytes.NewReader(dockerfilecontents[0]))
 	if err != nil {
 		return "", nil, fmt.Errorf("parsing main Dockerfile: %s: %w", containerFiles[0], err)
@@ -493,7 +516,13 @@ func buildDockerfilesOnce(ctx context.Context, store storage.Store, logger *logr
 
 // preprocessContainerfileContents runs CPP(1) in preprocess-only mode on the input
 // dockerfile content and will use ctxDir as the base include path.
-func preprocessContainerfileContents(logger *logrus.Logger, containerfile string, r io.Reader, ctxDir string, cppFlags []string) (stdout io.Reader, err error) {
+func preprocessContainerfileContents(ctx context.Context, logger *logrus.Logger, containerfile string, r io.Reader, ctxDir string, cppFlags []string) (stdout io.Reader, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	cppCommand := "cpp"
 	cppPath, err := exec.LookPath(cppCommand)
 	if err != nil {
@@ -515,7 +544,7 @@ func preprocessContainerfileContents(logger *logrus.Logger, containerfile string
 		cppArgs = append(cppArgs, args...)
 	}
 	cppArgs = append(cppArgs, cppFlags...)
-	cmd := exec.Command(cppPath, cppArgs...)
+	cmd := exec.CommandContext(ctx, cppPath, cppArgs...)
 	cmd.Stdin = r
 	cmd.Stdout = &stdoutBuffer
 	cmd.Stderr = &stderrBuffer
@@ -558,6 +587,12 @@ func platformIsAcceptable(platform *v1.Platform, logger *logrus.Logger) bool {
 // dockerfiles, and if they are all valid references to manifest lists, returns
 // the list of platforms that are supported by all of the base images.
 func platformsForBaseImages(ctx context.Context, logger *logrus.Logger, dockerfilepaths []string, dockerfiles [][]byte, from string, args map[string]string, additionalBuildContext map[string]*define.AdditionalBuildContext, systemContext *types.SystemContext) ([]struct{ OS, Arch, Variant string }, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	baseImages, err := baseImages(dockerfilepaths, dockerfiles, from, args, additionalBuildContext)
 	if err != nil {
 		return nil, fmt.Errorf("determining list of base images: %w", err)

--- a/imagebuildah/build_linux_test.go
+++ b/imagebuildah/build_linux_test.go
@@ -1,7 +1,6 @@
 package imagebuildah
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -25,7 +24,7 @@ func TestFilesClosedProperlyByBuildDockerfiles(t *testing.T) {
 	}
 
 	// send files as above, and a missing one, so that we error early and return and don't try an actual build
-	_, _, err := BuildDockerfiles(context.Background(), nil, define.BuildOptions{}, append(append(make([]string, 0, len(paths)), paths...), "missing")...)
+	_, _, err := BuildDockerfiles(t.Context(), nil, define.BuildOptions{}, append(append(make([]string, 0, len(paths)), paths...), "missing")...)
 	var pathErr *fs.PathError
 	assert.True(t, errors.As(err, &pathErr))
 	assert.Equal(t, "missing", pathErr.Path)

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -159,7 +159,6 @@ type executor struct {
 	cachePushSourceLookupReferenceFunc      func(dest types.ImageReference) libimage.LookupReferenceFunc
 	cachePushDestinationLookupReferenceFunc libimage.LookupReferenceFunc
 	ociDecryptConfig                        *encconfig.DecryptConfig
-	lastError                               error
 	terminatedStage                         map[int]error // maps from stage indexes to error results, serialized by stagesLock
 	stagesLock                              sync.Mutex    // serializes stages, stageImageIDs, imageMap, terminatedStage
 	stagesSemaphore                         *semaphore.Weighted
@@ -518,8 +517,8 @@ func (b *executor) waitForStage(ctx context.Context, name string, stages imagebu
 		return false, nil
 	}
 	for {
-		if b.lastError != nil {
-			return true, b.lastError
+		if ctx.Err() != nil {
+			return true, ctx.Err()
 		}
 
 		b.stagesLock.Lock()
@@ -534,8 +533,8 @@ func (b *executor) waitForStage(ctx context.Context, name string, stages imagebu
 		}
 
 		b.stagesSemaphore.Release(1)
-		time.Sleep(time.Millisecond * 10)
-		if err := b.stagesSemaphore.Acquire(ctx, 1); err != nil {
+		time.Sleep(time.Millisecond * 10)                                          // give any other goroutine a shot at running
+		if err := b.stagesSemaphore.Acquire(context.Background(), 1); err != nil { // don't let context cancellation throw off our count; trust another goroutine to release the semaphore
 			return true, fmt.Errorf("reacquiring job semaphore: %w", err)
 		}
 	}
@@ -543,6 +542,12 @@ func (b *executor) waitForStage(ctx context.Context, name string, stages imagebu
 
 // getImageTypeAndHistoryAndDiffIDs returns the os, architecture, manifest type, history, and diff IDs list of imageID.
 func (b *executor) getImageTypeAndHistoryAndDiffIDs(ctx context.Context, imageID string) (string, string, string, []v1.History, []digest.Digest, error) {
+	select {
+	case <-ctx.Done():
+		return "", "", "", nil, nil, ctx.Err()
+	default:
+	}
+
 	b.imageInfoLock.Lock()
 	imageInfo, ok := b.imageInfoCache[imageID]
 	b.imageInfoLock.Unlock()
@@ -583,6 +588,12 @@ func (b *executor) getImageTypeAndHistoryAndDiffIDs(ctx context.Context, imageID
 }
 
 func (b *executor) buildStage(ctx context.Context, cleanupStages map[int]*stageExecutor, stages imagebuilder.Stages, stageIndex int, afterDependency map[int]int) (imageID string, commitResults *buildah.CommitResults, onlyBaseImage bool, err error) {
+	select {
+	case <-ctx.Done():
+		return "", nil, false, ctx.Err()
+	default:
+	}
+
 	var prependInstructions, appendInstructions []string
 	stage := stages[stageIndex]
 	ib := stage.Builder
@@ -818,6 +829,12 @@ func (b *executor) warnOnUnsetBuildArgs(stages imagebuilder.Stages, dependencyMa
 // Build takes care of the details of running Prepare/Execute/Commit/Delete
 // over each of the one or more parsed Dockerfiles and stages.
 func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (imageID string, ref reference.Canonical, err error) {
+	select {
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	default:
+	}
+
 	if len(stages) == 0 {
 		return "", nil, errors.New("building: no stages to build")
 	}
@@ -1120,22 +1137,25 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 	ch := make(chan Result, len(stages))
 
 	if b.stagesSemaphore == nil {
+		// The API caller didn't supply a semaphore to share among possibly-many builds,
+		// and our caller didn't, either, so the intention is that there's no limit on the
+		// number of concurrent builds (stages) that can be running.  Represent that with
+		// a semaphore that has enough weight to allow all stages to acquire it at the
+		// same time.
 		b.stagesSemaphore = semaphore.NewWeighted(int64(len(stages)))
 	}
 
 	var wg sync.WaitGroup
 	wg.Add(len(stages))
-
-	var commitResults buildah.CommitResults
+	ctx, cancel := context.WithCancelCause(ctx)
 	go func() {
-		cancel := false
 		for stageIndex := range stages {
 			index := stageIndex
 			// Acquire the semaphore before creating the goroutine so we are sure they
-			// run in the specified order.
+			// run in something resembling the original order if they're not all
+			// running concurrently.  This will fail immediately if the build has been
+			// canceled due to an error or a timeout.
 			if err := b.stagesSemaphore.Acquire(ctx, 1); err != nil {
-				cancel = true
-				b.lastError = err
 				ch <- Result{
 					Index: index,
 					Error: err,
@@ -1149,12 +1169,14 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			go func() {
 				defer b.stagesSemaphore.Release(1)
 				defer wg.Done()
-				if cancel || cleanupStages == nil {
+				// If the context was canceled already, we should stop here and
+				// prepare to clean up.
+				if ctx.Err() != nil {
 					var err error
 					if stages[index].Name != strconv.Itoa(index) {
-						err = fmt.Errorf("not building stage %d: build canceled", index)
+						err = fmt.Errorf("not building stage %d: build canceled: %w", index, context.Cause(ctx))
 					} else {
-						err = fmt.Errorf("not building stage %d (%s): build canceled", index, stages[index].Name)
+						err = fmt.Errorf("not building stage %d (%s): build canceled: %w", index, stages[index].Name, context.Cause(ctx))
 					}
 					ch <- Result{
 						Index: index,
@@ -1162,9 +1184,9 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 					}
 					return
 				}
-				// Skip stage if it is not needed by TargetStage
-				// or any of its dependency stages and `SkipUnusedStages`
-				// is not set to `false`.
+				// Skip this stage (just mark it as successfully completed) if it is
+				// not needed by TargetStage or any of its dependency stages and
+				// `SkipUnusedStages` is not set to `false`.
 				if stageDependencyInfo, ok := dependencyMap[stages[index].Name]; ok {
 					if !stageDependencyInfo.NeededByTarget && b.skipUnusedStages != types.OptionalBoolFalse {
 						logrus.Debugf("Skipping stage with name %q and index %d since it's not needed by the target stage", stages[index].Name, index)
@@ -1175,10 +1197,11 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 						return
 					}
 				}
-
+				// Build this stage.
 				stageID, stageResults, stageOnlyBaseImage, stageErr := b.buildStage(ctx, cleanupStages, stages, index, afterDependency)
 				if stageErr != nil {
-					cancel = true
+					// Bail out.
+					cancel(stageErr)
 					ch <- Result{
 						Index:         index,
 						Error:         stageErr,
@@ -1186,7 +1209,7 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 					}
 					return
 				}
-
+				// Note success and output info for this stage.
 				ch <- Result{
 					Index:         index,
 					ImageID:       stageID,
@@ -1201,7 +1224,9 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 		wg.Wait()
 		close(ch)
 	}()
+	defer cancel(nil)
 
+	var commitResults buildah.CommitResults
 	for r := range ch {
 		stage := stages[r.Index]
 
@@ -1210,8 +1235,7 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 
 		if r.Error != nil {
 			b.stagesLock.Unlock()
-			b.lastError = r.Error
-			return "", nil, r.Error
+			continue
 		}
 
 		// If this is an intermediate stage, make a note of the ID, so
@@ -1235,6 +1259,11 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 			ref = commitResults.Canonical
 		}
 		b.stagesLock.Unlock()
+	}
+	select {
+	case <-ctx.Done():
+		return "", nil, context.Cause(ctx)
+	default:
 	}
 
 	if len(b.unusedArgs) > 0 {

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -64,7 +64,7 @@ import (
 // If we're naming the result of the build, only the last stage will apply that
 // name to the image that it produces.
 type stageExecutor struct {
-	ctx                   context.Context
+	ctx                   context.Context // we need _some_ way to get this into our Copy() and Run() methods
 	systemContext         *types.SystemContext
 	executor              *executor
 	log                   func(format string, args ...any)
@@ -101,11 +101,16 @@ type stageExecutor struct {
 // made within the directory are ultimately discarded.
 func (s *stageExecutor) Preserve(path string) error {
 	logrus.Debugf("PRESERVE %q in %q (already preserving %v)", path, s.builder.ContainerID, s.volumes)
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	default:
+	}
 
 	// Try and resolve the symlink (if one exists)
 	// Set archivedPath and path based on whether a symlink is found or not
 	var archivedPath string
-	if evaluated, err := copier.Eval(s.mountPoint, filepath.Join(s.mountPoint, path), copier.EvalOptions{}); err == nil {
+	if evaluated, err := copier.EvalContext(s.ctx, s.mountPoint, filepath.Join(s.mountPoint, path), copier.EvalOptions{}); err == nil {
 		symLink, err := filepath.Rel(s.mountPoint, evaluated)
 		if err != nil {
 			return fmt.Errorf("making evaluated path %q relative to %q: %w", evaluated, s.mountPoint, err)
@@ -129,7 +134,7 @@ func (s *stageExecutor) Preserve(path string) error {
 		// invalidate such cached copy.
 		logrus.Debugf("have to create volume %q", path)
 		createdDirPerms := createdDirPerms
-		if err := copier.Mkdir(s.mountPoint, archivedPath, copier.MkdirOptions{ChmodNew: &createdDirPerms}); err != nil {
+		if err := copier.MkdirContext(s.ctx, s.mountPoint, archivedPath, copier.MkdirOptions{ChmodNew: &createdDirPerms}); err != nil {
 			return fmt.Errorf("ensuring volume path exists: %w", err)
 		}
 		if err := s.volumeCacheInvalidate(path); err != nil {
@@ -373,6 +378,11 @@ func joinExcludePatternWithCopySource(srcNorm, excl string) string {
 // Copy copies data into the working tree.  The "Download" field is how
 // imagebuilder tells us the instruction was "ADD" and not "COPY".
 func (s *stageExecutor) Copy(excludes []string, copies ...imagebuilder.Copy) error {
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	default:
+	}
 	for _, cp := range copies {
 		if cp.KeepGitDir {
 			if cp.Download {
@@ -634,7 +644,7 @@ func (s *stageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 		}
 
 		if len(nonGitSources) > 0 {
-			if err := s.builder.Add(copy.Dest, copy.Download, options, nonGitSources...); err != nil {
+			if err := s.builder.AddContext(s.ctx, copy.Dest, copy.Download, options, nonGitSources...); err != nil {
 				return err
 			}
 		}
@@ -644,7 +654,7 @@ func (s *stageExecutor) performCopy(excludes []string, copies ...imagebuilder.Co
 			gitOptions := options
 			gitOptions.Excludes = copyExcludesWithoutContainerIgnore
 			gitOptions.IgnoreFile = ""
-			if err := s.builder.Add(copy.Dest, copy.Download, gitOptions, gitSources...); err != nil {
+			if err := s.builder.AddContext(s.ctx, copy.Dest, copy.Download, gitOptions, gitSources...); err != nil {
 				return err
 			}
 		}
@@ -817,6 +827,11 @@ func parseSheBang(data string) string {
 // as a root directory.
 func (s *stageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 	logrus.Debugf("RUN %#v, %#v", run, config)
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	default:
+	}
 	args := run.Args
 	heredocMounts := []Mount{}
 	if len(run.Files) > 0 {
@@ -940,7 +955,7 @@ func (s *stageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 	if len(heredocMounts) > 0 {
 		options.Mounts = append(options.Mounts, heredocMounts...)
 	}
-	err = s.builder.Run(args, options)
+	err = s.builder.RunContext(s.ctx, args, options)
 
 	if s.executor.compatVolumes == types.OptionalBoolTrue {
 		// Only bother with saving/restoring the contents of volumes if
@@ -959,6 +974,11 @@ func (s *stageExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 // imagebuilder parser didn't understand.
 func (s *stageExecutor) UnrecognizedInstruction(step *imagebuilder.Step) error {
 	errStr := fmt.Sprintf("Build error: Unknown instruction: %q ", strings.ToUpper(step.Command))
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	default:
+	}
 	err := fmt.Sprintf(errStr+"%#v", step)
 	if s.executor.ignoreUnrecognizedInstructions {
 		logrus.Debug(err)
@@ -1004,6 +1024,12 @@ func (s *stageExecutor) sanitizeFrom(from, tmpdir string) (newFrom string, err e
 // isn't specified, the first argument passed to the first FROM instruction we
 // can find in the stage's parsed tree.
 func (s *stageExecutor) prepare(ctx context.Context, from string, initializeIBConfig, rebase, preserveBaseImageAnnotations bool, pullPolicy define.PullPolicy) (builder *buildah.Builder, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	stage := s.stage
 	ib := stage.Builder
 	node := stage.Node
@@ -1210,6 +1236,11 @@ func (s *stageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 		}
 		return nil, fmt.Errorf("mounting new container: %w", err)
 	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 	if rebase {
 		// Make this our "current" working container.
 		s.mountPoint = mountPoint
@@ -1252,6 +1283,12 @@ func (*stageExecutor) stepRequiresLayer(step *imagebuilder.Step) bool {
 // working container root filesystem based on the image, it creates one.  Then
 // it returns that root filesystem's location.
 func (s *stageExecutor) getImageRootfs(ctx context.Context, image string) (mountPoint string, err error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
 	if builder, ok := s.executor.containerMap[image]; ok {
 		return builder.MountPoint, nil
 	}
@@ -1281,6 +1318,12 @@ func (s *stageExecutor) getContentSummaryAfterAddingContent() string {
 
 // Execute runs each of the steps in the stage's parsed tree, in turn.
 func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string, commitResults *buildah.CommitResults, onlyBaseImg bool, err error) {
+	select {
+	case <-ctx.Done():
+		return "", nil, false, ctx.Err()
+	default:
+	}
+
 	var resourceUsage rusage.Rusage
 	stage := s.stage
 	ib := stage.Builder
@@ -1441,7 +1484,7 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 		// Generate build output from the new image, or the preexisting
 		// one if we didn't actually do anything, if needed.
 		for _, buildOutputOption := range buildOutputOptions {
-			if err := s.generateBuildOutput(buildOutputOption); err != nil {
+			if err := s.generateBuildOutput(ctx, buildOutputOption); err != nil {
 				return "", nil, onlyBaseImage, err
 			}
 		}
@@ -1565,6 +1608,11 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 				logrus.Debugf("Error building at step %+v: %v", *step, err)
 				return "", nil, false, fmt.Errorf("building at STEP \"%s\": %w", step.Message, err)
 			}
+			select {
+			case <-ctx.Done():
+				return "", nil, false, ctx.Err()
+			default:
+			}
 			// In case we added content, retrieve its digest.
 			addedContentSummary := s.getContentSummaryAfterAddingContent()
 			if moreInstructions {
@@ -1607,7 +1655,7 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 				logImageID(imgID)
 				// Generate build output if needed.
 				for _, buildOutputOption := range buildOutputOptions {
-					if err := s.generateBuildOutput(buildOutputOption); err != nil {
+					if err := s.generateBuildOutput(ctx, buildOutputOption); err != nil {
 						return "", nil, false, err
 					}
 				}
@@ -1616,6 +1664,12 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 				commitResults = &buildah.CommitResults{}
 			}
 			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", nil, false, ctx.Err()
+		default:
 		}
 
 		// We're in a multi-layered build.
@@ -1847,7 +1901,7 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 			}
 			// Generate build output if needed.
 			for _, buildOutputOption := range buildOutputOptions {
-				if err := s.generateBuildOutput(buildOutputOption); err != nil {
+				if err := s.generateBuildOutput(ctx, buildOutputOption); err != nil {
 					return "", nil, false, err
 				}
 			}
@@ -1888,7 +1942,7 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 				}
 				// Generate build output if needed.
 				for _, buildOutputOption := range buildOutputOptions {
-					if err := s.generateBuildOutput(buildOutputOption); err != nil {
+					if err := s.generateBuildOutput(ctx, buildOutputOption); err != nil {
 						return "", nil, false, err
 					}
 				}
@@ -1903,7 +1957,7 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 				// for us to perform `commit` anywhere in the code.
 				// Generate build output if needed.
 				for _, buildOutputOption := range buildOutputOptions {
-					if err := s.generateBuildOutput(buildOutputOption); err != nil {
+					if err := s.generateBuildOutput(ctx, buildOutputOption); err != nil {
 						return "", nil, false, err
 					}
 				}
@@ -2224,6 +2278,12 @@ func (s *stageExecutor) getBuildArgsKey() string {
 
 // tagExistingImage adds names to an image already in the store
 func (s *stageExecutor) tagExistingImage(ctx context.Context, cacheID, output string) (string, *buildah.CommitResults, error) {
+	select {
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	default:
+	}
+
 	var manifestBytes []byte
 	var manifestType string
 	var ref reference.Canonical
@@ -2333,6 +2393,12 @@ func (s *stageExecutor) tagExistingImage(ctx context.Context, cacheID, output st
 // tag for the intermediate image which can be pushed and pulled to/from
 // the remote repository.
 func (s *stageExecutor) generateCacheKey(ctx context.Context, currNode *parser.Node, addedContentDigest string, buildAddsLayer bool, lastInstruction bool) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
 	hash := sha256.New()
 	var baseHistory []v1.History
 	var diffIDs []digest.Digest
@@ -2387,6 +2453,12 @@ func cacheImageReferences(repos []reference.Named, cachekey string) ([]types.Ima
 // to perform push at the remote repository with cacheKey as the tag.
 // Returns error if fails otherwise returns nil.
 func (s *stageExecutor) pushCache(ctx context.Context, src, cacheKey string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	destList, err := cacheImageReferences(s.executor.cacheTo, cacheKey)
 	if err != nil {
 		return err
@@ -2428,6 +2500,12 @@ func (s *stageExecutor) pushCache(ctx context.Context, src, cacheKey string) err
 // image was pulled function returns image id otherwise returns empty
 // string "" or error if any error was encontered while pulling the cache.
 func (s *stageExecutor) pullCache(ctx context.Context, cacheKey string) (reference.Named, string, error) {
+	select {
+	case <-ctx.Done():
+		return nil, "", ctx.Err()
+	default:
+	}
+
 	srcList, err := cacheImageReferences(s.executor.cacheFrom, cacheKey)
 	if err != nil {
 		return nil, "", err
@@ -2469,6 +2547,12 @@ func (s *stageExecutor) pullCache(ctx context.Context, cacheKey string) (referen
 // It verifies this by checking the parent of the top layer of the image and the history.
 // If more than one image matches as potential candidates then priority is given to the most recently built image.
 func (s *stageExecutor) intermediateImageExists(ctx context.Context, currNode *parser.Node, addedContentDigest string, buildAddsLayer bool, lastInstruction bool) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
 	cacheCandidates := []storage.Image{}
 	// Get the list of images available in the image store
 	images, err := s.executor.store.Images()
@@ -2584,6 +2668,12 @@ func (s *stageExecutor) intermediateImageExists(ctx context.Context, currNode *p
 // the name if there is one, generating a unique ID-based one otherwise.
 // or commit via any custom exporter if specified.
 func (s *stageExecutor) commit(ctx context.Context, createdBy string, emptyLayer types.OptionalBool, output string, squash, finalInstruction bool) (string, *buildah.CommitResults, error) {
+	select {
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	default:
+	}
+
 	ib := s.stage.Builder
 	var imageRef types.ImageReference
 	if output != "" {
@@ -2754,7 +2844,7 @@ func (s *stageExecutor) commit(ctx context.Context, createdBy string, emptyLayer
 	return results.ImageID, results, nil
 }
 
-func (s *stageExecutor) generateBuildOutput(buildOutputOpts output.BuildOutputOption) error {
+func (s *stageExecutor) generateBuildOutput(ctx context.Context, buildOutputOpts output.BuildOutputOption) error {
 	forceTimestamp := s.executor.timestamp
 	if s.executor.sourceDateEpoch != nil {
 		forceTimestamp = s.executor.sourceDateEpoch
@@ -2775,7 +2865,7 @@ func (s *stageExecutor) generateBuildOutput(buildOutputOpts output.BuildOutputOp
 		extractRootfsOpts.StripSetgidBit = true
 		extractRootfsOpts.StripXattrs = true
 	}
-	rc, errChan, err := s.builder.ExtractRootfs(buildah.CommitOptions{
+	rc, errChan, err := s.builder.ExtractRootfsContext(ctx, buildah.CommitOptions{
 		HistoryTimestamp:     s.executor.timestamp,
 		SourceDateEpoch:      s.executor.sourceDateEpoch,
 		RewriteTimestamp:     s.executor.rewriteTimestamp,
@@ -2800,11 +2890,21 @@ func (s *stageExecutor) generateBuildOutput(buildOutputOpts output.BuildOutputOp
 
 func (s *stageExecutor) EnsureContainerPath(path string) error {
 	logrus.Debugf("EnsureContainerPath %q in %q", path, s.builder.ContainerID)
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	default:
+	}
 	return s.builder.EnsureContainerPathAs(path, "", nil)
 }
 
 func (s *stageExecutor) EnsureContainerPathAs(path, user string, mode *os.FileMode) error {
 	logrus.Debugf("EnsureContainerPath %q (owner %q, mode %o) in %q", path, user, mode, s.builder.ContainerID)
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	default:
+	}
 	return s.builder.EnsureContainerPathAs(path, user, mode)
 }
 

--- a/import.go
+++ b/import.go
@@ -18,6 +18,12 @@ import (
 )
 
 func importBuilderDataFromImage(ctx context.Context, store storage.Store, systemContext *types.SystemContext, imageID, containerName, containerID string) (*Builder, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	if imageID == "" {
 		return nil, errors.New("internal error: imageID is empty in importBuilderDataFromImage")
 	}
@@ -120,6 +126,12 @@ func importBuilderDataFromImage(ctx context.Context, store storage.Store, system
 }
 
 func importBuilder(ctx context.Context, store storage.Store, options ImportOptions) (*Builder, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	if options.Container == "" {
 		return nil, errors.New("container name must be specified")
 	}
@@ -157,6 +169,12 @@ func importBuilder(ctx context.Context, store storage.Store, options ImportOptio
 }
 
 func importBuilderFromImage(ctx context.Context, store storage.Store, options ImportFromImageOptions) (*Builder, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	if options.Image == "" {
 		return nil, errors.New("image name must be specified")
 	}

--- a/internal/ctxreader/ctxreader.go
+++ b/internal/ctxreader/ctxreader.go
@@ -1,0 +1,30 @@
+package ctxreader
+
+import (
+	"context"
+	"io"
+)
+
+type cancelableReader struct {
+	ctx context.Context
+	io.Reader
+}
+
+func (c *cancelableReader) Read(p []byte) (n int, err error) {
+	// this will only even kind of work because we're using it in situations where we don't
+	// expect to block while waiting for more data - we're either reading from a file, or from
+	// a pipe where the writer is sending us data as fast as it can manage
+	select {
+	case <-c.ctx.Done():
+		return 0, c.ctx.Err()
+	default:
+	}
+	return c.Reader.Read(p)
+}
+
+func NewCancelableReader(ctx context.Context, r io.Reader) io.Reader {
+	return &cancelableReader{
+		ctx:    ctx,
+		Reader: r,
+	}
+}

--- a/internal/ctxreader/ctxreader_test.go
+++ b/internal/ctxreader/ctxreader_test.go
@@ -1,0 +1,22 @@
+package ctxreader
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCancelableReader(t *testing.T) {
+	var b bytes.Buffer
+	for range 1024 {
+		b.Write(make([]byte, 1024))
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+	cancel()
+	_, err := io.Copy(io.Discard, NewCancelableReader(ctx, &b))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/internal/mkcw/archive.go
+++ b/internal/mkcw/archive.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -22,6 +23,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	"go.podman.io/buildah/internal/ctxreader"
 	"go.podman.io/buildah/internal/tmpdir"
 	"go.podman.io/buildah/pkg/overlay"
 	"go.podman.io/storage/pkg/idtools"
@@ -75,7 +77,13 @@ func (c chainRetrievalError) Unwrap() error {
 
 // Archive generates a WorkloadConfig for a specified directory and produces a
 // tar archive of a container image's rootfs with the expected contents.
-func Archive(rootfsPath string, ociConfig *v1.Image, options ArchiveOptions) (io.ReadCloser, WorkloadConfig, error) {
+func Archive(ctx context.Context, rootfsPath string, ociConfig *v1.Image, options ArchiveOptions) (io.ReadCloser, WorkloadConfig, error) {
+	select {
+	case <-ctx.Done():
+		return nil, WorkloadConfig{}, ctx.Err()
+	default:
+	}
+
 	const (
 		teeDefaultCPUs       = 2
 		teeDefaultMemory     = 512
@@ -140,7 +148,7 @@ func Archive(rootfsPath string, ociConfig *v1.Image, options ArchiveOptions) (io
 			}
 		}()
 		logrus.Debugf("sevctl export -f %s", chain.Name())
-		cmd := exec.Command("sevctl", "export", "-f", chain.Name())
+		cmd := exec.CommandContext(ctx, "sevctl", "export", "-f", chain.Name())
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout, cmd.Stderr = &stdout, &stderr
 		if err := cmd.Run(); err != nil {
@@ -264,7 +272,7 @@ func Archive(rootfsPath string, ociConfig *v1.Image, options ArchiveOptions) (io
 				return err
 			}
 			defer input.Close()
-			if _, err := io.Copy(output, input); err != nil {
+			if _, err := io.Copy(output, ctxreader.NewCancelableReader(ctx, input)); err != nil {
 				return fmt.Errorf("copying contents of %q to %q in container root filesystem: %w", content, location, err)
 			}
 			if err := output.Chown(int(st.UID()), int(st.GID())); err != nil {
@@ -371,7 +379,7 @@ func Archive(rootfsPath string, ociConfig *v1.Image, options ArchiveOptions) (io
 	}
 
 	// Format the disk image with the filesystem contents.
-	if _, stderr, err := MakeFS(rootfsPath, plain.Name(), filesystem); err != nil {
+	if _, stderr, err := MakeFS(ctx, rootfsPath, plain.Name(), filesystem); err != nil {
 		if strings.TrimSpace(stderr) != "" {
 			return nil, WorkloadConfig{}, fmt.Errorf("%s: %w", strings.TrimSpace(stderr), err)
 		}
@@ -380,7 +388,7 @@ func Archive(rootfsPath string, ociConfig *v1.Image, options ArchiveOptions) (io
 
 	// If we're registering the workload, we can do that now.
 	if workloadConfig.AttestationURL != "" {
-		if err := SendRegistrationRequest(workloadConfig, diskEncryptionPassphrase, options.FirmwareLibrary, options.IgnoreAttestationErrors, logger); err != nil {
+		if err := SendRegistrationRequest(ctx, workloadConfig, diskEncryptionPassphrase, options.FirmwareLibrary, options.IgnoreAttestationErrors, logger); err != nil {
 			return nil, WorkloadConfig{}, err
 		}
 	}
@@ -524,7 +532,7 @@ func Archive(rootfsPath string, ociConfig *v1.Image, options ArchiveOptions) (io
 			return
 		}
 		encryptWrapper := luksy.EncryptWriter(encrypt, tw, blockSize)
-		if _, err = io.Copy(encryptWrapper, plain); err != nil {
+		if _, err = io.Copy(encryptWrapper, ctxreader.NewCancelableReader(ctx, plain)); err != nil {
 			logrus.Errorf("encrypting disk.img: %v", err)
 			return
 		}

--- a/internal/mkcw/archive_test.go
+++ b/internal/mkcw/archive_test.go
@@ -131,7 +131,7 @@ func TestArchive(t *testing.T) {
 								IgnoreAttestationErrors: requestIgnoreAttestationErrors,
 							}
 							inputPath := t.TempDir()
-							rc, workloadConfig, err := Archive(inputPath, ociConfig, archiveOptions)
+							rc, workloadConfig, err := Archive(t.Context(), inputPath, ociConfig, archiveOptions)
 							// bail now if we got an error we didn't expect
 							if errors.As(err, &chainRetrievalError{}) {
 								if !ignoreChainRetrievalErrors {

--- a/internal/mkcw/attest.go
+++ b/internal/mkcw/attest.go
@@ -3,6 +3,7 @@ package mkcw
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,13 +64,19 @@ func (h httpError) Error() string {
 
 // SendRegistrationRequest registers a workload with the specified decryption
 // passphrase with the service whose location is part of the WorkloadConfig.
-func SendRegistrationRequest(workloadConfig WorkloadConfig, diskEncryptionPassphrase, firmwareLibrary string, ignoreAttestationErrors bool, logger *logrus.Logger) error {
+func SendRegistrationRequest(ctx context.Context, workloadConfig WorkloadConfig, diskEncryptionPassphrase, firmwareLibrary string, ignoreAttestationErrors bool, logger *logrus.Logger) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if workloadConfig.AttestationURL == "" {
 		return errors.New("attestation URL not provided")
 	}
 
 	// Measure the execution environment.
-	measurement, err := GenerateMeasurement(workloadConfig, firmwareLibrary)
+	measurement, err := GenerateMeasurement(ctx, workloadConfig, firmwareLibrary)
 	if err != nil {
 		if !ignoreAttestationErrors {
 			return measurementError{err}
@@ -142,7 +149,12 @@ func SendRegistrationRequest(workloadConfig WorkloadConfig, diskEncryptionPassph
 	requestContentType := "application/json"
 	requestBody := bytes.NewReader(registrationRequestBytes)
 	defer http.DefaultClient.CloseIdleConnections()
-	resp, err := http.Post(url, requestContentType, requestBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, requestBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", requestContentType)
+	resp, err := http.DefaultClient.Do(req)
 	if resp != nil {
 		if resp.Body != nil {
 			resp.Body.Close()
@@ -174,7 +186,13 @@ func SendRegistrationRequest(workloadConfig WorkloadConfig, diskEncryptionPassph
 // of directories.
 // If firmwareLibrary is empty, both the filename and the directory it is in
 // will be taken from a hard-coded set of candidates.
-func GenerateMeasurement(workloadConfig WorkloadConfig, firmwareLibrary string) (string, error) {
+func GenerateMeasurement(ctx context.Context, workloadConfig WorkloadConfig, firmwareLibrary string) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
 	cpuString := fmt.Sprintf("%d", workloadConfig.CPUs)
 	memoryString := fmt.Sprintf("%d", workloadConfig.Memory)
 	var prefix string
@@ -232,7 +250,7 @@ func GenerateMeasurement(workloadConfig WorkloadConfig, firmwareLibrary string) 
 		if err := fileutils.Lexists(candidate); err == nil {
 			var stdout, stderr bytes.Buffer
 			logrus.Debugf("krunfw_measurement -c %s -m %s %s", cpuString, memoryString, candidate)
-			cmd := exec.Command("krunfw_measurement", "-c", cpuString, "-m", memoryString, candidate)
+			cmd := exec.CommandContext(ctx, "krunfw_measurement", "-c", cpuString, "-m", memoryString, candidate)
 			cmd.Stdout = &stdout
 			cmd.Stderr = &stderr
 			if err := cmd.Run(); err != nil {

--- a/internal/mkcw/makefs.go
+++ b/internal/mkcw/makefs.go
@@ -1,6 +1,7 @@
 package mkcw
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -13,19 +14,25 @@ import (
 // Recognized filesystem types are "btrfs", "ext2", "ext3", "ext4", and "xfs".
 // Note that krun's init is currently hard-wired to assume "ext4".
 // Returns the stdout, stderr, and any error returned by the mkfs command.
-func MakeFS(sourcePath, imageFile, filesystem string) (string, string, error) {
+func MakeFS(ctx context.Context, sourcePath, imageFile, filesystem string) (string, string, error) {
+	select {
+	case <-ctx.Done():
+		return "", "", ctx.Err()
+	default:
+	}
+
 	var stdout, stderr strings.Builder
 	switch filesystem {
 	case "ext2", "ext3", "ext4":
 		logrus.Debugf("mkfs -t %s --rootdir %q %q", filesystem, sourcePath, imageFile)
-		cmd := exec.Command("mkfs", "-t", filesystem, "-d", sourcePath, imageFile)
+		cmd := exec.CommandContext(ctx, "mkfs", "-t", filesystem, "-d", sourcePath, imageFile)
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 		err := cmd.Run()
 		return stdout.String(), stderr.String(), err
 	case "btrfs":
 		logrus.Debugf("mkfs -t %s --rootdir %q %q", filesystem, sourcePath, imageFile)
-		cmd := exec.Command("mkfs", "-t", filesystem, "--rootdir", sourcePath, imageFile)
+		cmd := exec.CommandContext(ctx, "mkfs", "-t", filesystem, "--rootdir", sourcePath, imageFile)
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 		err := cmd.Run()
@@ -35,7 +42,7 @@ func MakeFS(sourcePath, imageFile, filesystem string) (string, string, error) {
 		// available in xfsprogs-6.17.0 or later; before that, it only accepts prototype
 		// files
 		logrus.Debugf("mkfs -t %s -p %q %q", filesystem, sourcePath, imageFile)
-		cmd := exec.Command("mkfs", "-t", filesystem, "-p", sourcePath, imageFile)
+		cmd := exec.CommandContext(ctx, "mkfs", "-t", filesystem, "-p", sourcePath, imageFile)
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 		err := cmd.Run()

--- a/internal/mkcw/makefs.go
+++ b/internal/mkcw/makefs.go
@@ -10,14 +10,11 @@ import (
 
 // MakeFS formats the imageFile as a filesystem of the specified type,
 // populating it with the contents of the directory at sourcePath.
-// Recognized filesystem types are "ext2", "ext3", "ext4", and "btrfs".
+// Recognized filesystem types are "btrfs", "ext2", "ext3", "ext4", and "xfs".
 // Note that krun's init is currently hard-wired to assume "ext4".
 // Returns the stdout, stderr, and any error returned by the mkfs command.
 func MakeFS(sourcePath, imageFile, filesystem string) (string, string, error) {
 	var stdout, stderr strings.Builder
-	// N.B. mkfs.xfs can accept a protofile via its -p option, but the
-	// protofile format doesn't allow us to supply timestamp information or
-	// specify that files are hard linked
 	switch filesystem {
 	case "ext2", "ext3", "ext4":
 		logrus.Debugf("mkfs -t %s --rootdir %q %q", filesystem, sourcePath, imageFile)
@@ -29,6 +26,16 @@ func MakeFS(sourcePath, imageFile, filesystem string) (string, string, error) {
 	case "btrfs":
 		logrus.Debugf("mkfs -t %s --rootdir %q %q", filesystem, sourcePath, imageFile)
 		cmd := exec.Command("mkfs", "-t", filesystem, "--rootdir", sourcePath, imageFile)
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		return stdout.String(), stderr.String(), err
+	case "xfs":
+		// N.B. -p treating directories as source for the filesystem contents only
+		// available in xfsprogs-6.17.0 or later; before that, it only accepts prototype
+		// files
+		logrus.Debugf("mkfs -t %s -p %q %q", filesystem, sourcePath, imageFile)
+		cmd := exec.Command("mkfs", "-t", filesystem, "-p", sourcePath, imageFile)
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 		err := cmd.Run()

--- a/internal/source/add.go
+++ b/internal/source/add.go
@@ -44,6 +44,12 @@ func (o *AddOptions) annotations() (map[string]string, error) {
 // at `sourcePath`.  Note that the artifact will be added as a gzip-compressed
 // tar ball.  Add attempts to auto-tar and auto-compress only if necessary.
 func Add(ctx context.Context, sourcePath string, artifactPath string, options AddOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	// Let's first make sure `sourcePath` exists and that we can access it.
 	if err := fileutils.Exists(sourcePath); err != nil {
 		return err

--- a/internal/source/create.go
+++ b/internal/source/create.go
@@ -32,6 +32,12 @@ func (o *CreateOptions) createdTime() *time.Time {
 // Create creates an empty source image at the specified `sourcePath`.  Note
 // that `sourcePath` must not exist.
 func Create(ctx context.Context, sourcePath string, options CreateOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if err := fileutils.Exists(sourcePath); err == nil {
 		return fmt.Errorf("creating source image: %q already exists", sourcePath)
 	}

--- a/internal/source/pull.go
+++ b/internal/source/pull.go
@@ -28,6 +28,12 @@ type PullOptions struct {
 
 // Pull `imageInput` from a container registry to `sourcePath`.
 func Pull(ctx context.Context, imageInput string, sourcePath string, options PullOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if err := fileutils.Exists(sourcePath); err == nil {
 		return fmt.Errorf("%q already exists", sourcePath)
 	}
@@ -92,6 +98,12 @@ func stringToImageReference(imageInput string) (types.ImageReference, error) {
 }
 
 func validateSourceImageReference(ctx context.Context, ref types.ImageReference, sysCtx *types.SystemContext) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	src, err := ref.NewImageSource(ctx, sysCtx)
 	if err != nil {
 		return fmt.Errorf("creating image source from reference: %w", err)

--- a/internal/source/push.go
+++ b/internal/source/push.go
@@ -29,6 +29,12 @@ type PushOptions struct {
 // Push the source image at `sourcePath` to `imageInput` at a container
 // registry.
 func Push(ctx context.Context, sourcePath string, imageInput string, options PushOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	srcRef, err := layout.ParseReference(sourcePath)
 	if err != nil {
 		return err

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -32,6 +32,12 @@ type ImageConfig struct {
 // writeManifest writes the specified OCI `manifest` to the source image at
 // `ociDest`.
 func writeManifest(ctx context.Context, manifest *specV1.Manifest, ociDest types.ImageDestination) (*digest.Digest, int64, error) {
+	select {
+	case <-ctx.Done():
+		return nil, -1, ctx.Err()
+	default:
+	}
+
 	rawData, err := json.Marshal(&manifest)
 	if err != nil {
 		return nil, -1, fmt.Errorf("marshalling manifest: %w", err)
@@ -48,6 +54,12 @@ func writeManifest(ctx context.Context, manifest *specV1.Manifest, ociDest types
 // readManifestFromImageSource reads the manifest from the specified image
 // source.  Note that the manifest is expected to be an OCI v1 manifest.
 func readManifestFromImageSource(ctx context.Context, src types.ImageSource) (*specV1.Manifest, *digest.Digest, int64, error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, -1, ctx.Err()
+	default:
+	}
+
 	rawData, mimeType, err := image.UnparsedInstance(src, nil).Manifest(ctx)
 	if err != nil {
 		return nil, nil, -1, err
@@ -69,6 +81,12 @@ func readManifestFromImageSource(ctx context.Context, src types.ImageSource) (*s
 // at `sourcePath` along with its digest.  The digest can later on be used to
 // locate the manifest on the file system.
 func readManifestFromOCIPath(ctx context.Context, sourcePath string) (*specV1.Manifest, *digest.Digest, int64, error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, -1, ctx.Err()
+	default:
+	}
+
 	ociRef, err := layout.ParseReference(sourcePath)
 	if err != nil {
 		return nil, nil, -1, err
@@ -87,6 +105,12 @@ func readManifestFromOCIPath(ctx context.Context, sourcePath string) (*specV1.Ma
 // specified `sourcePath`.  Note that if the path doesn't exist, it'll be
 // created along with the OCI directory layout.
 func openOrCreateSourceImage(ctx context.Context, sourcePath string) (types.ImageDestination, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	ociRef, err := layout.ParseReference(sourcePath)
 	if err != nil {
 		return nil, err
@@ -99,6 +123,12 @@ func openOrCreateSourceImage(ctx context.Context, sourcePath string) (types.Imag
 // addConfig adds `config` to `ociDest` and returns the corresponding blob
 // info.
 func addConfig(ctx context.Context, config *ImageConfig, ociDest types.ImageDestination) (*types.BlobInfo, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	rawData, err := json.Marshal(config)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling config: %w", err)

--- a/new.go
+++ b/new.go
@@ -117,6 +117,12 @@ func findUnusedContainer(name string, containers []storage.Container) string {
 }
 
 func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions) (*Builder, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	var (
 		ref types.ImageReference
 		img *storage.Image
@@ -217,6 +223,11 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 			return nil, fmt.Errorf("instantiating image for %q instance %q: %w", transports.ImageName(ref), instanceDigest, err)
 		}
 	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 
 	name := "working-container"
 	if options.ContainerSuffix != "" {
@@ -276,6 +287,11 @@ func newBuilder(ctx context.Context, store storage.Store, options BuilderOptions
 			}
 		}
 	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 
 	uidmap, gidmap := convertStorageIDMaps(container.UIDMap, container.GIDMap)
 

--- a/pkg/rusage/rusage_test.go
+++ b/pkg/rusage/rusage_test.go
@@ -39,7 +39,7 @@ func TestRusage(t *testing.T) {
 	}
 	before, err := Get()
 	require.Nil(t, err, "unexpected error from GetRusage before running child: %v", err)
-	cmd := reexec.Command(noopCommand)
+	cmd := reexec.CommandContext(t.Context(), noopCommand)
 	err = cmd.Run()
 	require.Nil(t, err, "unexpected error running child process: %v", err)
 	after, err := Get()

--- a/pull.go
+++ b/pull.go
@@ -62,7 +62,13 @@ type PullOptions struct {
 
 // Pull copies the contents of the image from somewhere else to local storage.  Returns the
 // ID of the local image or an error.
-func Pull(_ context.Context, imageName string, options PullOptions) (imageID string, err error) {
+func Pull(ctx context.Context, imageName string, options PullOptions) (imageID string, err error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
 	libimageOptions := &libimage.PullOptions{}
 	libimageOptions.SignaturePolicyPath = options.SignaturePolicyPath
 	libimageOptions.Writer = options.ReportWriter
@@ -92,7 +98,7 @@ func Pull(_ context.Context, imageName string, options PullOptions) (imageID str
 		return "", err
 	}
 
-	pulledImages, err := runtime.Pull(context.Background(), imageName, pullPolicy, libimageOptions)
+	pulledImages, err := runtime.Pull(ctx, imageName, pullPolicy, libimageOptions)
 	if err != nil {
 		return "", err
 	}

--- a/push.go
+++ b/push.go
@@ -111,6 +111,12 @@ type PushOptions struct {
 
 // Push copies the contents of the image to a new location.
 func Push(ctx context.Context, image string, dest types.ImageReference, options PushOptions) (reference.Canonical, digest.Digest, error) {
+	select {
+	case <-ctx.Done():
+		return nil, "", ctx.Err()
+	default:
+	}
+
 	libimageOptions := &libimage.PushOptions{}
 	libimageOptions.SignaturePolicyPath = options.SignaturePolicyPath
 	libimageOptions.Writer = options.ReportWriter

--- a/run.go
+++ b/run.go
@@ -1,6 +1,7 @@
 package buildah
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -246,4 +247,11 @@ type netResult struct {
 	ipv6                              bool
 	keepHostResolvers                 bool
 	preferredHostContainersInternalIP string
+}
+
+// Run() calls RunContext() with context.TODO().
+//
+//go:fix inline
+func (b *Builder) Run(command []string, options RunOptions) error {
+	return b.RunContext(context.TODO(), command, options)
 }

--- a/run_common.go
+++ b/run_common.go
@@ -5,6 +5,7 @@ package buildah
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -430,9 +431,13 @@ func waitForSync(pipeR *os.File) error {
 	return err
 }
 
-func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs []string, spec *specs.Spec, bundlePath, containerName string,
-	containerCreateW io.WriteCloser, containerStartR io.ReadCloser,
-) (wstatus unix.WaitStatus, err error) {
+func runUsingRuntime(ctx context.Context, options RunOptions, configureNetwork bool, moreCreateArgs []string, spec *specs.Spec, bundlePath, containerName string, containerCreateW io.WriteCloser, containerStartR io.ReadCloser) (wstatus unix.WaitStatus, err error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
 	if options.Logger == nil {
 		options.Logger = logrus.StandardLogger()
 	}
@@ -661,7 +666,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, moreCreateArgs [
 		now := time.Now()
 		var state specs.State
 		args = append(options.Args, "state", containerName)
-		stat := exec.Command(runtime, args...)
+		stat := exec.CommandContext(ctx, runtime, args...)
 		stat.Dir = bundlePath
 		stat.Stderr = os.Stderr
 		stateOutput, err := stat.Output()
@@ -1123,7 +1128,7 @@ func runUsingRuntimeMain() {
 	}
 
 	// Run the container, start to finish.
-	status, err := runUsingRuntime(options.Options, options.ConfigureNetwork, options.MoreCreateArgs, ospec, options.BundlePath, options.ContainerName, containerCreateW, containerStartR)
+	status, err := runUsingRuntime(context.Background(), options.Options, options.ConfigureNetwork, options.MoreCreateArgs, ospec, options.BundlePath, options.ContainerName, containerCreateW, containerStartR)
 	reapStrays()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error running container: %v\n", err)
@@ -1139,9 +1144,13 @@ func runUsingRuntimeMain() {
 	os.Exit(1)
 }
 
-func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options RunOptions, configureNetwork bool, networkString string,
-	moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile, resolvFile string,
-) (err error) {
+func (b *Builder) runUsingRuntimeSubproc(ctx context.Context, isolation define.Isolation, options RunOptions, configureNetwork bool, networkString string, moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName, buildContainerName, hostsFile, resolvFile string) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	// Decide which runtime to use in case it was empty.
 	ociRuntime := options.Runtime
 	if ociRuntime == "" {
@@ -1171,7 +1180,7 @@ func (b *Builder) runUsingRuntimeSubproc(isolation define.Isolation, options Run
 	if conferr != nil {
 		return fmt.Errorf("encoding configuration for %q: %w", runUsingRuntimeCommand, conferr)
 	}
-	cmd := reexec.Command(runUsingRuntimeCommand)
+	cmd := reexec.CommandContext(ctx, runUsingRuntimeCommand)
 	setPdeathsig(cmd)
 	cmd.Dir = bundlePath
 	cmd.Stdin = options.Stdin
@@ -1319,7 +1328,13 @@ func init() {
 // If this succeeds, after the command which uses the spec finishes running,
 // the caller must call b.cleanupRunMounts() on the returned runMountArtifacts
 // structure.
-func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath string, optionMounts []specs.Mount, bindFiles map[string]string, builtinVolumes []string, compatBuiltinVolumes types.OptionalBool, volumeMounts []string, runFileMounts []string, runMountInfo runMountInfo) (*runMountArtifacts, error) {
+func (b *Builder) setupMounts(ctx context.Context, mountPoint string, spec *specs.Spec, bundlePath string, optionMounts []specs.Mount, bindFiles map[string]string, builtinVolumes []string, compatBuiltinVolumes types.OptionalBool, volumeMounts []string, runFileMounts []string, runMountInfo runMountInfo) (*runMountArtifacts, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// Start building a new list of mounts.
 	var mounts []specs.Mount
 	haveMount := func(destination string) bool {
@@ -1391,7 +1406,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 	}()
 	// Add temporary copies of the contents of volume locations at the
 	// volume locations, unless we already have something there.
-	builtins, err := runSetupBuiltinVolumes(b.MountLabel, mountPoint, cdir, builtinVolumes, compatBuiltinVolumes, int(rootUID), int(rootGID))
+	builtins, err := runSetupBuiltinVolumes(ctx, b.MountLabel, mountPoint, cdir, builtinVolumes, compatBuiltinVolumes, int(rootUID), int(rootGID))
 	if err != nil {
 		return nil, err
 	}
@@ -1428,7 +1443,13 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 	return mountArtifacts, nil
 }
 
-func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtinVolumes []string, compatBuiltinVolumes types.OptionalBool, rootUID, rootGID int) ([]specs.Mount, error) {
+func runSetupBuiltinVolumes(ctx context.Context, mountLabel, mountPoint, containerDir string, builtinVolumes []string, compatBuiltinVolumes types.OptionalBool, rootUID, rootGID int) ([]specs.Mount, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	var mounts []specs.Mount
 	hostOwner := idtools.IDPair{UID: rootUID, GID: rootGID}
 	// Add temporary copies of the contents of volume locations at the
@@ -1436,7 +1457,7 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 	for _, volume := range builtinVolumes {
 		// Make sure the volume exists in the rootfs.
 		createDirPerms := os.FileMode(0o755)
-		err := copier.Mkdir(mountPoint, filepath.Join(mountPoint, volume), copier.MkdirOptions{
+		err := copier.MkdirContext(ctx, mountPoint, filepath.Join(mountPoint, volume), copier.MkdirOptions{
 			ChownNew: &hostOwner,
 			ChmodNew: &createDirPerms,
 		})
@@ -1467,7 +1488,7 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 			initializeVolume = true
 		}
 		// Read the attributes of the volume's location in the rootfs.
-		srcPath, err := copier.Eval(mountPoint, filepath.Join(mountPoint, volume), copier.EvalOptions{})
+		srcPath, err := copier.EvalContext(ctx, mountPoint, filepath.Join(mountPoint, volume), copier.EvalOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("evaluating path %q: %w", srcPath, err)
 		}
@@ -1485,7 +1506,7 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, builtin
 				return nil, err
 			}
 			logrus.Debugf("populating directory %q for volume %q using contents of %q", volumePath, volume, srcPath)
-			if err = extractWithTar(mountPoint, srcPath, volumePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			if err = extractWithTar(ctx, mountPoint, srcPath, volumePath); err != nil && !errors.Is(err, os.ErrNotExist) {
 				return nil, fmt.Errorf("populating directory %q for volume %q using contents of %q: %w", volumePath, volume, srcPath, err)
 			}
 		}
@@ -2077,7 +2098,13 @@ func mapContainerNameToHostname(containerName string) string {
 
 // createMountTargets creates empty files or directories that are used as
 // targets for mounts in the spec, and makes a note of what it created.
-func (b *Builder) createMountTargets(spec *specs.Spec) ([]copier.ConditionalRemovePath, error) {
+func (b *Builder) createMountTargets(ctx context.Context, spec *specs.Spec) ([]copier.ConditionalRemovePath, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// Avoid anything weird happening, just in case.
 	if spec == nil || spec.Root == nil {
 		return nil, nil
@@ -2168,7 +2195,7 @@ func (b *Builder) createMountTargets(spec *specs.Spec) ([]copier.ConditionalRemo
 	if len(targets.Paths) == 0 {
 		return nil, nil
 	}
-	created, noted, err := copier.Ensure(rootfsPath, rootfsPath, targets)
+	created, noted, err := copier.EnsureContext(ctx, rootfsPath, rootfsPath, targets)
 	if err != nil {
 		return nil, err
 	}

--- a/run_common_test.go
+++ b/run_common_test.go
@@ -34,7 +34,7 @@ func TestMapContainerNameToHostname(t *testing.T) {
 }
 
 func TestCheckExitCodeError(t *testing.T) {
-	exitErr := exec.Command("false").Run()
+	exitErr := exec.CommandContext(t.Context(), "false").Run()
 	require.Error(t, exitErr)
 	var ee *exec.ExitError
 	require.True(t, errors.As(exitErr, &ee))

--- a/run_freebsd.go
+++ b/run_freebsd.go
@@ -3,6 +3,7 @@
 package buildah
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -63,7 +64,14 @@ func setChildProcess() error {
 	return nil
 }
 
-func (b *Builder) Run(command []string, options RunOptions) error {
+// RunContext runs the specified command in the container's root filesystem.
+func (b *Builder) RunContext(ctx context.Context, command []string, options RunOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	var runArtifacts *runMountArtifacts
 	if len(options.ExternalImageMounts) > 0 {
 		defer func() {
@@ -202,7 +210,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		ChownNew: idPair,
 		ChmodNew: &mode,
 	}
-	if err := copier.Mkdir(mountPoint, filepath.Join(mountPoint, spec.Process.Cwd), coptions); err != nil {
+	if err := copier.MkdirContext(ctx, mountPoint, filepath.Join(mountPoint, spec.Process.Cwd), coptions); err != nil {
 		return err
 	}
 
@@ -272,7 +280,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		SystemContext:    options.SystemContext,
 	}
 
-	runArtifacts, err = b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, options.CompatBuiltinVolumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo)
+	runArtifacts, err = b.setupMounts(ctx, mountPoint, spec, path, options.Mounts, bindFiles, volumes, options.CompatBuiltinVolumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo)
 	if err != nil {
 		return fmt.Errorf("resolving mountpoints for container %q: %w", b.ContainerID, err)
 	}
@@ -323,7 +331,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 
 	// Create any mount points that we need that aren't already present in
 	// the rootfs.
-	createdMountTargets, err := b.createMountTargets(spec)
+	createdMountTargets, err := b.createMountTargets(ctx, spec)
 	if err != nil {
 		return fmt.Errorf("ensuring mount targets for container %q: %w", b.ContainerID, err)
 	}
@@ -351,9 +359,9 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		} else {
 			moreCreateArgs = nil
 		}
-		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec, mountPoint, path, containerName, b.Container, hostsFile, resolvFile)
+		err = b.runUsingRuntimeSubproc(ctx, isolation, options, configureNetwork, networkString, moreCreateArgs, spec, mountPoint, path, containerName, b.Container, hostsFile, resolvFile)
 	case IsolationChroot:
-		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr, options.NoPivot)
+		err = chroot.RunUsingChrootContext(ctx, spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr, options.NoPivot)
 	default:
 		err = errors.New("don't know how to run this command")
 	}

--- a/run_linux.go
+++ b/run_linux.go
@@ -155,8 +155,14 @@ func separateDevicesFromRuntimeSpec(g *generate.Generator) define.ContainerDevic
 	return result
 }
 
-// Run runs the specified command in the container's root filesystem.
-func (b *Builder) Run(command []string, options RunOptions) error {
+// RunContext runs the specified command in the container's root filesystem.
+func (b *Builder) RunContext(ctx context.Context, command []string, options RunOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	var runArtifacts *runMountArtifacts
 	if len(options.ExternalImageMounts) > 0 {
 		defer func() {
@@ -384,7 +390,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		ChownNew: idPair,
 		ChmodNew: &mode,
 	}
-	if err := copier.Mkdir(mountPoint, filepath.Join(mountPoint, spec.Process.Cwd), coptions); err != nil {
+	if err := copier.MkdirContext(ctx, mountPoint, filepath.Join(mountPoint, spec.Process.Cwd), coptions); err != nil {
 		return err
 	}
 
@@ -494,7 +500,7 @@ rootless=%d
 	}
 
 	// Setup OCI hooks
-	_, err = b.setupOCIHooks(spec, (len(options.Mounts) > 0 || len(volumes) > 0))
+	_, err = b.setupOCIHooks(ctx, spec, (len(options.Mounts) > 0 || len(volumes) > 0))
 	if err != nil {
 		return fmt.Errorf("unable to setup OCI hooks: %w", err)
 	}
@@ -508,14 +514,14 @@ rootless=%d
 		SystemContext:    options.SystemContext,
 	}
 
-	runArtifacts, err = b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, options.CompatBuiltinVolumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo)
+	runArtifacts, err = b.setupMounts(ctx, mountPoint, spec, path, options.Mounts, bindFiles, volumes, options.CompatBuiltinVolumes, b.CommonBuildOpts.Volumes, options.RunMounts, runMountInfo)
 	if err != nil {
 		return fmt.Errorf("resolving mountpoints for container %q: %w", b.ContainerID, err)
 	}
 
 	// Create any mount points that we need that aren't already present in
 	// the rootfs.
-	createdMountTargets, err := b.createMountTargets(spec)
+	createdMountTargets, err := b.createMountTargets(ctx, spec)
 	if err != nil {
 		return fmt.Errorf("ensuring mount targets for container %q: %w", b.ContainerID, err)
 	}
@@ -526,7 +532,7 @@ rootless=%d
 		// points to stick around.  They'll still get filtered out at
 		// commit-time if another concurrent Run() is keeping something
 		// busy.
-		if _, err := copier.ConditionalRemove(mountPoint, mountPoint, copier.ConditionalRemoveOptions{
+		if _, err := copier.ConditionalRemoveContext(ctx, mountPoint, mountPoint, copier.ConditionalRemoveOptions{
 			UIDMap: b.store.UIDMap(),
 			GIDMap: b.store.GIDMap(),
 			Paths:  createdMountTargets,
@@ -581,16 +587,16 @@ rootless=%d
 		if options.NoPivot {
 			moreCreateArgs = append(moreCreateArgs, "--no-pivot")
 		}
-		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec,
+		err = b.runUsingRuntimeSubproc(ctx, isolation, options, configureNetwork, networkString, moreCreateArgs, spec,
 			mountPoint, path, define.Package+"-"+filepath.Base(path), b.Container, hostsFile, resolvFile)
 	case IsolationChroot:
-		err = chroot.RunUsingChroot(spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr, options.NoPivot)
+		err = chroot.RunUsingChrootContext(ctx, spec, path, homeDir, options.Stdin, options.Stdout, options.Stderr, options.NoPivot)
 	case IsolationOCIRootless:
 		moreCreateArgs := []string{"--no-new-keyring"}
 		if options.NoPivot {
 			moreCreateArgs = append(moreCreateArgs, "--no-pivot")
 		}
-		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, networkString, moreCreateArgs, spec,
+		err = b.runUsingRuntimeSubproc(ctx, isolation, options, configureNetwork, networkString, moreCreateArgs, spec,
 			mountPoint, path, define.Package+"-"+filepath.Base(path), b.Container, hostsFile, resolvFile)
 	default:
 		err = errors.New("don't know how to run this command")
@@ -598,14 +604,20 @@ rootless=%d
 	return checkExitCodeError(err, options.ValidExitCodes)
 }
 
-func (b *Builder) setupOCIHooks(config *specs.Spec, hasVolumes bool) (map[string][]specs.Hook, error) {
+func (b *Builder) setupOCIHooks(ctx context.Context, config *specs.Spec, hasVolumes bool) (map[string][]specs.Hook, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	allHooks := make(map[string][]specs.Hook)
 	if len(b.CommonBuildOpts.OCIHooksDir) == 0 {
 		if unshare.IsRootless() {
 			return nil, nil
 		}
 		for _, hDir := range []string{hooks.DefaultDir, hooks.OverrideDir} {
-			manager, err := hooks.New(context.Background(), []string{hDir}, []string{})
+			manager, err := hooks.New(ctx, []string{hDir}, []string{})
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {
 					continue
@@ -622,7 +634,7 @@ func (b *Builder) setupOCIHooks(config *specs.Spec, hasVolumes bool) (map[string
 			maps.Copy(allHooks, ociHooks)
 		}
 	} else {
-		manager, err := hooks.New(context.Background(), b.CommonBuildOpts.OCIHooksDir, []string{})
+		manager, err := hooks.New(ctx, b.CommonBuildOpts.OCIHooksDir, []string{})
 		if err != nil {
 			return nil, err
 		}
@@ -633,7 +645,7 @@ func (b *Builder) setupOCIHooks(config *specs.Spec, hasVolumes bool) (map[string
 		}
 	}
 
-	hookErr, err := hooksExec.RuntimeConfigFilter(context.Background(), allHooks["precreate"], config, hooksExec.DefaultPostKillTimeout) //nolint:staticcheck
+	hookErr, err := hooksExec.RuntimeConfigFilter(ctx, allHooks["precreate"], config, hooksExec.DefaultPostKillTimeout) //nolint:staticcheck
 	if err != nil {
 		logrus.Warnf("Container: precreate hook: %v", err)
 		if hookErr != nil && hookErr != err {

--- a/run_unix.go
+++ b/run_unix.go
@@ -3,6 +3,7 @@
 package buildah
 
 import (
+	"context"
 	"errors"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -20,7 +21,13 @@ func setChildProcess() error {
 
 func runUsingRuntimeMain() {}
 
-func (b *Builder) Run(command []string, options RunOptions) error {
+func (b *Builder) RunContext(ctx context.Context, command []string, options RunOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	return errors.New("function not supported on non-linux systems")
 }
 

--- a/run_unsupported.go
+++ b/run_unsupported.go
@@ -3,6 +3,7 @@
 package buildah
 
 import (
+	"context"
 	"errors"
 
 	nettypes "go.podman.io/common/libnetwork/types"
@@ -15,7 +16,13 @@ func setChildProcess() error {
 
 func runUsingRuntimeMain() {}
 
-func (b *Builder) Run(command []string, options RunOptions) error {
+func (b *Builder) RunContext(ctx context.Context, command []string, options RunOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	return errors.New("function not supported on non-linux systems")
 }
 

--- a/scan.go
+++ b/scan.go
@@ -36,6 +36,12 @@ func stringSliceReplaceAll(slice []string, replacements map[string]string, impor
 // sbomScan iterates through the scanning configuration settings, generating
 // SBOM files and storing them either in the rootfs or in a local file path.
 func (b *Builder) sbomScan(ctx context.Context, options CommitOptions) (imageFiles, localFiles map[string]string, scansDir string, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, "", ctx.Err()
+	default:
+	}
+
 	// We'll use a temporary per-container directory for this one.
 	cdir, err := b.store.ContainerDirectory(b.ContainerID)
 	if err != nil {
@@ -211,7 +217,7 @@ func (b *Builder) sbomScan(ctx context.Context, options CommitOptions) (imageFil
 		// or more files named "scan%d.json" in our temporary directory.
 		for _, resolvedCommand := range resolvedCommands {
 			logrus.Debugf("Running scan command %q", resolvedCommand)
-			if err = scanBuilder.Run(resolvedCommand, runOptions); err != nil {
+			if err = scanBuilder.RunContext(ctx, resolvedCommand, runOptions); err != nil {
 				return nil, nil, "", fmt.Errorf("running scanning command %v: %w", resolvedCommand, err)
 			}
 		}

--- a/tests/basic.bats
+++ b/tests/basic.bats
@@ -145,3 +145,9 @@ load helpers
 
   assert "$output" "!~" "dev" "The Buildah version string does not mention 'dev'."
 }
+
+@test "experimental-timeout" {
+  _prefetch busybox
+  run_buildah 125 --experimental-timeout=1ns from busybox
+  expect_output --substring "context deadline exceeded"
+}

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -198,7 +198,7 @@ func testConformanceInternal(t *testing.T, dateStamp string, testIndex int, muta
 	if mutate != nil {
 		mutate(&test)
 	}
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	cwd, err := os.Getwd()
 	require.NoError(t, err, "error finding current directory")
@@ -234,15 +234,15 @@ func testConformanceInternal(t *testing.T, dateStamp string, testIndex int, muta
 	var wg sync.WaitGroup
 	wg.Go(func() {
 		if test.contextDir != "" {
-			getErr = copier.Get("", testDataDir, copier.GetOptions{}, []string{test.contextDir}, pipeWriter)
+			getErr = copier.GetContext(t.Context(), "", testDataDir, copier.GetOptions{}, []string{test.contextDir}, pipeWriter)
 		} else if test.dockerfile != "" {
-			getErr = copier.Get("", testDataDir, copier.GetOptions{}, []string{test.dockerfile}, pipeWriter)
+			getErr = copier.GetContext(t.Context(), "", testDataDir, copier.GetOptions{}, []string{test.dockerfile}, pipeWriter)
 		}
 		pipeWriter.Close()
 	})
 	wg.Go(func() {
 		if test.contextDir != "" || test.dockerfile != "" {
-			putErr = copier.Put("", contextDir, copier.PutOptions{}, pipeReader)
+			putErr = copier.PutContext(t.Context(), "", contextDir, copier.PutOptions{}, pipeReader)
 		} else {
 			putErr = os.Mkdir(contextDir, 0o755)
 		}
@@ -4205,7 +4205,7 @@ func TestCommit(t *testing.T) {
 		dockerDir = filepath.Join(tempdir, "docker")
 	}
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	// connect to dockerd using go-dockerclient
 	client, err := docker.NewClientFromEnv()

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -125,7 +125,7 @@ func main() {
 				MaxParallelDownloads:  maxParallelDownloads,
 				ForceManifestMIMEType: manifestFormat,
 			}
-			if _, err = cp.Image(context.TODO(), policyContext, dest, src, &options); err != nil {
+			if _, err = cp.Image(context.Background(), policyContext, dest, src, &options); err != nil {
 				return err
 			}
 

--- a/tests/rpc/noop/noop.go
+++ b/tests/rpc/noop/noop.go
@@ -59,7 +59,7 @@ func main() {
 }
 
 func poke(c *cobra.Command, args []string) error {
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	socketPath := c.Flag("connect").Value.String()
 	if socketPath == "" {

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package buildah
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -151,18 +152,18 @@ func IsContainer(id string, store storage.Store) (bool, error) {
 // Copy content from the directory "src" to the directory "dest", ensuring that
 // content from outside of "root" (which is a parent of "src" or "src" itself)
 // isn't read.
-func extractWithTar(root, src, dest string) error {
+func extractWithTar(ctx context.Context, root, src, dest string) error {
 	var getErr, putErr error
 	var wg sync.WaitGroup
 
 	pipeReader, pipeWriter := io.Pipe()
 
 	wg.Go(func() {
-		getErr = copier.Get(root, src, copier.GetOptions{}, []string{"."}, pipeWriter)
+		getErr = copier.GetContext(ctx, root, src, copier.GetOptions{}, []string{"."}, pipeWriter)
 		pipeWriter.Close()
 	})
 	wg.Go(func() {
-		putErr = copier.Put(dest, dest, copier.PutOptions{}, pipeReader)
+		putErr = copier.PutContext(ctx, dest, dest, copier.PutOptions{}, pipeReader)
 		pipeReader.Close()
 	})
 	wg.Wait()


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Introduce versions of a number of functions and some methods which take a context.Context, to least try to provide proper cancellation support.

When copier.Get() returns an error, also write a non-NUL string after whatever it's already written, so that a tar.Reader that reads what it output will also flag the malformed header with an unexpected error.

In the CLI, pass our default global context down in places where we didn't before, connect it to an experimental timeout flag, and have it cancel on `os.Interrupt` signals, too.

#### How to verify it

New/updated unit tests!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```