### PR TITLE
chrootuser: do not let one bad line end the lookup

### DIFF
--- a/pkg/chrootuser/user_test.go
+++ b/pkg/chrootuser/user_test.go
@@ -40,3 +40,48 @@ func TestParseNextGroup(t *testing.T) {
 	}
 	assert.Nil(t, parseNextGroup(rc))
 }
+
+// "+::::::" is an NIS compat entry, it has the right number of fields but no uid
+var testPasswdData = `root:x:0:0::/root:/bin/sh
++::::::
+notenoughfields:x:1
+bob:x:1000:1000::/home/bob:/bin/sh
+`
+
+func TestParseNextPasswdSkipsBadLines(t *testing.T) {
+	t.Parallel()
+	// A line we cannot parse must not end the scan, the entries below it
+	// still have to be found.
+	rc := bufio.NewScanner(strings.NewReader(testPasswdData))
+	expected := []lookupPasswdEntry{
+		{"root", 0, 0, "/root"},
+		{"bob", 1000, 1000, "/home/bob"},
+	}
+	for _, exp := range expected {
+		pwd := parseNextPasswd(rc)
+		assert.NotNil(t, pwd)
+		assert.Equal(t, *pwd, exp)
+	}
+	assert.Nil(t, parseNextPasswd(rc))
+}
+
+var testGroupBadData = `root:x:0:
+badgid:x:notanumber:
+notenoughfields:x:1
+wheel:x:10:bob
+`
+
+func TestParseNextGroupSkipsBadLines(t *testing.T) {
+	t.Parallel()
+	rc := bufio.NewScanner(strings.NewReader(testGroupBadData))
+	expected := []lookupGroupEntry{
+		{"root", 0, ""},
+		{"wheel", 10, "bob"},
+	}
+	for _, exp := range expected {
+		grp := parseNextGroup(rc)
+		assert.NotNil(t, grp)
+		assert.Equal(t, *grp, exp)
+	}
+	assert.Nil(t, parseNextGroup(rc))
+}

--- a/pkg/chrootuser/user_unix.go
+++ b/pkg/chrootuser/user_unix.go
@@ -179,6 +179,9 @@ func lookupUserInContainer(rootdir, username string) (uid uint64, gid uint64, er
 		return pwd.uid, pwd.gid, nil
 	}
 
+	if err := rc.Err(); err != nil {
+		return 0, 0, fmt.Errorf("reading /etc/passwd: %w", err)
+	}
 	return 0, 0, user.UnknownUserError(fmt.Sprintf("error looking up user %q", username))
 }
 
@@ -205,6 +208,9 @@ func lookupGroupForUIDInContainer(rootdir string, userid uint64) (username strin
 		return pwd.name, pwd.gid, nil
 	}
 
+	if err := rc.Err(); err != nil {
+		return "", 0, fmt.Errorf("reading /etc/passwd: %w", err)
+	}
 	return "", 0, ErrNoSuchUser
 }
 
@@ -235,6 +241,9 @@ func lookupAdditionalGroupsForUIDInContainer(rootdir string, userid uint64) (gid
 		}
 		grp = parseNextGroup(rc)
 	}
+	if err := rc.Err(); err != nil {
+		return nil, fmt.Errorf("reading /etc/group: %w", err)
+	}
 	return gid, nil
 }
 
@@ -261,6 +270,9 @@ func lookupGroupInContainer(rootdir, groupname string) (gid uint64, err error) {
 		return grp.gid, nil
 	}
 
+	if err := rc.Err(); err != nil {
+		return 0, fmt.Errorf("reading /etc/group: %w", err)
+	}
 	return 0, user.UnknownGroupError(fmt.Sprintf("error looking up group %q", groupname))
 }
 
@@ -287,6 +299,9 @@ func lookupUIDInContainer(rootdir string, uid uint64) (string, uint64, error) {
 		return pwd.name, pwd.gid, nil
 	}
 
+	if err := rc.Err(); err != nil {
+		return "", 0, fmt.Errorf("reading /etc/passwd: %w", err)
+	}
 	return "", 0, user.UnknownUserError(fmt.Sprintf("error looking up uid %d", uid))
 }
 
@@ -313,5 +328,8 @@ func lookupHomedirInContainer(rootdir string, uid uint64) (string, error) {
 		return pwd.home, nil
 	}
 
+	if err := rc.Err(); err != nil {
+		return "", fmt.Errorf("reading /etc/passwd: %w", err)
+	}
 	return "", user.UnknownUserError(fmt.Sprintf("error looking up homedir for uid %d", uid))
 }

--- a/pkg/chrootuser/user_unix.go
+++ b/pkg/chrootuser/user_unix.go
@@ -102,51 +102,57 @@ func scanWithoutComments(rc *bufio.Scanner) (string, bool) {
 	}
 }
 
+// parseNextPasswd returns the next entry it can parse. Lines it cannot parse
+// are skipped, so one bad line does not hide the entries after it. It returns
+// nil at the end of the file and when the scanner failed, so callers need to
+// check rc.Err() to tell those two apart.
 func parseNextPasswd(rc *bufio.Scanner) *lookupPasswdEntry {
-	if !rc.Scan() {
-		return nil
+	for rc.Scan() {
+		fields := strings.Split(rc.Text(), ":")
+		if len(fields) != 7 {
+			continue
+		}
+		uid, err := strconv.ParseUint(fields[2], 10, 32)
+		if err != nil {
+			continue
+		}
+		gid, err := strconv.ParseUint(fields[3], 10, 32)
+		if err != nil {
+			continue
+		}
+		return &lookupPasswdEntry{
+			name: fields[0],
+			uid:  uid,
+			gid:  gid,
+			home: fields[5],
+		}
 	}
-	line := rc.Text()
-	fields := strings.Split(line, ":")
-	if len(fields) != 7 {
-		return nil
-	}
-	uid, err := strconv.ParseUint(fields[2], 10, 32)
-	if err != nil {
-		return nil
-	}
-	gid, err := strconv.ParseUint(fields[3], 10, 32)
-	if err != nil {
-		return nil
-	}
-	return &lookupPasswdEntry{
-		name: fields[0],
-		uid:  uid,
-		gid:  gid,
-		home: fields[5],
-	}
+	return nil
 }
 
+// parseNextGroup behaves like parseNextPasswd, see the comment there.
 func parseNextGroup(rc *bufio.Scanner) *lookupGroupEntry {
-	// On FreeBSD, /etc/group may contain comments:
-	//   https://man.freebsd.org/cgi/man.cgi?query=group&sektion=5&format=html
-	// We need to ignore those lines rather than trying to parse them.
-	line, ok := scanWithoutComments(rc)
-	if !ok {
-		return nil
-	}
-	fields := strings.Split(line, ":")
-	if len(fields) != 4 {
-		return nil
-	}
-	gid, err := strconv.ParseUint(fields[2], 10, 32)
-	if err != nil {
-		return nil
-	}
-	return &lookupGroupEntry{
-		name: fields[0],
-		gid:  gid,
-		user: fields[3],
+	for {
+		// On FreeBSD, /etc/group may contain comments:
+		//   https://man.freebsd.org/cgi/man.cgi?query=group&sektion=5&format=html
+		// We need to ignore those lines rather than trying to parse them.
+		line, ok := scanWithoutComments(rc)
+		if !ok {
+			return nil
+		}
+		fields := strings.Split(line, ":")
+		if len(fields) != 4 {
+			continue
+		}
+		gid, err := strconv.ParseUint(fields[2], 10, 32)
+		if err != nil {
+			continue
+		}
+		return &lookupGroupEntry{
+			name: fields[0],
+			gid:  gid,
+			user: fields[3],
+		}
 	}
 }
 


### PR DESCRIPTION

I was going through the `bufio.Scanner` error checks after Paul's sweep in podman and ended up in chrootuser, where there is a second thing happening first. `parseNextPasswd` returns nil for any line it cannot parse, and all six callers loop `for pwd != nil`, so one bad line hides every entry under it:

```
passwd = root / "+::::::" (NIS compat, 7 fields but no uid) / bob
names the lookup loop reached: [root]
scanner err: <nil>
```

bob is on line 3 and comes back as an unknown user. First commit makes both parsers skip lines they cannot read, which is what the group parser already does for comments.

Second commit is the scanner one. `Scan()` returns false at EOF and on error alike, so a failed read was reported as the user or group simply not existing.

I have not managed to hit this from the CLI, an image would need a `+` line or similar in /etc/passwd, so I am not claiming a live bug report behind it.

#### How to verify it

Both new tests fail on current main:

```
--- FAIL: TestParseNextPasswdSkipsBadLines (0.00s)
    user_test.go:71: got [root], want [root bob]
--- FAIL: TestParseNextGroupSkipsBadLines (0.00s)
    user_test.go:94: got [root], want [root wheel]
```

cc @nalind
