### PR TITLE
Fix a few format-specifier warnings

### DIFF
--- a/chroot/run_test.go
+++ b/chroot/run_test.go
@@ -571,7 +571,7 @@ func TestLinuxIDMapping(t *testing.T) {
 		},
 		func(t *testing.T, report *types.TestReport) {
 			if len(report.Spec.Linux.UIDMappings) != 1 {
-				t.Fatalf("expected 1 uid mapping, got %q", len(report.Spec.Linux.UIDMappings))
+				t.Fatalf("expected 1 uid mapping, got %d", len(report.Spec.Linux.UIDMappings))
 			}
 			if report.Spec.Linux.UIDMappings[0].HostID != uint32(unix.Getuid()) {
 				t.Fatalf("expected host uid mapping to be %d, got %d", unix.Getuid(), report.Spec.Linux.UIDMappings[0].HostID)
@@ -609,7 +609,7 @@ func TestLinuxIDMappingShift(t *testing.T) {
 		},
 		func(t *testing.T, report *types.TestReport) {
 			if len(report.Spec.Linux.UIDMappings) != 1 {
-				t.Fatalf("expected 1 uid mapping, got %q", len(report.Spec.Linux.UIDMappings))
+				t.Fatalf("expected 1 uid mapping, got %d", len(report.Spec.Linux.UIDMappings))
 			}
 			if report.Spec.Linux.UIDMappings[0].HostID != uint32(unix.Getuid()+1) {
 				t.Fatalf("expected host uid mapping to be %d, got %d", unix.Getuid()+1, report.Spec.Linux.UIDMappings[0].HostID)
@@ -621,7 +621,7 @@ func TestLinuxIDMappingShift(t *testing.T) {
 				t.Fatalf("expected container uid map size to be 1, got %d", report.Spec.Linux.UIDMappings[0].Size)
 			}
 			if report.Spec.Linux.GIDMappings[0].HostID != uint32(unix.Getgid()+1) {
-				t.Fatalf("expected host uid mapping to be %d, got %d", unix.Getgid()+1, report.Spec.Linux.GIDMappings[0].HostID)
+				t.Fatalf("expected host gid mapping to be %d, got %d", unix.Getgid()+1, report.Spec.Linux.GIDMappings[0].HostID)
 			}
 			if report.Spec.Linux.GIDMappings[0].ContainerID != 0 {
 				t.Fatalf("expected container gid mapping to be 0, got %d", report.Spec.Linux.GIDMappings[0].ContainerID)

--- a/internal/output/build_output.go
+++ b/internal/output/build_output.go
@@ -14,6 +14,20 @@ const (
 	BuildOutputTar      BuildOutputType = 3
 )
 
+func (b BuildOutputType) String() string {
+	switch b {
+	case BuildOutputInvalid:
+		return "invalid (unset)!"
+	case BuildOutputStdout:
+		return "stdout"
+	case BuildOutputLocalDir:
+		return "local"
+	case BuildOutputTar:
+		return "tar"
+	}
+	return fmt.Sprintf("unknown %d!", int(b))
+}
+
 // BuildOutputOptions contains the outcome of parsing the value of a build --output flag
 type BuildOutputOption struct {
 	Type BuildOutputType

--- a/pkg/chrootuser/user_unix.go
+++ b/pkg/chrootuser/user_unix.go
@@ -281,7 +281,7 @@ func lookupUIDInContainer(rootdir string, uid uint64) (string, uint64, error) {
 		return pwd.name, pwd.gid, nil
 	}
 
-	return "", 0, user.UnknownUserError(fmt.Sprintf("error looking up uid %q", uid))
+	return "", 0, user.UnknownUserError(fmt.Sprintf("error looking up uid %d", uid))
 }
 
 func lookupHomedirInContainer(rootdir string, uid uint64) (string, error) {
@@ -307,5 +307,5 @@ func lookupHomedirInContainer(rootdir string, uid uint64) (string, error) {
 		return pwd.home, nil
 	}
 
-	return "", user.UnknownUserError(fmt.Sprintf("error looking up uid %q for homedir", uid))
+	return "", user.UnknownUserError(fmt.Sprintf("error looking up homedir for uid %d", uid))
 }

--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -351,7 +351,7 @@ EOF
   echo "test \"\$(cat /proc/self/setgroups)\" = deny" >> ${TEST_SCRATCH_DIR}/script.sh
   echo "${TEST_SCRATCH_DIR}/copy ${storageopts} dir:\$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
   echo "ctr=\$(${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} from --pull=never -q $baseimage)" >> ${TEST_SCRATCH_DIR}/script.sh
-  echo "${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} run --isolation chroot -v $probe:/probe:ro,z \"\$ctr\" -- sh -c 'echo setgroups:\$(cat /proc/self/setgroups); stat -c \"member_denied=%u:%g:%a\" /probe/member_denied; stat -c \"nonmember_allowed=%u:%g:%a\" /probe/nonmember_allowed; grep ^Gid: /proc/self/status; cat /probe/nonmember_allowed && ! cat /probe/member_denied'" >> ${TEST_SCRATCH_DIR}/script.sh
+  echo "${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} run --isolation chroot -v $probe:/probe:z \"\$ctr\" -- sh -c 'echo setgroups:\$(cat /proc/self/setgroups); stat -c \"member_denied=%u:%g:%a\" /probe/member_denied; stat -c \"nonmember_allowed=%u:%g:%a\" /probe/nonmember_allowed; grep ^Gid: /proc/self/status; cat /probe/nonmember_allowed && ! cat /probe/member_denied'" >> ${TEST_SCRATCH_DIR}/script.sh
 
   # Two namespaces, mirroring the reported environment: the outer one is mapped
   # via newuidmap/newgidmap, which leaves setgroups() permitted, so we can drop

--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -176,7 +176,7 @@ load helpers
   mkdir -p ${TEST_SCRATCH_DIR}/chroot/merged/var/lib/containers/storage
   chmod 755 ${TEST_SCRATCH_DIR}/chroot/merged/var/lib/containers/storage
   # https://github.com/podman-container-tools/buildah/issues/6967
-  # chown -R is not safe against concurent removal, it will exit 1 when
+  # chown -R is not safe against concurrent removal, it will exit 1 when
   # it happens but still walks all files so we can ignore the error here.
   # Bug: https://bugs.gnu.org/81444
   # Only once the fix landed in our test distro images coreutils version this workaround can be removed.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In a few places, we were using "%q" as a format specifier for numbers, and for enumerated types which didn't have a `String()` method.

#### How to verify it

Updated unit test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```