### PR TITLE
Add more flags to test helpers

### DIFF
--- a/cmd/buildah/addcopy.go
+++ b/cmd/buildah/addcopy.go
@@ -30,6 +30,7 @@ type addCopyResults struct {
 	contextdir         string
 	from               string
 	blobCache          string
+	blobInfoCache      string
 	decryptionKeys     []string
 	removeSignatures   bool
 	signaturePolicy    string
@@ -74,6 +75,10 @@ func applyFlagVars(flags *pflag.FlagSet, opts *addCopyResults) {
 	flags.StringVar(&opts.blobCache, "blob-cache", "", "store copies of pulled image blobs in the specified directory")
 	if err := flags.MarkHidden("blob-cache"); err != nil {
 		panic(fmt.Sprintf("error marking blob-cache as hidden: %v", err))
+	}
+	flags.StringVar(&opts.blobInfoCache, "blob-info-cache-dir", "", "cache information about blobs in the specified directory instead of the default location")
+	if err := flags.MarkHidden("blob-info-cache-dir"); err != nil {
+		panic(fmt.Sprintf("error marking blob-info-cache-dir as hidden: %v", err))
 	}
 	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access registries and sources in HTTPS locations")
 	flags.StringVar(&opts.checksum, "checksum", "", "checksum the HTTP source content")

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -32,6 +32,7 @@ type commitInputOptions struct {
 	authfile               string
 	omitHistory            bool
 	blobCache              string
+	blobInfoCache          string
 	certDir                string
 	changes                []string
 	compressionFormat      string
@@ -109,6 +110,10 @@ func commitListFlagSet(cmd *cobra.Command, opts *commitInputOptions) {
 	flags.StringVar(&opts.blobCache, "blob-cache", "", "assume image blobs in the specified directory will be available for pushing")
 	if err := flags.MarkHidden("blob-cache"); err != nil {
 		panic(fmt.Sprintf("error marking blob-cache as hidden: %v", err))
+	}
+	flags.StringVar(&opts.blobInfoCache, "blob-info-cache-dir", "", "cache information about blobs in the specified directory instead of the default location")
+	if err := flags.MarkHidden("blob-info-cache-dir"); err != nil {
+		panic(fmt.Sprintf("error marking blob-info-cache-dir as hidden: %v", err))
 	}
 	flags.StringSliceVar(&opts.encryptionKeys, "encryption-key", nil, "key with the encryption protocol to use needed to encrypt the image (e.g. jwe:/path/to/key.pem)")
 	_ = cmd.RegisterFlagCompletionFunc("encryption-key", completion.AutocompleteDefault)

--- a/cmd/buildah/pull.go
+++ b/cmd/buildah/pull.go
@@ -20,6 +20,7 @@ type pullOptions struct {
 	allTags          bool
 	authfile         string
 	blobCache        string
+	blobInfoCache    string
 	certDir          string
 	creds            string
 	signaturePolicy  string
@@ -60,6 +61,10 @@ func pullInit() {
 	flags.BoolVarP(&opts.allTags, "all-tags", "a", false, "download all tagged images in the repository")
 	flags.StringVar(&opts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&opts.blobCache, "blob-cache", "", "store copies of pulled image blobs in the specified directory")
+	flags.StringVar(&opts.blobInfoCache, "blob-info-cache-dir", "", "cache information about blobs in the specified directory instead of the default location")
+	if err := flags.MarkHidden("blob-info-cache-dir"); err != nil {
+		panic(fmt.Sprintf("error marking blob-info-cache-dir as hidden: %v", err))
+	}
 	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	flags.StringVar(&opts.pullPolicy, "policy", "missing", "missing, always, ifnewer, or never.")

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -28,6 +28,7 @@ type pushOptions struct {
 	all                    bool
 	authfile               string
 	blobCache              string
+	blobInfoCache          string
 	certDir                string
 	creds                  string
 	digestfile             string
@@ -86,6 +87,10 @@ func pushInit() {
 	flags.BoolVar(&opts.all, "all", false, "push all of the images referenced by the manifest list")
 	flags.StringVar(&opts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&opts.blobCache, "blob-cache", "", "assume image blobs in the specified directory will be available for pushing")
+	flags.StringVar(&opts.blobInfoCache, "blob-info-cache-dir", "", "cache information about blobs in the specified directory instead of the default location")
+	if err := flags.MarkHidden("blob-info-cache-dir"); err != nil {
+		panic(fmt.Sprintf("error marking blob-info-cache-dir as hidden: %v", err))
+	}
 	flags.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
 	flags.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	flags.StringVar(&opts.digestfile, "digestfile", "", "after copying the image, write the digest of the resulting image to the file")

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -71,7 +71,9 @@ func runInit() {
 	flags.StringSliceVar(&opts.capAdd, "cap-add", []string{}, "add the specified capability (default [])")
 	flags.StringSliceVar(&opts.capDrop, "cap-drop", []string{}, "drop the specified capability (default [])")
 	flags.StringVar(&opts.cdiConfigDir, "cdi-config-dir", "", "`directory` of CDI configuration files")
-	_ = flags.MarkHidden("cdi-config-dir")
+	if err := flags.MarkHidden("cdi-config-dir"); err != nil {
+		panic(fmt.Sprintf("error marking cdi-config-dir as hidden: %v", err))
+	}
 	flags.StringVar(&opts.contextDir, "contextdir", "", "context directory path")
 	flags.StringArrayVar(&opts.devices, "device", []string{}, "additional devices to provide")
 	flags.StringArrayVarP(&opts.env, "env", "e", []string{}, "add environment variable to be set temporarily when running command (default [])")

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -146,6 +146,7 @@ type BudResults struct {
 type FromAndBudResults struct {
 	AddHost        []string
 	BlobCache      string
+	BlobInfoCache  string
 	CapAdd         []string
 	CapDrop        []string
 	CDIConfigDir   string
@@ -422,7 +423,11 @@ func GetFromAndBudFlags(flags *FromAndBudResults, usernsResults *UserNSResults, 
 	fs.StringSliceVar(&flags.AddHost, "add-host", []string{}, "add a custom host-to-IP mapping (`host:ip`) (default [])")
 	fs.StringVar(&flags.BlobCache, "blob-cache", "", "assume image blobs in the specified directory will be available for pushing")
 	if err := fs.MarkHidden("blob-cache"); err != nil {
-		panic(fmt.Sprintf("error marking net flag as hidden: %v", err))
+		panic(fmt.Sprintf("error marking blob-cache flag as hidden: %v", err))
+	}
+	fs.StringVar(&flags.BlobInfoCache, "blob-info-cache-dir", "", "cache information about blobs in the specified directory instead of the default location")
+	if err := fs.MarkHidden("blob-info-cache-dir"); err != nil {
+		panic(fmt.Sprintf("error marking blob-info-cache flag as hidden: %v", err))
 	}
 	fs.StringSliceVar(&flags.CapAdd, "cap-add", []string{}, "add the specified capability when running (default [])")
 	fs.StringSliceVar(&flags.CapDrop, "cap-drop", []string{}, "drop the specified capability when running (default [])")

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -498,6 +498,10 @@ func SystemContextFromFlagSet(flags *pflag.FlagSet, findFlagFunc func(name strin
 	if err == nil && findFlagFunc("short-name-alias-conf").Changed {
 		ctx.UserShortNameAliasConfPath = shortNameAliasConf
 	}
+	blobInfoCacheDir, err := flags.GetString("blob-info-cache-dir")
+	if err == nil && findFlagFunc("blob-info-cache-dir").Changed {
+		ctx.BlobInfoCacheDir = blobInfoCacheDir
+	}
 	ctx.DockerRegistryUserAgent = fmt.Sprintf("Buildah/%s", define.Version)
 	if findFlagFunc("os") != nil && findFlagFunc("os").Changed {
 		var os string

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -386,7 +386,6 @@ EOF
 }
 
 @test "bud: build push with --force-compression" {
-  skip_if_no_podman
   blobcachedir=${TEST_SCRATCH_DIR}/blobcachelocal
   mkdir -p ${blobcachedir}
   local contextdir=${TEST_SCRATCH_DIR}/bud/platform
@@ -408,7 +407,7 @@ _EOF
   run_buildah login --tls-verify=false --authfile ${TEST_SCRATCH_DIR}/test.auth --username testuser --password testpassword localhost:${REGISTRY_PORT}
   run_buildah build $WITH_POLICY_JSON -t $imgname --platform linux/amd64 $contextdir
 
-  # Helper function. push our image with the given options, and run skopeo inspect
+  # Helper function. push our image with the given options, and run imgtype to inspect
   function _test_buildah_push() {
     run_buildah push \
                 --blob-cache=${blobcachedir} \
@@ -419,15 +418,12 @@ _EOF
                 $imgname \
                 docker://localhost:${REGISTRY_PORT}/$imgname
 
-    echo "# skopeo inspect $imgname"
-    run podman run --rm \
-        --mount type=bind,src=${TEST_SCRATCH_DIR}/test.auth,target=/test.auth,Z \
-        --net host \
-        quay.io/skopeo/stable inspect \
-        --authfile=/test.auth \
-        --tls-verify=false \
-        --raw \
+    echo "# imgtype -show-manifest docker://localhost:${REGISTRY_PORT}/$imgname"
+    run imgtype -show-manifest \
+        -authfile=${TEST_SCRATCH_DIR}/test.auth \
+        -tls-verify=false \
         docker://localhost:${REGISTRY_PORT}/$imgname
+    assert $status -eq 0 "imgtype failed"
     echo "$output"
   }
 
@@ -439,11 +435,11 @@ _EOF
   _test_buildah_push --compression-format zstd --force-compression=false
   assert "$output" !~ "zstd" "zstd found even though push was without --force-compression"
 
-  # layers should container `zstd`
+  # layers should contain `zstd`
   _test_buildah_push --compression-format zstd
   expect_output --substring "zstd" "layers must contain zstd compression"
 
-  # layers should container `zstd`
+  # layers should contain `zstd`
   _test_buildah_push --compression-format zstd --force-compression
   expect_output --substring "zstd" "layers must contain zstd compression"
 }

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -30,6 +30,7 @@ func main() {
 	var logLevel string
 	var maxParallelDownloads uint
 	var compressionFormat string
+	var forceCompressionFormat bool
 	var manifestFormat string
 	compressionLevel := -1
 
@@ -62,9 +63,9 @@ func main() {
 				systemContext.CompressionFormat = &alg
 			}
 			switch strings.ToLower(manifestFormat) {
-			case "oci":
+			case "oci", "ociv1":
 				manifestFormat = v1.MediaTypeImageManifest
-			case "docker", "dockerv2s2":
+			case "docker", "dockerv2s2", "v2s2":
 				manifestFormat = manifest.DockerV2Schema2MediaType
 			}
 
@@ -119,11 +120,16 @@ func main() {
 			}()
 
 			options := cp.Options{
-				ReportWriter:          os.Stdout,
-				SourceCtx:             &systemContext,
-				DestinationCtx:        &systemContext,
-				MaxParallelDownloads:  maxParallelDownloads,
-				ForceManifestMIMEType: manifestFormat,
+				ReportWriter:           os.Stdout,
+				SourceCtx:              &systemContext,
+				DestinationCtx:         &systemContext,
+				MaxParallelDownloads:   maxParallelDownloads,
+				ForceManifestMIMEType:  manifestFormat,
+				ForceCompressionFormat: forceCompressionFormat,
+			}
+			if compressionFormat != "" && !cmd.Flag("dest-force-compression-format").Changed {
+				options.ForceCompressionFormat = true
+				systemContext.DirForceCompress = true
 			}
 			if _, err = cp.Image(context.TODO(), policyContext, dest, src, &options); err != nil {
 				return err
@@ -145,6 +151,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&storeOptions.TransientStore, "transient-store", false, "store some information in transient storage")
 	rootCmd.PersistentFlags().StringVar(&storeOptions.GraphDriverName, "storage-driver", "", "storage driver")
 	rootCmd.PersistentFlags().StringSliceVar(&storeOptions.GraphDriverOptions, "storage-opt", nil, "storage option")
+	rootCmd.PersistentFlags().StringVar(&systemContext.DockerCertPath, "cert-dir", "", "location of certificates to use for communicating with registries")
 	rootCmd.PersistentFlags().StringVar(&systemContext.SystemRegistriesConfPath, "registries-conf", "", "location of registries.conf")
 	rootCmd.PersistentFlags().StringVar(&systemContext.SystemRegistriesConfDirPath, "registries-conf-dir", "", "location of registries.d")
 	rootCmd.PersistentFlags().StringVar(&systemContext.SignaturePolicyPath, "signature-policy", "", "`pathname` of signature policy file")
@@ -152,10 +159,17 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "warn", "logging level")
 	rootCmd.PersistentFlags().UintVar(&maxParallelDownloads, "max-parallel-downloads", 0, "maximum `number` of blobs to copy at once")
 	rootCmd.PersistentFlags().StringVar(&manifestFormat, "format", "", "image manifest type")
+	rootCmd.PersistentFlags().StringVar(&systemContext.BlobInfoCacheDir, "blob-info-cache-dir", "", "cache information about blobs in the specified directory instead of the default location")
 	rootCmd.PersistentFlags().BoolVar(&systemContext.DirForceCompress, "dest-compress", false, "force compression of layers for dir: destinations")
 	rootCmd.PersistentFlags().BoolVar(&systemContext.DirForceDecompress, "dest-decompress", false, "force decompression of layers for dir: destinations")
+	rootCmd.PersistentFlags().BoolVar(&forceCompressionFormat, "dest-force-compression-format", false, "force compression of layers for dir: destinations")
 	rootCmd.PersistentFlags().StringVar(&compressionFormat, "dest-compress-format", "", "compression type")
 	rootCmd.PersistentFlags().IntVar(&compressionLevel, "dest-compress-level", 0, "compression level")
+	rootCmd.PersistentFlags().StringVar(&systemContext.AuthFilePath, "authfile", "", "registry credentials")
+	rootCmd.PersistentFlags().StringVar(&systemContext.LegacyFormatAuthFilePath, "legacy-format-authfile", "", "registry credentials in legacy format")
+	rootCmd.PersistentFlags().StringVar(&systemContext.DockerCompatAuthFilePath, "docker-compat-authfile", "", "registry credentials in docker-compatible format")
+
+	rootCmd.PersistentFlags().SetInterspersed(true)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -49,6 +49,13 @@ func main() {
 	rebuildm := flag.Bool("rebuild-manifest", false, "rebuild the manifest JSON")
 	showc := flag.Bool("show-config", false, "output the configuration JSON")
 	rebuildc := flag.Bool("rebuild-config", false, "rebuild the configuration JSON")
+	authFile := flag.String("authfile", "", "location of credentials for accessing registries")
+	legacyAuthFile := flag.String("legacy-format-authfile", "", "location of credentials for accessing registries in legacy format")
+	blobInfoCacheDir := flag.String("blob-info-cache-dir", "", "cache information about blobs in the specified directory instead of the default location")
+
+	certDir := flag.String("cert-dir", "", "location of certificates for use with registries")
+	dockerCompatAuthFile := flag.String("docker-compat-authfile", "", "location of credentials for accessing registries in docker format")
+	tlsVerify := flag.Bool("tls-verify", true, "use HTTPS with certificate verification when accessing registries")
 	flag.Parse()
 	logrus.SetLevel(logrus.ErrorLevel)
 	if debug != nil && *debug {
@@ -67,7 +74,7 @@ func main() {
 	default:
 		logrus.Errorf("unknown -expected-manifest-type value, expected either %q or %q or %q",
 			define.OCIv1ImageManifest, define.Dockerv2ImageManifest, "*")
-		return
+		os.Exit(1)
 	}
 	if root != nil {
 		storeOptions.GraphRoot = *root
@@ -91,10 +98,29 @@ func main() {
 	systemContext := &types.SystemContext{
 		SignaturePolicyPath: *policy,
 	}
+	if authFile != nil {
+		systemContext.AuthFilePath = *authFile
+	}
+	if legacyAuthFile != nil {
+		systemContext.LegacyFormatAuthFilePath = *legacyAuthFile
+	}
+	if blobInfoCacheDir != nil {
+		systemContext.BlobInfoCacheDir = *blobInfoCacheDir
+	}
+	if dockerCompatAuthFile != nil {
+		systemContext.DockerCompatAuthFilePath = *dockerCompatAuthFile
+	}
+	if certDir != nil {
+		systemContext.DockerCertPath = *certDir
+	}
+	if tlsVerify != nil {
+		systemContext.OCIInsecureSkipTLSVerify = !*tlsVerify
+		systemContext.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!*tlsVerify)
+	}
 	args := flag.Args()
 	if len(args) == 0 {
 		flag.Usage()
-		return
+		os.Exit(1)
 	}
 	store, err := storage.GetStore(storeOptions)
 	if err != nil {
@@ -109,6 +135,7 @@ func main() {
 		if errors {
 			os.Exit(1)
 		}
+		os.Exit(0)
 	}()
 	for _, image := range args {
 		var ref types.ImageReference


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

* Add a hidden "--blob-info-cache-dir" flag to our `add`, `build`, `copy`, `commit`, `from`, `pull`, and `push` commands.
* Panic if we can't hide the "--cdi-config-dir" flag for `run`, like we do for the rest of the flags that we hide.
* Correct the panicking message when we fail to hide the "--blob-cache" flag for `from` and `build`.
* Add CLI flags to the "copy" and "imgtype" helpers for setting the location of registry certificates and credentials, and a "--dest-force-compression-format" flag to catch up with the main binary.
* Use imgtype instead of pulling and running a skopeo image to inspect an image after pushing it to a test registry.

#### How to verify it

Updated integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```