### PR TITLE
Packit config update to skip TF jobs for unavailable composes and Fedora-45 downstream addition

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -98,6 +98,7 @@ jobs:
   - job: tests
     trigger: pull_request
     packages: [buildah-fedora]
+    skip_missing_branched_composes: true
     targets:
       - fedora-all-x86_64
     tf_extra_params:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -132,6 +132,7 @@ jobs:
     update_release: false
     dist_git_branches: &fedora_targets
       - fedora-rawhide
+      - fedora-45
 
   # Sync to CentOS Stream
   - job: propose_downstream


### PR DESCRIPTION
See individual commits.

Refs:
https://github.com/packit/packit-service/issues/2992
https://github.com/podman-container-tools/podman/pull/29383

<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Silences testing-farm jobs when the composes are unavailable. This usually happens after an upcoming release branches from rawhide and copr environments are available for packit build jobs, but testing-farm composes haven't been published yet.

#### How to verify it

Can be verified after Fedora 45 branching, but better to get this in before we see testing-farm jobs failing / waiting on unavailable composes.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

None


#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

