### PR TITLE
docs(login): note --tls-verify needs = for false

### DIFF
--- a/docs/buildah-login.1.md
+++ b/docs/buildah-login.1.md
@@ -56,15 +56,14 @@ Take the password from stdin
 
 **--tls-verify**
 
-Require HTTPS and verification of certificates when talking to container registries (default: true). If explicitly set to true,
-then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
-TLS verification cannot be used when talking to an insecure registry.
-
-This is a boolean flag. Use the `=` form when passing a value (for example
-`--tls-verify=false`). A bare `--tls-verify` is treated as true; a space-separated
-form such as `--tls-verify false` is not accepted (the word after the flag is
-parsed as a registry name).
+Require HTTPS and certificate verification when talking to container registries
+(default: true). As this is a boolean value, use the `=` form when passing a
+value, for example `--tls-verify=false`. A bare `--tls-verify` is treated as
+true; a space-separated form such as `--tls-verify false` is not accepted (the
+word after the flag is parsed as a registry name). If not specified, TLS
+verification is used unless the target registry is listed as an insecure
+registry in registries.conf. TLS verification cannot be used when talking to an
+insecure registry.
 
 **--username**, **-u**
 

--- a/docs/buildah-login.1.md
+++ b/docs/buildah-login.1.md
@@ -61,6 +61,11 @@ then TLS verification will be used. If set to false, then TLS verification will 
 TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
 TLS verification cannot be used when talking to an insecure registry.
 
+This is a boolean flag. Use the `=` form when passing a value (for example
+`--tls-verify=false`). A bare `--tls-verify` is treated as true; a space-separated
+form such as `--tls-verify false` is not accepted (the word after the flag is
+parsed as a registry name).
+
 **--username**, **-u**
 
 Username for registry


### PR DESCRIPTION
`--tls-verify` is a bool flag, so a bare `--tls-verify` means true and `--tls-verify false` is not a value assignment (the next token is treated as the registry). The examples already use `--tls-verify=false`; spelled that out next to the option so it is less surprising.

Fixes #6375