### PR TITLE
docs: fix buildah pull --policy value from newer to ifnewer

### DIFF
--- a/docs/buildah-pull.1.md
+++ b/docs/buildah-pull.1.md
@@ -70,14 +70,14 @@ and can also be found by running `go tool dist list`.
 
 **NOTE:** The `--platform` option may not be used in combination with the `--arch`, `--os`, or `--variant` options.
 
-**--policy**=**always**|**missing**|**never**|**newer**
+**--policy**=**always**|**missing**|**never**|**ifnewer**
 
 Pull image policy. The default is **missing**.
 
 - **always**: Always pull the image and throw an error if the pull fails.
 - **missing**: Pull the image only if it could not be found in the local containers storage.  Throw an error if no image could be found and the pull fails.
 - **never**: Never pull the image but use the one from the local containers storage.  Throw an error if no image could be found.
-- **newer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
+- **ifnewer**: Pull if the image on the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
 
 **--quiet**, **-q**
 


### PR DESCRIPTION
buildah-pull.1.md documented `--policy=newer`, but `cmd/buildah/pull.go` validates the policy against `define.PolicyMap`, which only supports `ifnewer`. As a result, `--policy=newer` is rejected at runtime with `unsupported pull policy`, while `--policy=ifnewer` works as expected.

This PR corrects the `buildah-pull` man page to document the supported `ifnewer` policy value.

#### What this PR does / why we need it:

Updates the `buildah-pull.1.md` documentation to use `ifnewer` instead of `newer` for the `--policy` option. This brings the documentation in line with the behavior implemented in `cmd/buildah/pull.go` and prevents users from following an invalid example.

#### How to verify it

```console
$ buildah pull --policy newer <image>
Error: unsupported pull policy "newer"

$ buildah pull --policy ifnewer <image>
# succeeds
```

Verify that the corrected `--policy` value in `buildah-pull.1.md` matches the values supported by `define.PolicyMap` in `cmd/buildah/pull.go`.

#### Which issue(s) this PR fixes:

Fixes #6992

#### Special notes for your reviewer:

The `--pull` flag used by `buildah build` and `buildah from` is separate and already accepts both `newer` and `ifnewer` as synonyms. This PR only corrects the `--policy` documentation for `buildah pull`.

#### Does this PR introduce a user-facing change?

No. This change only corrects the documentation; runtime behavior is unchanged.

```release-note
None
```
