### PR TITLE
CI: enable several linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,13 +12,42 @@ formatters:
 
 linters:
   enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - copyloopvar
+    - decorder
+    - durationcheck
+    - errchkjson
+    - exptostd
+    - fatcontext
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - goprintffuncname
+    - grouper
+    - iface
+    - inamedparam
+    - makezero
+    - mirror
+    - misspell
     - modernize
     - nilnesserr
     - nolintlint
+    - nosprintfhostport
+    - protogetter
+    - reassign
+    - recvcheck
     - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - testableexamples
     - unconvert
     - unparam
     - unused
+    - usestdlibvars
+    - usetesting
     - whitespace
   exclusions:
     presets:

--- a/cmd/buildah/commit.go
+++ b/cmd/buildah/commit.go
@@ -408,7 +408,7 @@ func commitCmd(c *cobra.Command, args []string, iopts commitInputOptions) error 
 		options.HistoryTimestamp = &timestamp
 	}
 	if exclusiveFlags > 1 {
-		return errors.New("cannot use more then one timestamp option at at time")
+		return errors.New("cannot use more then one timestamp option at a time")
 	}
 
 	// Add builder identity information.

--- a/cmd/buildah/sftp.go
+++ b/cmd/buildah/sftp.go
@@ -253,7 +253,7 @@ func serveSftpCmd(c *cobra.Command, args []string) error {
 		mountPoint = mp
 	} else {
 		// was not a container, and failed to mount an image
-		return fmt.Errorf("mounting builder container, container, or image %q: %w", toMount, err)
+		return fmt.Errorf("mounting builder container, non-builder container, or image %q: %w", toMount, err)
 	}
 
 	logrus.Debugf("mounted %q, serving sftp", mountPoint)

--- a/docker/types.go
+++ b/docker/types.go
@@ -234,7 +234,7 @@ type V2S2Descriptor struct {
 	Size int64 `json:"size,omitempty"`
 
 	// Digest uniquely identifies the content. A byte stream can be verified
-	// against against this digest.
+	// against this digest.
 	Digest digest.Digest `json:"digest,omitempty"`
 
 	// URLs contains the source URLs of this content.

--- a/image.go
+++ b/image.go
@@ -821,7 +821,7 @@ func (mb *ociManifestBuilder) manifestAndConfig() ([]byte, []byte, error) {
 }
 
 // filterExclusionsByImage returns a slice of the members of "exclusions" which are present in the image with the specified ID
-func (i containerImageRef) filterExclusionsByImage(ctx context.Context, exclusions []copier.EnsureParentPath, imageID string) ([]copier.EnsureParentPath, error) {
+func (i *containerImageRef) filterExclusionsByImage(ctx context.Context, exclusions []copier.EnsureParentPath, imageID string) ([]copier.EnsureParentPath, error) {
 	if len(exclusions) == 0 || imageID == "" {
 		return nil, nil
 	}

--- a/imagebuildah/build.go
+++ b/imagebuildah/build.go
@@ -348,7 +348,7 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options define.B
 	//   multiple platforms ( more than one platform ) and --manifest
 	//   option then this assignment is insignificant since it will be
 	//   overridden anyways with the id and ref of manifest list later in
-	//   in this code.
+	//   this code.
 	//
 	// * Multi-platform build without manifest list: If this is a build for
 	//   multiple platforms without --manifest then we are free to return

--- a/imagebuildah/build_linux_test.go
+++ b/imagebuildah/build_linux_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestFilesClosedProperlyByBuildDockerfiles(t *testing.T) {
-	// create files in in temp dir
+	// create files in temp dir
 	var paths []string
 	for _, name := range []string{"Dockerfile", "Dockerfile.in"} {
 		fpath, err := filepath.Abs(filepath.Join(t.TempDir(), name))

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -689,7 +689,7 @@ func (s *stageExecutor) runStageMountPoints(mountList []string) (map[string]inte
 						return nil, fmt.Errorf("unable to resolve argument %q: %w", val, fromErr)
 					}
 					// If the value corresponds to an additional build context,
-					// the mount source is either either the rootfs of the image,
+					// the mount source is either the rootfs of the image,
 					// the filesystem path, or a temporary directory populated
 					// with the contents of the URL, all in preference to any
 					// stage which might have the value as its name.

--- a/internal/rpc/noop/noop.go
+++ b/internal/rpc/noop/noop.go
@@ -17,7 +17,7 @@ func (n *noopServer) Noop(_ context.Context, req *pb.NoopRequest) (*pb.NoopRespo
 		return nil, syscall.EINVAL
 	}
 	resp := &pb.NoopResponse{}
-	resp.Ignored = req.Ignored
+	resp.Ignored = req.GetIgnored()
 	return resp, nil
 }
 

--- a/internal/sanitize/sanitize_test.go
+++ b/internal/sanitize/sanitize_test.go
@@ -197,7 +197,7 @@ func TestSanitizeImageName(t *testing.T) {
 	}
 	mutateDirectory := func(t *testing.T, parentdir, input, replace string) string {
 		t.Helper()
-		tmpdir, err := os.MkdirTemp(parentdir, "directory")
+		tmpdir, err := os.MkdirTemp(parentdir, "directory") //nolint:usetesting
 		require.NoError(t, err, "creating mutated directory")
 		found := false
 		err = filepath.Walk(input, func(path string, info fs.FileInfo, err error) error {
@@ -311,7 +311,7 @@ func TestSanitizeImageName(t *testing.T) {
 	require.NoError(t, os.Mkdir(archiveDir, 0o700), "creating archives directory")
 
 	// create a normal layout somewhere under contextDir
-	goodLayout, err := os.MkdirTemp(subdirsDir, "goodlayout")
+	goodLayout, err := os.MkdirTemp(subdirsDir, "goodlayout") //nolint:usetesting
 	require.NoErrorf(t, err, "creating a known-good OCI layout")
 	diffDigest, blobDigest := generateLayout(t, goodLayout)
 	goodLayoutRef, err := alltransports.ParseImageName("oci:" + goodLayout)
@@ -321,7 +321,7 @@ func TestSanitizeImageName(t *testing.T) {
 	assert.False(t, sus, "check on known-good OCI layout")
 
 	// copy to a directory
-	goodDir, err := os.MkdirTemp(subdirsDir, "gooddir")
+	goodDir, err := os.MkdirTemp(subdirsDir, "gooddir") //nolint:usetesting
 	require.NoErrorf(t, err, "creating a temporary directory to store a good directory")
 	goodDirRef, err := alltransports.ParseImageName("dir:" + goodDir)
 	require.NoErrorf(t, err, "parsing image reference to good directory")

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -83,7 +83,7 @@ func readManifestFromOCIPath(ctx context.Context, sourcePath string) (*specV1.Ma
 	return readManifestFromImageSource(ctx, ociSource)
 }
 
-// openOrCreateSourceImage returns an OCI types.ImageDestination of the the
+// openOrCreateSourceImage returns an OCI types.ImageDestination of the
 // specified `sourcePath`.  Note that if the path doesn't exist, it'll be
 // created along with the OCI directory layout.
 func openOrCreateSourceImage(ctx context.Context, sourcePath string) (types.ImageDestination, error) {

--- a/internal/tmpdir/tmpdir_test.go
+++ b/internal/tmpdir/tmpdir_test.go
@@ -11,32 +11,28 @@ import (
 )
 
 func TestGetTempDir(t *testing.T) {
-	t.Parallel()
 	// test default
 	err := os.Unsetenv("TMPDIR")
 	require.NoError(t, err)
-	err = os.Setenv("CONTAINERS_CONF", "/dev/null")
-	require.NoError(t, err)
+	t.Setenv("CONTAINERS_CONF", "/dev/null")
 	tmpdir := GetTempDir()
 	assert.Equal(t, "/var/tmp", tmpdir)
 
 	// test TMPDIR Environment
-	err = os.Setenv("TMPDIR", "/tmp/bogus")
-	require.NoError(t, err)
+	t.Setenv("TMPDIR", "/tmp/bogus")
 	tmpdir = GetTempDir()
 	assert.Equal(t, tmpdir, "/tmp/bogus")
 	err = os.Unsetenv("TMPDIR")
 	require.NoError(t, err)
 
 	// relative TMPDIR should be automatically converted to absolute
-	err = os.Setenv("TMPDIR", ".")
-	require.NoError(t, err)
+	t.Setenv("TMPDIR", ".")
 	tmpdir = GetTempDir()
 	assert.True(t, filepath.IsAbs(tmpdir), "path from GetTempDir should always be absolute")
 	err = os.Unsetenv("TMPDIR")
 	require.NoError(t, err)
 
-	f, err := os.CreateTemp("", "containers.conf-")
+	f, err := os.CreateTemp(t.TempDir(), "containers.conf-")
 	require.NoError(t, err)
 	// close and remove the temporary file at the end of the program
 	defer f.Close()
@@ -45,8 +41,7 @@ func TestGetTempDir(t *testing.T) {
 	_, err = f.Write(data)
 	require.NoError(t, err)
 
-	err = os.Setenv("CONTAINERS_CONF", f.Name())
-	require.NoError(t, err)
+	t.Setenv("CONTAINERS_CONF", f.Name())
 	// force config reset of default containers.conf
 	options := config.Options{
 		SetDefault: true,

--- a/pkg/blobcache/blobcache.go
+++ b/pkg/blobcache/blobcache.go
@@ -19,7 +19,7 @@ type BlobCache interface {
 	types.ImageReference
 	// HasBlob checks if a blob that matches the passed-in digest (and
 	// size, if not -1), is present in the cache.
-	HasBlob(types.BlobInfo) (bool, int64, error)
+	HasBlob(blobInfo types.BlobInfo) (bool, int64, error)
 	// Directories returns the list of cache directories.
 	Directory() string
 	// ClearCache() clears the contents of the cache directories.  Note

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,7 +1,6 @@
 package util //nolint:revive,nolintlint
 
 import (
-	"os"
 	"strconv"
 	"testing"
 
@@ -45,8 +44,7 @@ func TestMergeEnv(t *testing.T) {
 }
 
 func TestRuntime(t *testing.T) {
-	t.Parallel()
-	os.Setenv("CONTAINERS_CONF", "/dev/null")
+	t.Setenv("CONTAINERS_CONF", "/dev/null")
 	conf, _ := config.Default()
 	defaultRuntime := conf.Engine.OCIRuntime
 	runtime := Runtime()
@@ -54,7 +52,7 @@ func TestRuntime(t *testing.T) {
 		t.Fatalf("expected %v, got %v", runtime, defaultRuntime)
 	}
 	defaultRuntime = "myoci"
-	os.Setenv("BUILDAH_RUNTIME", defaultRuntime)
+	t.Setenv("BUILDAH_RUNTIME", defaultRuntime)
 	runtime = Runtime()
 	if runtime != defaultRuntime {
 		t.Fatalf("expected %v, got %v", runtime, defaultRuntime)


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Enable the "asasalint", "asciicheck", "bidichk", "bodyclose", "copyloopvar", "decorder", "durationcheck", "errchkjson", "exptostd", "fatcontext", "gocheckcompilerdirectives", "gochecksumtype", "goprintffuncname", "grouper", "iface", "inamedparam", "makezero", "mirror", "misspell", "nosprintfhostport", "protogetter", "reassign", "recvcheck", "rowserrcheck", "sqlclosecheck", "staticcheck", "testableexamples", "usestdlibvars", and "usetesting" linters in the configuration used in CI and by the "make lint" target.

Fix a few things that they complained about.

#### How to verify it

Updated CI configuration!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```