### PR TITLE
parsevolume: fix escape guard and option normalization

### DIFF
--- a/internal/parsevolume/parse.go
+++ b/internal/parsevolume/parse.go
@@ -63,14 +63,14 @@ func Volume(volume string) (specs.Mount, error) {
 	if err := parse.ValidateVolumeCtrDir(arr[1]); err != nil {
 		return mount, err
 	}
-	mountOptions := ""
+	var mountOpts []string
 	if len(arr) > 2 {
-		mountOptions = arr[2]
-		if _, err := parse.ValidateVolumeOpts(strings.Split(arr[2], ",")); err != nil {
+		opts, err := parse.ValidateVolumeOpts(strings.Split(arr[2], ","))
+		if err != nil {
 			return mount, err
 		}
+		mountOpts = opts
 	}
-	mountOpts := strings.Split(mountOptions, ",")
 	mount.Source = arr[0]
 	mount.Destination = arr[1]
 	mount.Type = "rbind"

--- a/internal/parsevolume/parse.go
+++ b/internal/parsevolume/parse.go
@@ -33,7 +33,7 @@ func SplitStringWithColonEscape(str string) []string {
 	for idx, r := range str {
 		if r == ':' {
 			// the colon is backslash-escaped
-			if idx-1 > 0 && str[idx-1] == '\\' {
+			if idx > 0 && str[idx-1] == '\\' {
 				sb.WriteRune(r)
 			} else {
 				// os.Stat will fail if path contains escaped colon

--- a/internal/parsevolume/parse_test.go
+++ b/internal/parsevolume/parse_test.go
@@ -29,3 +29,42 @@ func TestSplitStringWithColonEscape(t *testing.T) {
 		}
 	}
 }
+
+func TestVolume(t *testing.T) {
+	hostDir := t.TempDir()
+
+	tests := []struct {
+		volume      string
+		expectedErr bool
+		options     []string
+	}{
+		{hostDir + ":/ctr", false, nil},
+		{hostDir + ":/ctr:ro", false, []string{"ro"}},
+		{hostDir + ":/ctr:ro,Z", false, []string{"ro", "Z"}},
+		// cached and delegated are documented as silently dropped
+		{hostDir + ":/ctr:cached", false, nil},
+		{hostDir + ":/ctr:ro,delegated", false, []string{"ro"}},
+		{hostDir, true, nil},
+		{hostDir + ":/ctr:ro,rw", true, nil},
+		{"relative/dir:/ctr", true, nil},
+	}
+	for _, test := range tests {
+		mount, err := Volume(test.volume)
+		if test.expectedErr {
+			if err == nil {
+				t.Errorf("Volume(%q) expected an error, got %+v", test.volume, mount)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Volume(%q) unexpected error: %v", test.volume, err)
+			continue
+		}
+		if len(mount.Options) != len(test.options) || !reflect.DeepEqual(append([]string{}, mount.Options...), append([]string{}, test.options...)) {
+			t.Errorf("Volume(%q) options = %v, expected %v", test.volume, mount.Options, test.options)
+		}
+		if mount.Source != hostDir || mount.Destination != "/ctr" {
+			t.Errorf("Volume(%q) source/dest = %q %q", test.volume, mount.Source, mount.Destination)
+		}
+	}
+}

--- a/internal/parsevolume/parse_test.go
+++ b/internal/parsevolume/parse_test.go
@@ -1,0 +1,31 @@
+package parsevolume
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitStringWithColonEscape(t *testing.T) {
+	tests := []struct {
+		volume   string
+		expected []string
+	}{
+		{"/a:/b", []string{"/a", "/b"}},
+		{"/a:/b:ro", []string{"/a", "/b", "ro"}},
+		// escaped colon inside a path
+		{`/a\:b:/c`, []string{"/a:b", "/c"}},
+		{`/a:/b\:c`, []string{"/a", "/b:c"}},
+		// escaped colon as the second character used to be split wrong
+		// because the guard read idx-1 > 0 instead of idx > 0
+		{`\:a:/b`, []string{":a", "/b"}},
+		// unescaped leading colon is a separator, first field is empty
+		{":/a:/b", []string{"", "/a", "/b"}},
+		{"/a", []string{"/a"}},
+	}
+	for _, test := range tests {
+		got := SplitStringWithColonEscape(test.volume)
+		if !reflect.DeepEqual(got, test.expected) {
+			t.Errorf("SplitStringWithColonEscape(%q) = %v, expected %v", test.volume, got, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
I was reading the volume parser and noticed the escape guard in `SplitStringWithColonEscape `checks `idx-1 > 0`, which excludes index 1, so a volume starting with an escaped colon gets split on it anyway:

```
\:foo:/dst  ->  ["\", "foo", "/dst"]   (expected [":foo", "/dst"])
```

Mid-string escapes are unaffected. I don't think this is reachable from the CLI today since the host path has to be absolute, so I am pitching it as correctness plus coverage, not a live bug.

While writing tests for it I also noticed Volume() discards the normalized slice ValidateVolumeOpts returns, so the cached/delegated options that function is documented to silently drop still end up in `mount.Options`, and with no options at all mount.Options comes back as [""] instead of empty.

so the package had no tests, so both commits bring their own here 
cc @lsm5 