### PR TITLE
Update golangci-lint to v2.13.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ifeq ($(BUILDDEBUG), 1)
 endif
 
 # Managed by renovate.
-export GOLANGCI_LINT_VERSION := 2.12.2
+export GOLANGCI_LINT_VERSION := 2.13.1
 
 #   make all BUILDDEBUG=1
 #     Note: Uses the -N -l go compiler options to disable compiler optimizations

--- a/chroot/run_linux.go
+++ b/chroot/run_linux.go
@@ -109,7 +109,7 @@ func statFlagNames(flags uintptr) []string {
 	for flag, name := range statFlagMap {
 		if int(flags)&flag == flag {
 			names = append(names, name)
-			flags = flags &^ (uintptr(flag))
+			flags = flags &^ uintptr(flag)
 		}
 	}
 	if flags != 0 { // got some unknown leftovers

--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -155,9 +155,11 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 	dest, err := alltransports.ParseImageName(destSpec)
 	// add the docker:// transport to see if they neglected it.
 	if err != nil {
-		destTransport := strings.Split(destSpec, ":")[0]
-		if t := transports.Get(destTransport); t != nil {
-			return err
+		destTransport, _, destHasSeparator := strings.Cut(destSpec, ":")
+		if destHasSeparator {
+			if t := transports.Get(destTransport); t != nil {
+				return err
+			}
 		}
 
 		if strings.Contains(destSpec, "://") {

--- a/define/namespace.go
+++ b/define/namespace.go
@@ -34,7 +34,7 @@ func (n *NamespaceOptions) Find(namespace string) *NamespaceOption {
 	for i := range *n {
 		j := len(*n) - 1 - i
 		if (*n)[j].Name == namespace {
-			return &((*n)[j])
+			return &(*n)[j]
 		}
 	}
 	return nil

--- a/run_linux.go
+++ b/run_linux.go
@@ -436,7 +436,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		}
 	}
 
-	if !options.NoHostname && !(slices.Contains(volumes, "/etc/hostname")) {
+	if !options.NoHostname && !slices.Contains(volumes, "/etc/hostname") {
 		hostnameFile, err := b.generateHostname(path, spec.Hostname, rootIDPair)
 		if err != nil {
 			return err

--- a/run_linux.go
+++ b/run_linux.go
@@ -1160,8 +1160,6 @@ func (b *Builder) runSetupVolumeMounts(mountLabel string, volumeMounts []string,
 			}
 
 			overlayOpts := overlay.Options{
-				RootUID:                idMaps.rootUID,
-				RootGID:                idMaps.rootGID,
 				UpperDirOptionFragment: upperDir,
 				WorkDirOptionFragment:  workDir,
 				GraphOpts:              slices.Clone(b.store.GraphOptions()),


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Update our version of golangci-lint to v2.13.1 and fix the new things it finds.  Now that 1.27 is released, the v2.12.2 release panics during the validate workflow.

#### How to verify it

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```