### PR TITLE
Add initial commit-using-multiple-layers implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mattn/go-shellwords v1.0.14
 	github.com/moby/buildkit v0.31.2
+	github.com/moby/docker-image-spec v1.3.1
 	github.com/moby/go-archive v0.2.0
 	github.com/moby/moby/client v0.5.1
 	github.com/moby/sys/capability v0.4.0
@@ -97,7 +98,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.49 // indirect
 	github.com/miekg/pkcs11 v1.1.2 // indirect
 	github.com/mistifyio/go-zfs/v4 v4.0.0 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect

--- a/internal/ops/commit.go
+++ b/internal/ops/commit.go
@@ -1,0 +1,759 @@
+package ops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"slices"
+	"time"
+
+	_ "github.com/moby/docker-image-spec/specs-go/v1" // docker+oci format
+	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	imgspec "github.com/opencontainers/image-spec/specs-go"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+	"go.podman.io/buildah/copier"
+	"go.podman.io/buildah/define"
+	"go.podman.io/buildah/docker"
+	"go.podman.io/buildah/internal/tmpdir"
+	"go.podman.io/image/v5/manifest"
+	"go.podman.io/image/v5/types"
+	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/ioutils"
+)
+
+// configDigestToImageID converts a config digest to an image ID.
+// FIXME: for algorithms other than SHA256, the method used here is just a guess, and this function
+// should be replaced, and callers to this function updated, once we figure out how we're going to
+// handle other digest algorithms.
+func configDigestToImageID(configDigest digest.Digest) string {
+	if configDigest.Algorithm() == digest.SHA256 {
+		return configDigest.Encoded()
+	}
+	return digest.SHA256.FromBytes([]byte(configDigest.String())).Encoded()
+}
+
+// CommitOptions provides options for the Commit() function.  Most of what might have been
+// provided by Commit() before should now be handled by the Export() function.
+type CommitOptions struct {
+	Names            []string
+	ImageAnnotations map[string]string // annotations to set in the image's manifest
+	OCIMediaTypes    bool              // use OCI MediaType values instead of v2s2 MediaType values
+	DigestAlgorithm  digest.Algorithm  // use when computing diffIDs for the config and layer digests for the manifest
+}
+
+// buildImageInfoWithLayerSpecs() builds the configuration and manifest blobs for the image
+// described by the passed-in arguments, using the passed-in configBlob as a starting point, but
+// overwriting its rootfs field.
+// Returns the digest of the configuration blob and an ImageOptions structure
+// which includes the configuration and manifest blobs as big data items.
+// The configuration and manifest will describe the layers in layerSpecs.
+func buildImageInfoWithLayerSpecs(configBlob []byte, layerSpecs LayerSpecs, layerType, configType, manifestType string, options CommitOptions) (imageID string, configDigest digest.Digest, imageOptions *storage.ImageOptions, err error) {
+	// Start with the passed-in image configuration, whatever its format.
+	if len(configBlob) == 0 {
+		configBlob = []byte("{}")
+	}
+	config := make(map[string]any)
+	if err := json.Unmarshal(configBlob, &config); err != nil {
+		return "", "", nil, fmt.Errorf("decoding original configuration blob: %w", err)
+	}
+
+	// Build the config blob with this layer chain's diffIDs as a RootFS.
+	var configDiffIDs []digest.Digest
+	var configDiffSizes []int64
+	for i, layerSpec := range layerSpecs {
+		switch layerSpec.Type {
+		case LayerSourceTypeLayer:
+			layerID := layerSpec.LayerID
+			diffID := layerSpec.LayerDigest
+			if err := diffID.Validate(); err != nil {
+				return "", "", nil, fmt.Errorf("diff ID for layer %q (layer chain %d) not known: %w", layerID, i, err)
+			}
+			var diffSize int64
+			if layerSpec.LayerDiffSize != nil {
+				diffSize = *layerSpec.LayerDiffSize
+			} else {
+				return "", "", nil, fmt.Errorf("diff size for layer %q (layer chain %d) not known", layerID, i)
+			}
+			configDiffIDs = append(configDiffIDs, diffID)
+			configDiffSizes = append(configDiffSizes, diffSize)
+		case LayerSourceTypeDirectory:
+			directory := layerSpec.Directory
+			diffID := layerSpec.DirectoryDigest
+			if err := diffID.Validate(); err != nil {
+				return "", "", nil, fmt.Errorf("diff ID for directory %q (layer chain %d) not known: %w", directory, i, err)
+			}
+			var diffSize int64
+			if layerSpec.DirectoryDiffSize != nil {
+				diffSize = *layerSpec.DirectoryDiffSize
+			} else {
+				return "", "", nil, fmt.Errorf("diff size for directory %q (layer chain %d) not known", directory, i)
+			}
+			configDiffIDs = append(configDiffIDs, diffID)
+			configDiffSizes = append(configDiffSizes, diffSize)
+		default:
+			return "", "", nil, fmt.Errorf("unhandled layer source type %s", layerSpec.Type.String())
+		}
+	}
+	config["rootfs"] = imgspecv1.RootFS{
+		Type:    docker.TypeLayers,
+		DiffIDs: configDiffIDs,
+	}
+	config[define.Package] = define.Version // a little something non-standard that'll be filtered out if we try to "export"
+	configForStorage, err := json.Marshal(config)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("re-encoding configuration blob with updated layer information: %w", err)
+	}
+	configDigest = options.DigestAlgorithm.FromBytes(configForStorage)
+
+	// Build a manifest using the just-marshaled config.
+	rawManifest := imgspecv1.Manifest{
+		Versioned: imgspec.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: manifestType,
+		Config: imgspecv1.Descriptor{
+			Digest:    configDigest,
+			Size:      int64(len(configForStorage)),
+			MediaType: configType,
+		},
+		Annotations: maps.Clone(options.ImageAnnotations),
+	}
+	for i, diffID := range configDiffIDs {
+		rawManifest.Layers = append(rawManifest.Layers, imgspecv1.Descriptor{
+			Digest:      diffID,
+			Size:        configDiffSizes[i],
+			MediaType:   layerType,
+			Annotations: layerSpecs[i].Annotations,
+		})
+	}
+	manifestForStorage, err := json.Marshal(rawManifest)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encoding manifest for image: %w", err)
+	}
+	manifestForStorageDigest := options.DigestAlgorithm.FromBytes(manifestForStorage)
+
+	// Set up the big data items we're going to want to save along with the new image record.
+	imageOptions = &storage.ImageOptions{
+		CreationDate: time.Now(),
+		BigData: []storage.ImageBigDataOption{
+			{
+				Key:    configDigest.String(),
+				Data:   configForStorage,
+				Digest: configDigest,
+			},
+			{
+				Key:    storage.ImageDigestManifestBigDataNamePrefix + "-" + manifestForStorageDigest.String(),
+				Data:   manifestForStorage,
+				Digest: manifestForStorageDigest,
+			},
+			{
+				Key:    storage.ImageDigestManifestBigDataNamePrefix,
+				Data:   manifestForStorage,
+				Digest: manifestForStorageDigest,
+			},
+		},
+	}
+
+	return configDigestToImageID(configDigest), configDigest, imageOptions, nil
+}
+
+// validateMediaTypes supplies a corresponding layer, config, or manifest
+// MediaType when we know at least one such value, or a default if we know none
+// of them
+func validateMediaTypes(layerType, configType, manifestType string) (string, string, string, error) {
+	if configType == "" && manifestType == "" && layerType == "" {
+		layerType, configType, manifestType = imgspecv1.MediaTypeImageLayer, imgspecv1.MediaTypeImageConfig, imgspecv1.MediaTypeImageManifest
+	}
+	if layerType == "" {
+		switch manifestType {
+		case imgspecv1.MediaTypeImageManifest:
+			layerType = imgspecv1.MediaTypeImageLayer
+		case manifest.DockerV2Schema2MediaType:
+			layerType = manifest.DockerV2SchemaLayerMediaTypeUncompressed
+		case "":
+			switch configType {
+			case imgspecv1.MediaTypeImageConfig:
+				layerType = imgspecv1.MediaTypeImageLayer
+			case manifest.DockerV2Schema2ConfigMediaType:
+				layerType = manifest.DockerV2SchemaLayerMediaTypeUncompressed
+			default:
+				return "", "", "", fmt.Errorf("no layerType specified, and could not guess based on no manifest type and config type %q", configType)
+			}
+		default:
+			return "", "", "", fmt.Errorf("no layerType specified, and could not guess based on manifest type %q", manifestType)
+		}
+	}
+	if configType == "" {
+		switch manifestType {
+		case imgspecv1.MediaTypeImageManifest:
+			configType = imgspecv1.MediaTypeImageConfig
+		case manifest.DockerV2Schema2MediaType:
+			configType = manifest.DockerV2Schema2ConfigMediaType
+		case "":
+			switch layerType {
+			case imgspecv1.MediaTypeImageLayer, imgspecv1.MediaTypeImageLayerGzip, imgspecv1.MediaTypeImageLayerZstd:
+				configType = imgspecv1.MediaTypeImageConfig
+			case manifest.DockerV2Schema2LayerMediaType, manifest.DockerV2SchemaLayerMediaTypeUncompressed, manifest.DockerV2SchemaLayerMediaTypeZstd:
+				configType = manifest.DockerV2Schema2ConfigMediaType
+			default:
+				return "", "", "", fmt.Errorf("no configType specified, and could not guess based on no manifest type and layer type %q", layerType)
+			}
+		default:
+			return "", "", "", fmt.Errorf("no configType specified, and could not guess based on manifest type %q", manifestType)
+		}
+	}
+	if manifestType == "" {
+		switch configType {
+		case imgspecv1.MediaTypeImageConfig:
+			manifestType = imgspecv1.MediaTypeImageManifest
+		case manifest.DockerV2Schema2ConfigMediaType:
+			manifestType = manifest.DockerV2Schema2MediaType
+		case "":
+			switch layerType {
+			case imgspecv1.MediaTypeImageLayer, imgspecv1.MediaTypeImageLayerGzip, imgspecv1.MediaTypeImageLayerZstd:
+				manifestType = imgspecv1.MediaTypeImageManifest
+			case manifest.DockerV2Schema2LayerMediaType, manifest.DockerV2SchemaLayerMediaTypeUncompressed, manifest.DockerV2SchemaLayerMediaTypeZstd:
+				manifestType = manifest.DockerV2Schema2MediaType
+			default:
+				return "", "", "", fmt.Errorf("no manifestType specified, and could not guess based on no config type and layer type %q", layerType)
+			}
+		default:
+			return "", "", "", fmt.Errorf("no manifestType specified, and could not guess based on config type %q", configType)
+		}
+	}
+	return layerType, configType, manifestType, nil
+}
+
+// BuildImageInfo creates the information that we'd need to commit a new image using the list of
+// layers whose IDs or names or locations in the filesystem are in layerSpecs (in the order given),
+// the passed-in configuration blob, and a manifest type.  The diffIDs for the layers will be
+// calculated and implanted/replaced as we go, and represented in the manifest.
+// Returns the top layer's ID, the digest of the config blob, image options which contain the config
+// blob and manifest, and a list of layer IDs which can be removed on successful commit.
+func buildImageInfo(ctx context.Context, sys *types.SystemContext, store storage.Store, layerSpecs LayerSpecs, configBlob []byte, layerType, configType, manifestType string, options CommitOptions) (imageID, leafLayer string, configDigest digest.Digest, imageOptions *storage.ImageOptions, disposableLayers []string, returnErr error) {
+	var err error
+	if configType == "" && manifestType == "" {
+		if options.OCIMediaTypes {
+			configType = imgspecv1.MediaTypeImageConfig
+			manifestType = imgspecv1.MediaTypeImageManifest
+		} else {
+			configType = manifest.DockerV2Schema2ConfigMediaType
+			manifestType = manifest.DockerV2Schema2MediaType
+		}
+	}
+	if layerType, configType, manifestType, err = validateMediaTypes(layerType, configType, manifestType); err != nil {
+		return "", "", "", nil, nil, err
+	}
+	if sys == nil {
+		sys = &types.SystemContext{}
+	}
+	if options.DigestAlgorithm == "" {
+		options.DigestAlgorithm = digest.Canonical
+	}
+	layerSpecs = slices.Clone(layerSpecs)
+	// Walk the passed-in list of layer IDs.  They may all be parent-child links in a single
+	// chain, but layers added for the sake of "COPY --link" and similar may just show up in
+	// there anywhere.  This means we have to walk all of their chains to be sure we've found
+	// them all.
+	layers := make(map[string]*storage.Layer)
+	for _, layerSpec := range layerSpecs {
+		switch layerSpec.Type {
+		case LayerSourceTypeLayer:
+			thisLayerID := layerSpec.LayerID
+			layerLineage := []string{thisLayerID}
+			for thisLayerID != "" {
+				// Only bother pulling up information about a given layer once.  If
+				// we already visited it for a previous entry in the layerIDs list,
+				// we don't need to do it again.
+				if _, seen := layers[thisLayerID]; !seen {
+					layer, err := store.Layer(thisLayerID)
+					if err != nil {
+						return "", "", "", nil, nil, fmt.Errorf("did not find layer with ID or name %q (lineage %v): %w", thisLayerID, layerLineage, err)
+					}
+					layers[thisLayerID] = layer
+				}
+				layer := layers[thisLayerID]
+				// Walk up to the next link in this layer's parents chain.
+				layerLineage = append([]string{thisLayerID}, layerLineage...)
+				thisLayerID = layer.Parent
+			}
+		case LayerSourceTypeDirectory:
+			// we're not caching any info about them, so nothing to do for directories
+		default:
+			return "", "", "", nil, nil, fmt.Errorf("unhandled layer source type %s", layerSpec.Type.String())
+		}
+	}
+	// Construct the image info.
+	var leafLayerID string
+	if len(layerSpecs) == 0 {
+		// "Image has no layers" is the simplest case.
+		imageID, configDigest, imageOptions, err = buildImageInfoWithLayerSpecs(configBlob, layerSpecs, layerType, configType, manifestType, options)
+		if err != nil {
+			return "", "", "", nil, nil, fmt.Errorf("calculating info for image: %w", err)
+		}
+	} else {
+		var temporaryDir string
+		// setupTemporaryDir: a helper to create and clean up a temporary directory for
+		// holding temporary copies of layer blobs.
+		setupTemporaryDir := func() (string, error) {
+			var setupTemporaryParent bool
+			if temporaryDir == "" {
+				temporaryDir = sys.BigFilesTemporaryDir
+				setupTemporaryParent = true
+			}
+			if temporaryDir == "" {
+				temporaryDir = tmpdir.GetTempDir()
+				setupTemporaryParent = true
+			}
+			if temporaryDir == "" {
+				return "", errors.New("unable to determine location for storing temporary files")
+			}
+			if setupTemporaryParent {
+				temporaryDir, err = os.MkdirTemp(temporaryDir, "buildah-commit")
+				if err != nil {
+					return "", fmt.Errorf("creating temporary directory for layer blobs under %q: %w", sys.BigFilesTemporaryDir, err)
+				}
+			}
+			return temporaryDir, nil
+		}
+		defer func() {
+			if temporaryDir != "" {
+				returnErr = errors.Join(returnErr, os.RemoveAll(temporaryDir))
+			}
+		}()
+		// For each layer that should be a part of this image, make sure we have the
+		// information required to build a manifest descriptor for it.
+		diffSizesByLayerID := make(map[string]int64)
+		diffIDsByLayerID := make(map[string]digest.Digest)
+		diffSizesByDirectory := make(map[string]int64)
+		diffIDsByDirectory := make(map[string]digest.Digest)
+		diffSizesByDiffID := make(map[digest.Digest]int64)
+		var layerChainDigests []digest.Digest
+		var layerChain []string
+		var chainParentID string
+		for i := range layerSpecs {
+			select {
+			case <-ctx.Done():
+				return "", "", "", nil, nil, ctx.Err()
+			default:
+			}
+			var diffID digest.Digest
+			var diffSize int64
+			var getLayerFileName func() (string, error)
+
+			switch layerSpecs[i].Type {
+			case LayerSourceTypeLayer:
+				layerID := layerSpecs[i].LayerID
+				// saveLayerFile: a helper to save a layer's contents to a temporary
+				// file and return the temporary file's name, the new file's digest,
+				// and its size.
+				saveLayerFile := func(layerID string) (string, digest.Digest, int64, error) {
+					temporaryDir, err := setupTemporaryDir()
+					if err != nil {
+						return "", "", -1, err
+					}
+					f, err := os.CreateTemp(temporaryDir, "buildah-commit-")
+					if err != nil {
+						return "", "", -1, fmt.Errorf("creating temporary file to hold copy of diff for layer with ID or name %q: %w", layerID, err)
+					}
+					layerFileName := f.Name()
+					var rc io.ReadCloser
+					select {
+					case <-ctx.Done():
+						err = ctx.Err()
+						return "", "", -1, errors.Join(fmt.Errorf("generating diff for layer with ID or name %q: %w", layerID, err), f.Close())
+					case readCloserOrError, ok := <-diffContext(ctx, store, "", layerID, nil):
+						if !ok {
+							return "", "", -1, errors.Join(fmt.Errorf("generating diff for layer with ID or name %q: unknown error", layerID), f.Close())
+						}
+						if readCloserOrError.err != nil {
+							return "", "", -1, errors.Join(fmt.Errorf("generating diff for layer with ID or name %q: %w", layerID, readCloserOrError.err), f.Close())
+						}
+						rc = readCloserOrError.readCloser
+					}
+					digester := options.DigestAlgorithm.Digester()
+					counter := ioutils.NewWriteCounter(io.MultiWriter(digester.Hash(), f))
+					n, copyErr := io.Copy(counter, rc)
+					if n != counter.Count {
+						panic("internal error: two byte counts that should be the same are not")
+					}
+					if copyErr != nil {
+						copyErr = fmt.Errorf("digesting and counting size of diff for layer with ID or name %q: %w", layerID, copyErr)
+					}
+					return layerFileName, digester.Digest(), counter.Count, errors.Join(copyErr, rc.Close(), f.Close())
+				}
+				// a helper to save a layer's contents to a temporary file and
+				// return the temporary file's name, cache the diff's digest and
+				// size, and update the local maps that hold that information.
+				getLayerFileName = func() (string, error) {
+					tempLayerFileName, layerDigest, layerSize, err := saveLayerFile(layerID)
+					if err != nil {
+						return "", err
+					}
+					diffIDsByLayerID[layerID] = layerDigest
+					diffSizesByLayerID[layerID] = layerSize
+					diffSizesByDiffID[layerDigest] = layerSize
+					getLayerFileName = func() (string, error) { return tempLayerFileName, nil } //nolint:unparam
+					layerDigests := map[digest.Algorithm]digest.Digest{layerDigest.Algorithm(): layerDigest}
+					return tempLayerFileName, writeLayerInfoCache(store, layerID, layerDigests, layerSize)
+				}
+				// Check if we already know the digest and size of the layer's
+				// contents.
+				layer := layers[layerID]
+				var knowDiffID, knowDiffSize bool
+				diffID, knowDiffID = diffIDsByLayerID[layer.ID]
+				diffSize, knowDiffSize = diffSizesByLayerID[layer.ID]
+				if knowDiffID && knowDiffSize {
+					// Looks like we computed and cached these already for this
+					// layer, probably a repeat of the layer?
+					diffSizesByDiffID[diffID] = diffSize
+				} else {
+					// use prerecorded or cached values if we're not going to mess with the contents
+					if layer.UncompressedDigest.Validate() == nil && layer.UncompressedSize != -1 {
+						// These were already recorded for this layer by the storage
+						// library, reused from another completed build?
+						diffIDsByLayerID[layer.ID] = layer.UncompressedDigest
+						diffSizesByLayerID[layer.ID] = layer.UncompressedSize
+						diffSizesByDiffID[layer.UncompressedDigest] = layer.UncompressedSize
+					} else {
+						// If we previously cached these values for the layer
+						// (either here or as part of another build), read them.
+						if err := readLayerInfoCache(store, layer.ID, diffIDsByLayerID, diffSizesByLayerID, diffSizesByDiffID, nil, options.DigestAlgorithm); err != nil {
+							// We didn't previously cache these values for the
+							// layer, so we'll need to determine them for this
+							// layer now instead of later.
+							if _, err := getLayerFileName(); err != nil {
+								return "", "", "", nil, nil, err
+							}
+						}
+					}
+				}
+				var ok bool
+				diffID, ok = diffIDsByLayerID[layerID]
+				if !ok {
+					return "", "", "", nil, nil, fmt.Errorf("should have a digest for layer %q, but don't?", layer.ID)
+				}
+				diffSize, ok = diffSizesByLayerID[layerID]
+				if !ok {
+					return "", "", "", nil, nil, fmt.Errorf("should have a diff size layer %q, but don't?", layer.ID)
+				}
+				layerSpecs[i].LayerDigest = diffID
+				layerSpecs[i].LayerDiffSize = &diffSize
+			case LayerSourceTypeDirectory:
+				directory := layerSpecs[i].Directory
+				// saveDirectory: a helper to save a directory's contents to a
+				// temporary file and return the temporary file's name, the diff's
+				// digest, and its size.
+				saveDirectory := func() (string, digest.Digest, int64, error) {
+					temporaryDir, err := setupTemporaryDir()
+					if err != nil {
+						return "", "", -1, err
+					}
+					f, err := os.CreateTemp(temporaryDir, "buildah-commit-")
+					if err != nil {
+						return "", "", -1, fmt.Errorf("creating temporary file to hold contents of %q: %w", directory, err)
+					}
+					archiveFileName := f.Name()
+					digester := options.DigestAlgorithm.Digester()
+					counter := ioutils.NewWriteCounter(io.MultiWriter(digester.Hash(), f))
+					err = copier.Get(directory, directory, copier.GetOptions{}, []string{"."}, counter)
+					if err != nil {
+						return "", "", -1, errors.Join(fmt.Errorf("generating archive for directory at %q: %w", directory, err), f.Close())
+					}
+					return archiveFileName, digester.Digest(), counter.Count, f.Close()
+				}
+				// a helper to save a directory's contents to a temporary file and
+				// return the temporary file's name and update the local maps that
+				// hold that information.
+				getLayerFileName = func() (string, error) {
+					tempFileName, directoryDigest, directorySize, err := saveDirectory()
+					if err != nil {
+						return "", err
+					}
+					diffIDsByDirectory[directory] = directoryDigest
+					diffSizesByDirectory[directory] = directorySize
+					diffSizesByDiffID[diffID] = diffSize
+					getLayerFileName = func() (string, error) { return tempFileName, nil } //nolint:unparam
+					return tempFileName, nil
+				}
+				var knowDiffID, knowDiffSize bool
+				diffID, knowDiffID = diffIDsByDirectory[directory]
+				diffSize, knowDiffSize = diffSizesByDirectory[directory]
+				if knowDiffID && knowDiffSize {
+					// Looks like we computed and cached these already for this
+					// directory, probably a repeat of its contents?
+					diffSizesByDiffID[diffID] = diffSize
+				} else {
+					// We need to calculate these figures, so buffer the
+					// directory's contents now instead of later.
+					if _, err := getLayerFileName(); err != nil {
+						return "", "", "", nil, nil, err
+					}
+				}
+				var ok bool
+				diffID, ok = diffIDsByDirectory[directory]
+				if !ok {
+					return "", "", "", nil, nil, fmt.Errorf("should have a digest for directory %q, but don't?", directory)
+				}
+				diffSize, ok = diffSizesByDirectory[directory]
+				if !ok {
+					return "", "", "", nil, nil, fmt.Errorf("should have a diff size directory %q, but don't?", directory)
+				}
+				layerSpecs[i].DirectoryDigest = diffID
+				layerSpecs[i].DirectoryDiffSize = &diffSize
+			}
+
+			// Check if there is already a layer with the chain ID we'd expect to
+			// generate from this layer's contents and the contents of its parents.
+			layerChainDigests = append(layerChainDigests, diffID)
+			chainID := identity.ChainID(layerChainDigests).Encoded()
+			_, err = store.Layer(chainID)
+			var layerFileName string
+			if err != nil && errors.Is(err, storage.ErrLayerUnknown) {
+				// There's not already a layer that has the right contents with the
+				// right ID, so if we didn't already (re?)generate the layer diff,
+				// we need to make that happen now.
+				var saveErr error
+				layerFileName, saveErr = getLayerFileName()
+				if saveErr != nil {
+					return "", "", "", nil, nil, saveErr
+				}
+				// Create a new layer with the right chain ID using the temporary
+				// file with the layer's contents.
+				layerOptions := &storage.LayerOptions{
+					OriginalDigest:     diffID,
+					OriginalSize:       &diffSize,
+					UncompressedDigest: diffID,
+				}
+				f, openErr := os.Open(layerFileName)
+				if openErr != nil {
+					return "", "", "", nil, nil, fmt.Errorf("reading temporary copy of layer: %w", openErr)
+				}
+				layerDigests := map[digest.Algorithm]digest.Digest{diffID.Algorithm(): diffID}
+				opt, optErr := encodeLayerInfoCache(chainID, layerDigests, diffSize)
+				if optErr != nil {
+					return "", "", "", nil, nil, fmt.Errorf("setting up to save cache info for layer %q: %w", chainID, errors.Join(optErr, f.Close()))
+				}
+				layerOptions.BigData = append(layerOptions.BigData, opt)
+				select {
+				case <-ctx.Done():
+					err = errors.Join(ctx.Err(), f.Close())
+				case layerAndSizeOrError, ok := <-putLayerContext(ctx, store, chainID, chainParentID, nil, "", false, layerOptions, f):
+					if !ok {
+						err = errors.Join(fmt.Errorf("writing new layer %q with contents from %q: unknown error", chainID, chainID), f.Close())
+					} else if layerAndSizeOrError.err != nil {
+						err = errors.Join(fmt.Errorf("writing new layer %q with contents from %q: %w", chainID, chainID, layerAndSizeOrError.err), f.Close())
+					} else {
+						newLayer := layerAndSizeOrError.layer
+						err = errors.Join(readLayerInfoCache(store, newLayer.ID, diffIDsByLayerID, diffSizesByLayerID, diffSizesByDiffID, layerDigests, options.DigestAlgorithm), f.Close())
+					}
+				}
+			} else if err == nil {
+				layerDigests := map[digest.Algorithm]digest.Digest{diffID.Algorithm(): diffID}
+				err = readLayerInfoCache(store, chainID, diffIDsByLayerID, diffSizesByLayerID, diffSizesByDiffID, layerDigests, options.DigestAlgorithm)
+			}
+			// If we buffered the diff contents to a file, we don't need them any more,
+			// and not letting them pile up may be the difference between running out of
+			// disk space, or not.
+			if layerFileName != "" {
+				if removeErr := os.Remove(layerFileName); removeErr != nil {
+					return "", "", "", nil, nil, errors.Join(err, fmt.Errorf("cleaning up temporary copy of layer %q: %w", chainID, removeErr))
+				}
+			}
+			if err != nil {
+				return "", "", "", nil, nil, fmt.Errorf("ensuring layer with chain ID %q for layer: %w", chainID, err)
+			}
+			if layerSpecs[i].Type == LayerSourceTypeLayer && chainID != layerSpecs[i].LayerID {
+				// we should clean up this temporary layer at some point
+				disposableLayers = append(disposableLayers, layerSpecs[i].LayerID)
+			}
+			// Append this layer's ID to the layer list that we're reconstructing.
+			layerChain = append(layerChain, chainID)
+			chainParentID = chainID
+		}
+		imageID, configDigest, imageOptions, err = buildImageInfoWithLayerSpecs(configBlob, layerSpecs, layerType, configType, manifestType, options)
+		if err != nil {
+			return "", "", "", nil, nil, fmt.Errorf("calculating info for image with layer chain %v, diffIDsByLayerID %v, diffSizesByLayerID %v: %w", layerChain, diffIDsByLayerID, diffSizesByLayerID, err)
+		}
+		leafLayerID = layerChain[len(layerChain)-1]
+	}
+	return imageID, leafLayerID, configDigest, imageOptions, disposableLayers, nil
+}
+
+func digestDataItem(algorithmHint digest.Digest) func([]byte) (digest.Digest, error) {
+	if algorithmHint.Validate() == nil {
+		return func(item []byte) (digest.Digest, error) { return algorithmHint.Algorithm().FromBytes(item), nil }
+	}
+	return func(item []byte) (digest.Digest, error) { return digest.Canonical.FromBytes(item), nil }
+}
+
+// LayerSpecs are used to tell Commit() where to get layer contents.
+type (
+	LayerSpecs []LayerSpec
+	LayerSpec  struct {
+		LayerSource
+		Annotations map[string]string // annotations for this layer's entry in the manifest
+	}
+)
+
+// LayerSource describes where a single layer's contents should be found.
+type LayerSource struct {
+	Type              LayerSourceType // "LayerSourceTypeLayer" or "LayerSourceTypeDirectory"
+	LayerID           string          // a layer in storage
+	LayerDigest       digest.Digest   // the digest of a diff of that layer
+	LayerDiffSize     *int64          // the size of the same diff of that layer
+	Directory         string          // a directory out on the filesystem
+	DirectoryDigest   digest.Digest   // the digest of an archive of that directory
+	DirectoryDiffSize *int64          // the size of the same archive of that directory
+}
+
+// LayerSourceType is used to determine which fields in a LayerSource matter.
+type LayerSourceType int
+
+const (
+	LayerSourceTypeLayer     = LayerSourceType(0) // a layer in storage
+	LayerSourceTypeDirectory = LayerSourceType(1) // a directory on the filesystem
+)
+
+// String() returns the name of the type, or a generic "unknown layer" string
+func (t LayerSourceType) String() string {
+	switch t {
+	case LayerSourceTypeLayer:
+		return "layer"
+	case LayerSourceTypeDirectory:
+		return "directory"
+	default:
+		return fmt.Sprintf("unknown layer source type %d", int(t))
+	}
+}
+
+// Valid() returns true if the type is a recognized value
+func (t LayerSourceType) Valid() bool {
+	switch t {
+	case LayerSourceTypeLayer, LayerSourceTypeDirectory:
+		return true
+	default:
+		return false
+	}
+}
+
+// Commit creates or updates a new image record using contents of the layers whose IDs or names, and
+// directories whose locations, are in layerSpecs (in the order given), the passed-in configuration
+// blob, and a manifest type.  If the right layers happen to be in place, they will be reused.  The
+// diffIDs for the layers will be calculated and implanted into the configuration, and represented
+// in the manifest.
+func Commit(ctx context.Context, sys *types.SystemContext, store storage.Store, layerSpecs LayerSpecs, configBlob []byte, layerType, configType, manifestType string, options CommitOptions) (*storage.Image, error) {
+	if sys == nil {
+		sys = &types.SystemContext{}
+	}
+	desiredImageID, leafLayerID, configDigest, imageOptions, disposableLayers, err := buildImageInfo(ctx, sys, store, layerSpecs, configBlob, layerType, configType, manifestType, options)
+	if err != nil {
+		return nil, fmt.Errorf("calculating image info: %w", err)
+	}
+	img, err := store.CreateImage(desiredImageID, nil, leafLayerID, "", imageOptions)
+	if err != nil {
+		if !errors.Is(err, storage.ErrDuplicateID) {
+			return nil, fmt.Errorf("creating image record: %w", err)
+		}
+		if imageOptions.Metadata != "" {
+			if err := store.SetMetadata(configDigest.Encoded(), imageOptions.Metadata); err != nil {
+				return nil, fmt.Errorf("updating image metadata for %q: %w", configDigest.Encoded(), err)
+			}
+		}
+		for _, item := range imageOptions.BigData {
+			if err := store.SetImageBigData(configDigest.Encoded(), item.Key, item.Data, digestDataItem(configDigest)); err != nil {
+				return nil, fmt.Errorf("updating image metadata for %q: %w", configDigest.Encoded(), err)
+			}
+		}
+	} else {
+		if img.ID != desiredImageID {
+			return nil, fmt.Errorf("requested image ID not preserved: requested %q, received %q?", desiredImageID, img.ID)
+		}
+	}
+	for _, disposableLayer := range slices.Backward(disposableLayers) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		if err := store.DeleteLayer(disposableLayer); err != nil {
+			logrus.Debugf("not deleting layer %q: %v", disposableLayer, err)
+		}
+	}
+	if len(options.Names) > 0 {
+		if err := store.AddNames(configDigest.Encoded(), options.Names); err != nil {
+			return nil, fmt.Errorf("adding names to image %q: %w", configDigest.Encoded(), err)
+		}
+	}
+	return store.Image(configDigestToImageID(configDigest))
+}
+
+type layerAndSizeOrError struct {
+	layer *storage.Layer
+	n     int64
+	err   error
+}
+
+type readCloserOrError struct {
+	readCloser io.ReadCloser
+	err        error
+}
+
+func putLayerContext(ctx context.Context, store storage.Store, chainID, chainParentID string, names []string, mountLabel string, writeable bool, options *storage.LayerOptions, diff io.Reader) <-chan layerAndSizeOrError {
+	c := make(chan layerAndSizeOrError, 1)
+	go func() {
+		defer close(c)
+		select {
+		case <-ctx.Done():
+			c <- layerAndSizeOrError{
+				err: ctx.Err(),
+			}
+			return
+		default:
+		}
+		newLayer, n, err := store.PutLayer(chainID, chainParentID, names, mountLabel, writeable, options, diff)
+		if err != nil {
+			c <- layerAndSizeOrError{
+				err: err,
+			}
+			return
+		}
+		c <- layerAndSizeOrError{
+			layer: newLayer,
+			n:     n,
+		}
+	}()
+	return c
+}
+
+func diffContext(ctx context.Context, store storage.Store, from, to string, diffOptions *storage.DiffOptions) <-chan readCloserOrError {
+	c := make(chan readCloserOrError, 1)
+	go func() {
+		defer close(c)
+		select {
+		case <-ctx.Done():
+			c <- readCloserOrError{
+				err: ctx.Err(),
+			}
+			return
+		default:
+		}
+		rc, err := store.Diff(from, to, diffOptions)
+		if err != nil {
+			c <- readCloserOrError{
+				err: err,
+			}
+			return
+		}
+		c <- readCloserOrError{
+			readCloser: rc,
+		}
+	}()
+	return c
+}

--- a/internal/ops/commit_test.go
+++ b/internal/ops/commit_test.go
@@ -1,0 +1,251 @@
+package ops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/system"
+	"go.podman.io/storage/types"
+)
+
+func testCreateStorage(t *testing.T) storage.Store {
+	topdir := filepath.Join(t.TempDir(), "storage")
+	root := filepath.Join(topdir, "root")
+	run := filepath.Join(topdir, "runroot")
+	store, err := storage.GetStore(types.StoreOptions{
+		RunRoot:         run,
+		GraphRoot:       root,
+		GraphDriverName: "vfs",
+	})
+	require.NoError(t, err, "initializing test storage")
+	t.Cleanup(func() {
+		t.Log("shutting down storage")
+		mounted, err := store.Shutdown(true)
+		assert.NoError(t, err, "error shutting down test storage")
+		assert.Empty(t, mounted, "list of still-mounted layers")
+		assert.NoError(t, system.EnsureRemoveAll(topdir), "clearing storage")
+		assert.Empty(t, mounted, "expected to not have mounted layers left over in test storage")
+		t.Log("shut down storage")
+	})
+	t.Log("initialized storage")
+	return store
+}
+
+func testCreateSomeLayers(t *testing.T, store storage.Store) LayerSpecs {
+	// create some storage layers in sequence, but without copying their contents to generate diff and size metadata
+	var layerSpecs LayerSpecs
+	var layerList []string
+	for i := range 10 {
+		parentLayer := ""
+		if len(layerList) > 2 && len(layerList)%2 == 1 {
+			parentLayer = layerList[len(layerList)-2]
+		}
+		layer, err := store.CreateLayer("", parentLayer, nil, "", true, &storage.LayerOptions{})
+		require.NoErrorf(t, err, "creating layer %d", i)
+		mountPoint, err := store.Mount(layer.ID, "")
+		require.NoErrorf(t, err, "mounting layer %d", i)
+		err = os.WriteFile(filepath.Join(mountPoint, fmt.Sprintf("layerfile%d.txt", i)), fmt.Appendf(nil, "this is file %d", i), 0o600)
+		require.NoErrorf(t, err, "writing a file to layer %d", i)
+		err = os.WriteFile(filepath.Join(mountPoint, "binary"), fmt.Appendf(nil, "this is file %d", i), 0o755)
+		require.NoErrorf(t, err, `writing a "binary" file to layer %d`, i)
+		_, err = store.Unmount(layer.ID, true)
+		require.NoErrorf(t, err, "unmounting layer %d", i)
+		if parentLayer != "" {
+			t.Logf("created layer %q based on %q", layer.ID, parentLayer)
+		} else {
+			t.Logf("created layer %q", layer.ID)
+		}
+		layerSpecs = append(layerSpecs, LayerSpec{
+			LayerSource: LayerSource{
+				Type:    LayerSourceTypeLayer,
+				LayerID: layer.ID,
+			},
+		})
+		layerList = append(layerList, layer.ID)
+		if i%3 == 0 {
+			tempDir := t.TempDir()
+			tempFile, err := os.Create(filepath.Join(tempDir, fmt.Sprintf("directoryfile%d", i/3)))
+			require.NoError(t, err)
+			_, err = io.Copy(tempFile, strings.NewReader(fmt.Sprintf("this is another file %d", i)))
+			require.NoErrorf(t, err, "writing contents to %q", tempFile)
+			require.NoError(t, tempFile.Close())
+			layerSpecs = append(layerSpecs, LayerSpec{
+				LayerSource: LayerSource{
+					Type:      LayerSourceTypeDirectory,
+					Directory: tempDir,
+				},
+			})
+			t.Logf("created layer in %q", tempDir)
+		}
+	}
+	t.Log("created test layers")
+	return layerSpecs
+}
+
+func testRunTrashImage(t *testing.T, store storage.Store, imageID string) {
+	// don't expect that listing this image (these images?) will work, since there's no data about the size or content of its layers
+	cmd := podmanCommand(t, store, "images")
+	output, err := cmd.CombinedOutput()
+	if errors.Is(err, exec.ErrNotFound) {
+		t.Skip("podman not found")
+	}
+	t.Log("`podman images`:\n" + string(output))
+	require.NoErrorf(t, err, "expected no fatal errors trying to list images with podman:\n%q", string(output))
+
+	// expect that they don't immediately get pruned by a system check
+	cmd = podmanCommand(t, store, "system", "check", "--max=0", "--repair")
+	output, err = cmd.CombinedOutput()
+	if errors.Is(err, exec.ErrNotFound) {
+		t.Skip("podman not found")
+	}
+	t.Log("`podman system check --repair`:\n" + string(output))
+	require.NoErrorf(t, err, "expected no fatal errors repairing storage with podman:\n%q", string(output))
+
+	cmd = podmanCommand(t, store, "images")
+	output, err = cmd.CombinedOutput()
+	if errors.Is(err, exec.ErrNotFound) {
+		t.Skip("podman not found")
+	}
+	t.Log("`podman images`:\n" + string(output))
+	require.NoErrorf(t, err, "expected no fatal errors trying to list images with podman:\n%q", string(output))
+
+	// hope that we can try to run the image, at least as far as attempting to run the entry point
+	cmd = podmanCommand(t, store, "run", "--rm", "--network=host", imageID, "/binary")
+	output, err = cmd.CombinedOutput()
+	t.Log("`podman run` on the new image with a bogus binary:\n" + string(output))
+	assert.Error(t, err, "expected an error trying to run a minimal-but-broken image")
+	assert.Regexp(t, "[Ee]xec format error", err.Error()+"\n"+string(output))
+}
+
+func TestBuildImageInfo(t *testing.T) {
+	for digestAlgorithmNickname, digestAlgorithm := range map[string]digest.Algorithm{
+		"default":   "",
+		"canonical": digest.Canonical,
+		"sha256":    digest.SHA256,
+		// "sha512":    digest.SHA512,
+	} {
+		t.Run(digestAlgorithmNickname, func(t *testing.T) {
+			store := testCreateStorage(t)
+			layerSpecs := testCreateSomeLayers(t, store)
+			t.Logf("calculating image information (layerSpecs= %v)", layerSpecs)
+			_, _, _, _, _, err := buildImageInfo(t.Context(), nil, store, layerSpecs, nil, "", imgspecv1.MediaTypeImageConfig, "", CommitOptions{DigestAlgorithm: digestAlgorithm})
+			require.NoError(t, err, "calculating image info")
+		})
+	}
+}
+
+func TestBuildImageInfoNotFastEnough(t *testing.T) {
+	for digestAlgorithmNickname, digestAlgorithm := range map[string]digest.Algorithm{
+		"default":   "",
+		"canonical": digest.Canonical,
+		"sha256":    digest.SHA256,
+		"sha512":    digest.SHA512,
+	} {
+		t.Run(digestAlgorithmNickname, func(t *testing.T) {
+			store := testCreateStorage(t)
+			layerSpecs := testCreateSomeLayers(t, store)
+			t.Logf("calculating image information (layerSpecs= %v)", layerSpecs)
+			subctx, cancel := context.WithTimeout(t.Context(), (1 * time.Nanosecond))
+			defer cancel()
+			time.Sleep(1 * time.Millisecond)
+			_, _, _, _, _, err := buildImageInfo(subctx, nil, store, layerSpecs, nil, "", imgspecv1.MediaTypeImageConfig, "", CommitOptions{DigestAlgorithm: digestAlgorithm})
+			require.ErrorIs(t, err, context.DeadlineExceeded, "calculating image info")
+		})
+	}
+}
+
+func TestCommitDumb(t *testing.T) {
+	for digestAlgorithmNickname, digestAlgorithm := range map[string]digest.Algorithm{
+		"default":   "",
+		"canonical": digest.Canonical,
+		"sha256":    digest.SHA256,
+		// "sha512":    digest.SHA512,
+	} {
+		t.Run(digestAlgorithmNickname, func(t *testing.T) {
+			store := testCreateStorage(t)
+			layerSpecs := testCreateSomeLayers(t, store)
+			imageID, topLayer, configDigest, imageOptions, disposableLayers, err := buildImageInfo(t.Context(), nil, store, layerSpecs, nil, "", imgspecv1.MediaTypeImageConfig, "", CommitOptions{DigestAlgorithm: digestAlgorithm})
+			require.NoError(t, err, "calculating image info")
+			t.Logf("could dispose of layers: %v", disposableLayers)
+
+			t.Log("creating image record")
+			img, err := store.CreateImage(imageID, nil, topLayer, "", imageOptions)
+			require.NoError(t, err, "committing image directly with CreateImage()")
+			t.Logf("created image %q with config digest %q", img.ID, configDigest.String())
+
+			t.Log("recalculating image information")
+			imageID2, topLayer, configDigest2, imageOptions, disposableLayers2, err := buildImageInfo(t.Context(), nil, store, layerSpecs, nil, "", imgspecv1.MediaTypeImageConfig, "", CommitOptions{DigestAlgorithm: digestAlgorithm})
+			require.NoError(t, err, "recalculating image info")
+			assert.Equal(t, imageID2, imageID, "recalculated image ID should have been the same")
+			assert.Equal(t, configDigest, configDigest2, "recalculated config's digest should have been the same")
+			assert.ElementsMatch(t, disposableLayers, disposableLayers2, "expected to derive the same set of disposable layers")
+			t.Logf("could dispose of layers: %v", disposableLayers2)
+
+			_, err = store.CreateImage(imageID2, nil, topLayer, "", imageOptions)
+			require.ErrorIs(t, err, storage.ErrDuplicateID)
+
+			for _, disposableLayer := range slices.Backward(disposableLayers) {
+				if err := store.DeleteLayer(disposableLayer); err != nil {
+					t.Logf("did not delete layer %q: %v", disposableLayer, err)
+				} else {
+					t.Logf("removed disposable layer %q", disposableLayer)
+				}
+			}
+
+			testRunTrashImage(t, store, img.ID)
+		})
+	}
+}
+
+func TestCommitNotAsDumb(t *testing.T) {
+	for digestAlgorithmNickname, digestAlgorithm := range map[string]digest.Algorithm{
+		"default":   "",
+		"canonical": digest.Canonical,
+		"sha256":    digest.SHA256,
+		// "sha512":    digest.SHA512,
+	} {
+		t.Run(digestAlgorithmNickname, func(t *testing.T) {
+			store := testCreateStorage(t)
+			layerSpecs := testCreateSomeLayers(t, store)
+			img, err := Commit(t.Context(), nil, store, layerSpecs, nil, "", "", "", CommitOptions{DigestAlgorithm: digestAlgorithm})
+			require.NoError(t, err, "committing image via Commit()")
+			t.Logf("committed image %q", img.ID)
+
+			testRunTrashImage(t, store, img.ID)
+		})
+	}
+}
+
+func TestCommitNotAsDumbButNotFastEnough(t *testing.T) {
+	for digestAlgorithmNickname, digestAlgorithm := range map[string]digest.Algorithm{
+		"default":   "",
+		"canonical": digest.Canonical,
+		"sha256":    digest.SHA256,
+		"sha512":    digest.SHA512,
+	} {
+		t.Run(digestAlgorithmNickname, func(t *testing.T) {
+			store := testCreateStorage(t)
+			layerSpecs := testCreateSomeLayers(t, store)
+			subctx, cancel := context.WithTimeout(t.Context(), (1 * time.Nanosecond))
+			defer cancel()
+			time.Sleep(1 * time.Millisecond)
+			img, err := Commit(subctx, nil, store, layerSpecs, nil, "", "", "", CommitOptions{DigestAlgorithm: digestAlgorithm})
+			require.ErrorIs(t, err, context.DeadlineExceeded, "committing image via Commit()")
+			require.Nil(t, img, "committed image?")
+		})
+	}
+}

--- a/internal/ops/ops.go
+++ b/internal/ops/ops.go
@@ -1,0 +1,111 @@
+package ops
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"syscall"
+
+	digest "github.com/opencontainers/go-digest"
+	"go.podman.io/storage"
+)
+
+// buildahExportInfoLayer holds information about a layer and its contents
+type buildahExportInfoLayer struct {
+	LayerID string                             `json:"layer"`   // the ID of the layer described here
+	Digests map[digest.Algorithm]digest.Digest `json:"digests"` // uncompressed digest of the layer named by LayerID
+	Size    int64                              `json:"size"`    // uncompressed size of the diff for the layer named by LayerID
+}
+
+const (
+	buildahExportInfoBigDataKey = "buildah-export-info-v1"
+)
+
+// readLayerInfoCache: a helper to read a cached record of a layer's digest and size
+// from its big data.
+func readLayerInfoCacheRaw(store storage.Store, layerID string) (*buildahExportInfoLayer, error) {
+	rc, err := store.LayerBigData(layerID, buildahExportInfoBigDataKey)
+	if err != nil && !errors.Is(err, syscall.ENOENT) {
+		return nil, err
+	}
+	var exportInfoLayer buildahExportInfoLayer
+	buf, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("reading cached info about layer %q: %w", layerID, errors.Join(err, rc.Close()))
+	}
+	err = json.Unmarshal(buf, &exportInfoLayer)
+	if err != nil {
+		return nil, fmt.Errorf("parsing cached info about layer %q: %w", layerID, errors.Join(err, rc.Close()))
+	}
+	if exportInfoLayer.LayerID != layerID {
+		return nil, fmt.Errorf("validating cached info about layer %q: %w", layerID, errors.Join(err, rc.Close()))
+	}
+	return &exportInfoLayer, rc.Close()
+}
+
+// readLayerInfoCache: a helper to read a cached record of a layer's digest and size
+// from its big data.
+func readLayerInfoCache(store storage.Store, layerID string, diffIDsByLayerID map[string]digest.Digest, diffSizesByLayerID map[string]int64, diffSizesByDiffID map[digest.Digest]int64, digests map[digest.Algorithm]digest.Digest, mustHaveDigestAlgorithm digest.Algorithm) error {
+	exportInfoLayer, err := readLayerInfoCacheRaw(store, layerID)
+	if err != nil {
+		return err
+	}
+	if mustHaveDigestAlgorithm.String() != "" {
+		if _, ok := exportInfoLayer.Digests[mustHaveDigestAlgorithm]; !ok {
+			return fmt.Errorf("cached info about layer %q did not include %q digest: %w", layerID, mustHaveDigestAlgorithm.String(), syscall.ENOENT)
+		}
+		diffIDsByLayerID[layerID] = exportInfoLayer.Digests[mustHaveDigestAlgorithm]
+	} else {
+		for _, v := range exportInfoLayer.Digests {
+			diffIDsByLayerID[layerID] = v
+			if v.Algorithm() == digest.Canonical {
+				break
+			}
+		}
+	}
+	diffSizesByLayerID[layerID] = exportInfoLayer.Size
+	diffSizesByDiffID[exportInfoLayer.Digests[mustHaveDigestAlgorithm]] = exportInfoLayer.Size
+	if digests != nil {
+		maps.Copy(digests, exportInfoLayer.Digests)
+	}
+	return nil
+}
+
+// encodeLayerInfoCache: a helper to encode a cache of a layer's digest and
+// size for storing in its big data.
+func encodeLayerInfoCache(layerID string, layerDigests map[digest.Algorithm]digest.Digest, layerSize int64) (storage.LayerBigDataOption, error) {
+	exportInfoLayer := buildahExportInfoLayer{
+		LayerID: layerID,
+		Digests: layerDigests,
+		Size:    layerSize,
+	}
+	var opt storage.LayerBigDataOption
+	buf, err := json.Marshal(&exportInfoLayer)
+	if err != nil {
+		return opt, fmt.Errorf("encoding info about layer for cache: %w", err)
+	}
+	opt.Key = buildahExportInfoBigDataKey
+	opt.Data = bytes.NewReader(buf)
+	return opt, nil
+}
+
+// writeLayerInfoCache: a helper to write a cache of a layer's digest and size to
+// its big data.
+func writeLayerInfoCache(store storage.Store, layerID string, layerDigests map[digest.Algorithm]digest.Digest, layerSize int64) error {
+	exportInfoLayer := buildahExportInfoLayer{
+		LayerID: layerID,
+		Digests: layerDigests,
+		Size:    layerSize,
+	}
+	buf, err := json.Marshal(&exportInfoLayer)
+	if err != nil {
+		return fmt.Errorf("encoding info about layer for cache: %w", err)
+	}
+	if err := store.SetLayerBigData(layerID, buildahExportInfoBigDataKey, bytes.NewReader(buf)); err != nil {
+		return fmt.Errorf("saving %q for layer with ID or name %q: %w", buildahExportInfoBigDataKey, layerID, err)
+	}
+	return err
+}

--- a/internal/ops/ops_test.go
+++ b/internal/ops/ops_test.go
@@ -1,0 +1,42 @@
+package ops
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/reexec"
+)
+
+func TestMain(m *testing.M) {
+	var logLevel string
+	debug := false
+	if reexec.Init() {
+		return
+	}
+	flag.BoolVar(&debug, "debug", false, "turn on debug logging")
+	flag.StringVar(&logLevel, "log-level", "error", "log level")
+	flag.Parse()
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		logrus.Fatalf("error parsing log level %q: %v", logLevel, err)
+	}
+	if debug && level < logrus.DebugLevel {
+		level = logrus.DebugLevel
+	}
+	logrus.SetLevel(level)
+	os.Exit(m.Run())
+}
+
+func podmanCommand(t *testing.T, store storage.Store, args ...string) *exec.Cmd {
+	storageArgs := []string{
+		"podman",
+		"--storage-driver=" + store.GraphDriverName(),
+		"--root=" + store.GraphRoot(),
+		"--runroot=" + store.RunRoot(),
+	}
+	return exec.CommandContext(t.Context(), storageArgs[0], append(storageArgs[1:], args...)...)
+}

--- a/vendor/github.com/opencontainers/image-spec/identity/chainid.go
+++ b/vendor/github.com/opencontainers/image-spec/identity/chainid.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package identity provides implementations of subtle calculations pertaining
+// to image and layer identity.  The primary item present here is the ChainID
+// calculation used in identifying the result of subsequent layer applications.
+//
+// Helpers are also provided here to ease transition to the
+// github.com/opencontainers/go-digest package, but that package may be used
+// directly.
+package identity
+
+import "github.com/opencontainers/go-digest"
+
+// ChainID takes a slice of digests and returns the ChainID corresponding to
+// the last entry. Typically, these are a list of layer DiffIDs, with the
+// result providing the ChainID identifying the result of sequential
+// application of the preceding layers.
+func ChainID(dgsts []digest.Digest) digest.Digest {
+	chainIDs := make([]digest.Digest, len(dgsts))
+	copy(chainIDs, dgsts)
+	ChainIDs(chainIDs)
+
+	if len(chainIDs) == 0 {
+		return ""
+	}
+	return chainIDs[len(chainIDs)-1]
+}
+
+// ChainIDs calculates the recursively applied chain id for each identifier in
+// the slice. The result is written direcly back into the slice such that the
+// ChainID for each item will be in the respective position.
+//
+// By definition of ChainID, the zeroth element will always be the same before
+// and after the call.
+//
+// As an example, given the chain of ids `[A, B, C]`, the result `[A,
+// ChainID(A|B), ChainID(A|B|C)]` will be written back to the slice.
+//
+// The input is provided as a return value for convenience.
+//
+// Typically, these are a list of layer DiffIDs, with the
+// result providing the ChainID for each the result of each layer application
+// sequentially.
+func ChainIDs(dgsts []digest.Digest) []digest.Digest {
+	if len(dgsts) < 2 {
+		return dgsts
+	}
+
+	parent := digest.FromBytes([]byte(dgsts[0] + " " + dgsts[1]))
+	next := dgsts[1:]
+	next[0] = parent
+	ChainIDs(next)
+
+	return dgsts
+}

--- a/vendor/github.com/opencontainers/image-spec/identity/helpers.go
+++ b/vendor/github.com/opencontainers/image-spec/identity/helpers.go
@@ -1,0 +1,40 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	_ "crypto/sha256" // side-effect to install impls, sha256
+	_ "crypto/sha512" // side-effect to install impls, sha384/sh512
+
+	"io"
+
+	digest "github.com/opencontainers/go-digest"
+)
+
+// FromReader consumes the content of rd until io.EOF, returning canonical
+// digest.
+func FromReader(rd io.Reader) (digest.Digest, error) {
+	return digest.Canonical.FromReader(rd)
+}
+
+// FromBytes digests the input and returns a Digest.
+func FromBytes(p []byte) digest.Digest {
+	return digest.Canonical.FromBytes(p)
+}
+
+// FromString digests the input and returns a Digest.
+func FromString(s string) digest.Digest {
+	return digest.Canonical.FromString(s)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -342,6 +342,7 @@ github.com/opencontainers/cgroups/internal/path
 github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.1.1
 ## explicit; go 1.18
+github.com/opencontainers/image-spec/identity
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.5.1


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

Add an initial method for committing an image given a configuration blob, which may or may not have rootfs information to be replaced, and a list of layer IDs and/or directory locations.

Adds some helper functions for caching and retrieving digest and size information about layers.

#### How to verify it

This currently isn't used anywhere, but it has unit tests.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```