### PR TITLE
Run tests in parallel on testing-farm

### DIFF
--- a/tests/tmt/system.fmf
+++ b/tests/tmt/system.fmf
@@ -1,5 +1,6 @@
 require:
     - buildah-tests
+    - coreutils
     - git-daemon
 
 environment:

--- a/tests/tmt/system.sh
+++ b/tests/tmt/system.sh
@@ -15,4 +15,4 @@ rpm -q \
     netavark \
     systemd
 
-bats /usr/share/buildah/test/system
+bats --jobs $(nproc) --timing /usr/share/buildah/test/system


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Use bats's --jobs flag to run integration tests in parallel, as we do in other CI tasks.
~Also enables some linters that were already happy with us.~

#### How to verify it

Testing-farm CI tasks shouldn't time out.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```