### PR TITLE
validate: run the helpers self-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ validate: all lint lint-entrypoint codespell
 	./hack/xref-helpmsgs-manpages
 	./tests/validate/pr-should-include-tests
 	./tests/validate/commit-subject-check.sh $(EPOCH_TEST_COMMIT)..$(HEAD)
+	./tests/helpers.bash.t
 
 .PHONY: lint-entrypoint
 lint-entrypoint: internal/mkcw/embed/entrypoint_amd64.gz


### PR DESCRIPTION
tests/helpers.bash.t is a working self-test for the assert helpers - 31 checks, TAP output, exits nonzero on failure - but as far as I can tell nothing runs it: no Makefile target, no workflow, no mention in test_runner.sh. Its only commit is the one that added it in 2021.

This hooks it into `make validate`, which the CI validate job already runs, so a change that breaks the assert helpers gets caught before it confuses a real test run. podman recently did the same for its hack self-tests.

It runs in under a second and needs no built binaries. To be clear it only covers assert(), so this is just running what already exists, not adding coverage.
