### PR TITLE
test(bud): cover symbolic COPY/ADD --chmod

### DIFF
--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4259,9 +4259,11 @@ _EOF
   _prefetch alpine
   imgName=alpine-symbolic-chmod
   run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/copy-chmod-symbolic
-  # u+x,go-rwx on a 0644 source -> 0700; a+rX,go-w keeps an executable 0755
+  # u+x,go-rwx on a 0644 source -> 0700; a+rX,go-w keeps an executable 0755;
+  # a+rX alone on a 0644 source leaves it 0644 (conditional X adds nothing)
   expect_output --substring "sym1:700"
   expect_output --substring "sym2:755"
+  expect_output --substring "sym3:644"
 }
 
 @test "bud with bad symbolic chmod copy" {

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -4255,6 +4255,22 @@ _EOF
   expect_output --substring "chmod:777 user:2367 group:3267"
 }
 
+@test "bud with symbolic chmod copy" {
+  _prefetch alpine
+  imgName=alpine-symbolic-chmod
+  run_buildah build $WITH_POLICY_JSON -t ${imgName} $BUDFILES/copy-chmod-symbolic
+  # u+x,go-rwx on a 0644 source -> 0700; a+rX,go-w keeps an executable 0755
+  expect_output --substring "sym1:700"
+  expect_output --substring "sym2:755"
+}
+
+@test "bud with bad symbolic chmod copy" {
+  _prefetch alpine
+  imgName=alpine-symbolic-chmod
+  run_buildah 125 build $WITH_POLICY_JSON -t ${imgName} -f $BUDFILES/copy-chmod-symbolic/Dockerfile.bad $BUDFILES/copy-chmod-symbolic
+  expect_output --substring "parsing chmod"
+}
+
 @test "bud with chown copy with bad chown flag in Dockerfile with --layers" {
   _prefetch alpine
   imgName=alpine-image

--- a/tests/bud/copy-chmod-symbolic/Dockerfile
+++ b/tests/bud/copy-chmod-symbolic/Dockerfile
@@ -4,7 +4,11 @@ FROM alpine
 COPY --chmod=u+x,go-rwx copychmod.txt /tmp/sym1
 # a+rX,go-w on an executable (0755) script: X keeps the exec bit, 0755
 COPY --chmod=a+rX,go-w copysym.sh /tmp/sym2
+# a+rX on a plain (non-executable, 0644) file: the conditional X adds
+# nothing, the mode stays 0644
+COPY --chmod=a+rX copychmod.txt /tmp/sym3
 
 RUN stat -c "sym1:%a" /tmp/sym1
 RUN stat -c "sym2:%a" /tmp/sym2
+RUN stat -c "sym3:%a" /tmp/sym3
 CMD /bin/sh

--- a/tests/bud/copy-chmod-symbolic/Dockerfile
+++ b/tests/bud/copy-chmod-symbolic/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+
+# u+x,go-rwx on a plain (non-executable, 0644) source file: 0644 -> 0700
+COPY --chmod=u+x,go-rwx copychmod.txt /tmp/sym1
+# a+rX,go-w on an executable (0755) script: X keeps the exec bit, 0755
+COPY --chmod=a+rX,go-w copysym.sh /tmp/sym2
+
+RUN stat -c "sym1:%a" /tmp/sym1
+RUN stat -c "sym2:%a" /tmp/sym2
+CMD /bin/sh

--- a/tests/bud/copy-chmod-symbolic/Dockerfile
+++ b/tests/bud/copy-chmod-symbolic/Dockerfile
@@ -1,12 +1,18 @@
+# Stage 0 pins the fixtures' starting modes with octal --chmod, which is
+# absolute: the CI runner's umask (002 on checkout, group-writable files)
+# cannot leak into what the stage-1 COPY --from clauses resolve against.
 FROM alpine
+COPY --chmod=644 copychmod.txt /fixtures/copychmod.txt
+COPY --chmod=755 copysym.sh /fixtures/copysym.sh
 
-# u+x,go-rwx on a plain (non-executable, 0644) source file: 0644 -> 0700
-COPY --chmod=u+x,go-rwx copychmod.txt /tmp/sym1
+FROM alpine
+# u+x,go-rwx on a plain (0644) source file: 0644 -> 0700
+COPY --from=0 --chmod=u+x,go-rwx /fixtures/copychmod.txt /tmp/sym1
 # a+rX,go-w on an executable (0755) script: X keeps the exec bit, 0755
-COPY --chmod=a+rX,go-w copysym.sh /tmp/sym2
+COPY --from=0 --chmod=a+rX,go-w /fixtures/copysym.sh /tmp/sym2
 # a+rX on a plain (non-executable, 0644) file: the conditional X adds
 # nothing, the mode stays 0644
-COPY --chmod=a+rX copychmod.txt /tmp/sym3
+COPY --from=0 --chmod=a+rX /fixtures/copychmod.txt /tmp/sym3
 
 RUN stat -c "sym1:%a" /tmp/sym1
 RUN stat -c "sym2:%a" /tmp/sym2

--- a/tests/bud/copy-chmod-symbolic/Dockerfile.bad
+++ b/tests/bud/copy-chmod-symbolic/Dockerfile.bad
@@ -1,0 +1,5 @@
+FROM alpine
+
+COPY --chmod=rwxrwxrwx copychmod.txt /tmp/
+
+CMD /bin/sh

--- a/tests/bud/copy-chmod-symbolic/copychmod.txt
+++ b/tests/bud/copy-chmod-symbolic/copychmod.txt
@@ -1,0 +1,1 @@
+plain fixture file for symbolic chmod test

--- a/tests/bud/copy-chmod-symbolic/copysym.sh
+++ b/tests/bud/copy-chmod-symbolic/copysym.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo symbolic chmod fixture


### PR DESCRIPTION
Upstream main already vendors imagebuilder v1.2.22 (#7068), the release tag containing openshift/imagebuilder#324, so the original vendor bump is no longer needed. What remains, and what this PR now adds, is bud coverage so the regression cannot come back silently:

## What
- `tests/bud/copy-chmod-symbolic`: a Containerfile exercising symbolic `COPY --chmod` forms (`u+x,go-rwx` on a 0644 file -> 0700; `a+rX,go-w` on a 0755 script -> 0755, capital `X` keeping the exec bit) plus a `Dockerfile.bad` asserting the still-invalid bare `rwxrwxrwx` form fails with `Error parsing chmod`.
- Two `bud.bats` cases wiring those fixtures.

## Why
`checkChmodConversion` rejected every symbolic value at dispatch time before openshift/imagebuilder#324 (root cause of #6938); the executor was already symbolic-aware. With the fix vendored via v1.2.22, these tests pin both the accepted clause forms and the rejected ones at the layer that used to regress.

Fixes #6938 (test coverage; the functional fix is v1.2.22 vendored in #7068).