### PR TITLE
Reject checksums for Git ADD sources

### DIFF
--- a/add.go
+++ b/add.go
@@ -583,7 +583,11 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 		var multiErr *multierror.Error
 		var getErr, closeErr, renameErr, putErr error
 		var wg sync.WaitGroup
-		if urlsource.IsRemote(src) || urlsource.IsGit(src) {
+		isGitSource := urlsource.IsGit(src)
+		if urlsource.IsRemote(src) || isGitSource {
+			if isGitSource && options.Checksum != "" {
+				return errors.New("checksum flag is not supported for Git sources")
+			}
 			pipeReader, pipeWriter := io.Pipe()
 			var srcDigest digest.Digest
 			if options.Checksum != "" {
@@ -594,7 +598,7 @@ func (b *Builder) Add(destination string, extract bool, options AddAndCopyOption
 			}
 
 			wg.Add(1)
-			if urlsource.IsGit(src) {
+			if isGitSource {
 				go func() {
 					defer wg.Done()
 					defer pipeWriter.Close()

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -8249,6 +8249,13 @@ _EOF
 
   cat > $contextdir/Dockerfile << _EOF
 FROM scratch
+ADD --checksum=sha256:0000000000000000000000000000000000000000000000000000000000000000 http://0.0.0.0:${HTTP_SERVER_PORT}/git/podman.git#v5.0 /src
+_EOF
+  run_buildah 125 build -f $contextdir/Dockerfile -t git-image $contextdir
+  expect_output --substring "checksum flag is not supported for Git sources"
+
+  cat > $contextdir/Dockerfile << _EOF
+FROM scratch
 ADD http://0.0.0.0:${HTTP_SERVER_PORT}/git/podman.git#nosuchbranch /src
 _EOF
   run_buildah 125 build -f $contextdir/Dockerfile -t git-image $contextdir


### PR DESCRIPTION
## What does this PR do?

Reject `ADD --checksum` when the source is a Git repository.

The flag was parsed successfully for Git sources, but the checksum was never used for verification. The build therefore succeeded as if the flag was not present. This change returns a clear error instead.

A regression case covers a Git HTTP source with a checksum.

## Why?

Silently ignoring a checksum makes a security/integrity control look active when it is not. Failing explicitly is safer until Git checksum verification is implemented.

Fixes #7042

## Testing

- `go test -tags containers_image_openpgp ./imagebuildah`
- `go build -tags containers_image_openpgp ./cmd/buildah`
- Full `go test ./...` was also attempted, but this Windows checkout cannot run the repository's Linux/cgo and Unix-specific test dependencies.
