### PR TITLE
info: add CDI information

### DIFF
--- a/info.go
+++ b/info.go
@@ -3,11 +3,13 @@ package buildah
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
@@ -15,9 +17,11 @@ import (
 	putil "go.podman.io/buildah/pkg/util"
 	"go.podman.io/buildah/util"
 	"go.podman.io/common/pkg/cgroups"
+	"go.podman.io/common/pkg/config"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/system"
 	"go.podman.io/storage/pkg/unshare"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 // InfoData holds the info type, i.e store, host etc and the data for each type
@@ -39,6 +43,15 @@ func Info(store storage.Store) ([]InfoData, error) {
 		logrus.Error(err, "error getting store info")
 	}
 	info = append(info, InfoData{Type: "store", Data: storeInfo})
+
+	// get CDI information
+	cdiInfo, err := cdiInfo()
+	if err != nil && !errors.Is(err, syscall.ENOSYS) {
+		logrus.Error(err, "error getting CDI info")
+	}
+	if len(cdiInfo) > 0 {
+		info = append(info, InfoData{Type: "cdi", Data: cdiInfo})
+	}
 	return info, nil
 }
 
@@ -186,4 +199,36 @@ func getHostDistributionInfo() map[string]string {
 		}
 	}
 	return dist
+}
+
+// cdiInfo returns info about devices configured by CDI, and how we know about them.
+func cdiInfo() (map[string]any, error) {
+	cfg, err := config.Default()
+	if err != nil {
+		return nil, fmt.Errorf("reading default configuration: %w", err)
+	}
+	cache, err := cdi.NewCache(cdi.WithSpecDirs(cfg.Engine.CdiSpecDirs.Get()...), cdi.WithAutoRefresh(false))
+	if err != nil {
+		return nil, fmt.Errorf("reading CDI spec directories (%v): %w", cfg.Engine.CdiSpecDirs.Get(), err)
+	}
+	if err := cache.Refresh(); err != nil {
+		return nil, fmt.Errorf("refreshing CDI specs: %w", err)
+	}
+	devices := map[string]any{}
+	for _, device := range cache.ListDevices() {
+		devSpec := cache.GetDevice(device)
+		devices[device] = devSpec
+	}
+	vendors := map[string]any{}
+	for _, vendor := range cache.ListVendors() {
+		vendorSpecs := cache.GetVendorSpecs(vendor)
+		vendors[vendor] = vendorSpecs
+	}
+	summary := map[string]any{
+		"classes":     append([]string{}, cache.ListClasses()...),
+		"directories": cache.GetSpecDirectories(),
+		"devices":     devices,
+		"vendors":     vendors,
+	}
+	return summary, nil
 }

--- a/run_linux.go
+++ b/run_linux.go
@@ -99,14 +99,15 @@ func (b *Builder) cdiSetupDevicesInSpec(deviceSpecs []string, configDir string, 
 		// handled by CDI, so we don't need to do anything here.
 		return deviceSpecs, nil
 	}
-	if err := cdi.Configure(cdi.WithSpecDirs(configDirs...)); err != nil {
+	var cache *cdi.Cache
+	if cache, err = cdi.NewCache(cdi.WithSpecDirs(configDirs...), cdi.WithAutoRefresh(false)); err != nil {
 		return nil, fmt.Errorf("CDI default registry ignored configured directories %v: %w", configDirs, err)
 	}
 	leftoverDevices := slices.Clone(deviceSpecs)
-	if err := cdi.Refresh(); err != nil {
+	if err := cache.Refresh(); err != nil {
 		logrus.Warnf("CDI default registry refresh: %v", err)
 	} else {
-		leftoverDevices, err = cdi.InjectDevices(spec, qualifiedDeviceSpecs...)
+		leftoverDevices, err = cache.InjectDevices(spec, qualifiedDeviceSpecs...)
 		if err != nil {
 			return nil, fmt.Errorf("CDI device injection (leftover devices: %v): %w", leftoverDevices, err)
 		}

--- a/tests/cdi.bats
+++ b/tests/cdi.bats
@@ -44,3 +44,30 @@ load helpers
   cid="$output"
   run_buildah run --cdi-config-dir=$cdidir --device=containers.github.io/sample=all "$cid" cat /dev/containers-cdi.yaml
 }
+
+@test "info with CDI" {
+  skip_if_chroot
+  _prefetch busybox
+  cdidir=${TEST_SCRATCH_DIR}/cdi-config-dir
+  mkdir -p $cdidir
+  sed -e s:@@hostcdipath@@:$cdidir:g $BUDFILES/cdi/containers-cdi.yaml > $cdidir/containers-cdi.yaml
+  chmod 644 $cdidir/containers-cdi.yaml
+  cat > ${TEST_SCRATCH_DIR}/containers.conf <<-EOF
+  [engine]
+  cdi_spec_dirs = ["$cdidir"]
+EOF
+  echo === Begin CDI configuration in $cdidir/containers-cdi.yaml ===
+  cat $cdidir/containers-cdi.yaml
+  echo === End CDI configuration ===
+  CONTAINERS_CONF=${TEST_SCRATCH_DIR}/containers.conf run_buildah info
+  info="$output"
+  run jq .cdi <<< "$info"
+  assert $status -eq 0
+  cdi="$output"
+  echo === Begin CDI section of info output ===
+  echo "$cdi"
+  echo === End CDI section of info output ===
+  run jq -r '.vendors.["containers.github.io"].[0].["devices"].[0].["containerEdits"].["mounts"].[0].["containerPath"]' <<< "$cdi"
+  assert "$output" = "/dev/containers-cdi.yaml"
+  assert $status -eq 0
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Teaches `buildah info` to dump out the list of configured CDI spec directories, and the discovered devices and vendors along with whatever spec info is associated with all of them.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah info` now includes information about the system CDI (container device interface) settings.
```