### PR TITLE
imagebuildah: add --no-cache-filter for per-stage cache control

### DIFF
--- a/define/build.go
+++ b/define/build.go
@@ -304,6 +304,10 @@ type BuildOptions struct {
 	// NoCache tells the builder to build the image from scratch without checking for a cache.
 	// It creates a new set of cached images for the build.
 	NoCache bool
+	// NoCacheFilter is a list of stage names or indices for which the cache should not be
+	// used, even when NoCache is false. Named stages not present in this list can still use
+	// the cache. Mirrors "docker buildx build --no-cache-filter".
+	NoCacheFilter []string
 	// RemoveIntermediateCtrs tells the builder whether to remove intermediate containers used
 	// during the build process. Default is true.
 	RemoveIntermediateCtrs bool

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -724,6 +724,15 @@ Valid _mode_ values are:
 
 Do not use existing cached images for the container build. Build from the start with a new set of cached layers.
 
+**--no-cache-filter** *stage*
+
+Do not use existing cached images for the named or numbered build *stage*, regardless of whether **--no-cache** is set.
+Stages not named by **--no-cache-filter** may still use the cache. Only has an effect when **--layers** is used, since
+caching is not performed on a per-stage basis otherwise. May be specified multiple times.
+
+Note: if a stage's name is identical to another stage's numeric position (for example, a stage literally named "1"),
+a value passed to **--no-cache-filter** may match both.
+
 **--no-hostname**
 
 Do not create the _/etc/hostname_ file in the container for RUN instructions.

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -131,6 +131,7 @@ type executor struct {
 	noHostname                              bool
 	noHosts                                 bool
 	useCache                                bool
+	noCacheFilter                           map[string]struct{} // stage names/indices for which cache lookups are always skipped
 	removeIntermediateCtrs                  bool
 	forceRmIntermediateCtrs                 bool
 	imageMap                                map[int]string              // Used to map from stage indexes to images that we create to be used in a later FROM...AS construct.  Serialized by stagesLock.
@@ -280,6 +281,11 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		wrappedAdditionalBuildContexts[name] = &additionalBuildContext{AdditionalBuildContext: *ctx}
 	}
 
+	noCacheFilter := make(map[string]struct{}, len(options.NoCacheFilter))
+	for _, stageNameOrIndex := range options.NoCacheFilter {
+		noCacheFilter[stageNameOrIndex] = struct{}{}
+	}
+
 	exec := executor{
 		args:                                    options.Args,
 		cacheFrom:                               options.CacheFrom,
@@ -342,6 +348,7 @@ func newExecutor(logger *logrus.Logger, logPrefix string, store storage.Store, o
 		noHostname:                              options.CommonBuildOpts.NoHostname,
 		noHosts:                                 options.CommonBuildOpts.NoHosts,
 		useCache:                                !options.NoCache,
+		noCacheFilter:                           noCacheFilter,
 		removeIntermediateCtrs:                  options.RemoveIntermediateCtrs,
 		forceRmIntermediateCtrs:                 options.ForceRmIntermediateCtrs,
 		imageMap:                                make(map[int]string),
@@ -1244,6 +1251,19 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 		}
 		slices.Sort(unusedList)
 		fmt.Fprintf(b.out, "[Warning] one or more build args were not consumed: %v\n", unusedList)
+	}
+
+	if len(b.noCacheFilter) > 0 {
+		unusedList := make([]string, 0, len(b.noCacheFilter))
+		for stageNameOrIndex := range b.noCacheFilter {
+			if _, ok := dependencyMap[stageNameOrIndex]; !ok {
+				unusedList = append(unusedList, stageNameOrIndex)
+			}
+		}
+		if len(unusedList) > 0 {
+			slices.Sort(unusedList)
+			fmt.Fprintf(b.out, "[Warning] one or more --no-cache-filter values did not match any stage: %v\n", unusedList)
+		}
 	}
 
 	// Add additional tags and print image names recorded in storage

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1279,12 +1279,23 @@ func (s *stageExecutor) getContentSummaryAfterAddingContent() string {
 	return summary
 }
 
+// stageMatchesNoCacheFilter reports whether a stage, identified by its name (the
+// alias given after "AS", or the stringified position if it has none) or its
+// numeric position, was named in a --no-cache-filter argument.
+func stageMatchesNoCacheFilter(noCacheFilter map[string]struct{}, stageName string, stagePosition int) bool {
+	return internalUtil.SetHas(noCacheFilter, stageName) || internalUtil.SetHas(noCacheFilter, strconv.Itoa(stagePosition))
+}
+
 // Execute runs each of the steps in the stage's parsed tree, in turn.
 func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string, commitResults *buildah.CommitResults, onlyBaseImg bool, err error) {
 	var resourceUsage rusage.Rusage
 	stage := s.stage
 	ib := stage.Builder
-	checkForLayers := s.executor.layers && s.executor.useCache
+	stageNoCache := stageMatchesNoCacheFilter(s.executor.noCacheFilter, stage.Name, stage.Position)
+	checkForLayers := s.executor.layers && s.executor.useCache && !stageNoCache
+	if stageNoCache {
+		logrus.Debugf("not checking for cached layers for stage %q (%d): matched --no-cache-filter", stage.Name, stage.Position)
+	}
 	moreStages := s.index < len(s.stages)-1
 	lastStage := !moreStages
 	onlyBaseImage := false

--- a/imagebuildah/stage_executor_test.go
+++ b/imagebuildah/stage_executor_test.go
@@ -99,3 +99,56 @@ func TestHistoryEntriesEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestStageMatchesNoCacheFilter(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description   string
+		noCacheFilter map[string]struct{}
+		stageName     string
+		stagePosition int
+		matches       bool
+	}{
+		{
+			description:   "empty filter never matches",
+			noCacheFilter: map[string]struct{}{},
+			stageName:     "build",
+			stagePosition: 0,
+			matches:       false,
+		},
+		{
+			description:   "matches by stage name",
+			noCacheFilter: map[string]struct{}{"build": {}},
+			stageName:     "build",
+			stagePosition: 0,
+			matches:       true,
+		},
+		{
+			description:   "matches by numeric position",
+			noCacheFilter: map[string]struct{}{"1": {}},
+			stageName:     "1",
+			stagePosition: 1,
+			matches:       true,
+		},
+		{
+			description:   "unrelated name in filter does not match",
+			noCacheFilter: map[string]struct{}{"other": {}},
+			stageName:     "build",
+			stagePosition: 0,
+			matches:       false,
+		},
+		{
+			description:   "named stage not matched by its numeric position alone",
+			noCacheFilter: map[string]struct{}{"2": {}},
+			stageName:     "build",
+			stagePosition: 0,
+			matches:       false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			matches := stageMatchesNoCacheFilter(tc.noCacheFilter, tc.stageName, tc.stagePosition)
+			assert.Equal(t, tc.matches, matches, tc.description)
+		})
+	}
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -468,6 +468,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		MaxPullPushRetries:      iopts.Retry,
 		NamespaceOptions:        namespaceOptions,
 		NoCache:                 iopts.NoCache,
+		NoCacheFilter:           iopts.NoCacheFilter,
 		OS:                      systemContext.OSChoice,
 		OSFeatures:              iopts.OSFeatures,
 		OSVersion:               iopts.OSVersion,

--- a/pkg/cli/common.go
+++ b/pkg/cli/common.go
@@ -92,6 +92,7 @@ type BudResults struct {
 	NoHostname             bool
 	NoHosts                bool
 	NoCache                bool
+	NoCacheFilter          []string
 	Timestamp              int64
 	OmitHistory            bool
 	OCIHooksDir            []string
@@ -285,6 +286,7 @@ func GetBudFlags(flags *BudResults) pflag.FlagSet {
 	fs.StringVar(&flags.Manifest, "manifest", "", "add the image to the specified manifest list. Creates manifest list if it does not exist")
 	fs.StringVar(&flags.MetadataFile, "metadata-file", "", "`file` to write metadata about the image to")
 	fs.BoolVar(&flags.NoCache, "no-cache", false, "do not use existing cached images for the container build. Build from the start with a new set of cached layers.")
+	fs.StringArrayVar(&flags.NoCacheFilter, "no-cache-filter", []string{}, "do not use existing cached images for the specified build `stage`(s). May be used multiple times.")
 	fs.BoolVar(&flags.NoHostname, "no-hostname", false, "do not create new /etc/hostname file for RUN instructions, use the one from the base image.")
 	fs.BoolVar(&flags.NoHosts, "no-hosts", false, "do not create new /etc/hosts file for RUN instructions, use the one from the base image.")
 	fs.String("os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
@@ -384,6 +386,7 @@ func GetBudFlagsCompletions() commonComp.FlagCompletions {
 	flagCompletion["os"] = commonComp.AutocompleteNone
 	flagCompletion["os-feature"] = commonComp.AutocompleteNone
 	flagCompletion["os-version"] = commonComp.AutocompleteNone
+	flagCompletion["no-cache-filter"] = commonComp.AutocompleteNone
 	flagCompletion["output"] = commonComp.AutocompleteNone
 	flagCompletion["pull"] = commonComp.AutocompleteDefault
 	flagCompletion["runtime-flag"] = commonComp.AutocompleteNone

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -2741,6 +2741,76 @@ _EOF
 
 }
 
+@test "bud with --no-cache-filter" {
+  _prefetch alpine
+
+  local contextdir="${TEST_SCRATCH_DIR}/no-cache-filter"
+  mkdir -p "$contextdir"
+  cat > "$contextdir/Containerfile" << _EOF
+FROM alpine AS base
+RUN echo base-stage
+FROM base AS final
+RUN echo final-stage
+_EOF
+
+  local target="no-cache-filter-test-$(safename)"
+
+  # First build: populate the cache for both stages.
+  run_buildah build $WITH_POLICY_JSON --layers -t "${target}-first" -f "$contextdir/Containerfile" "$contextdir"
+
+  # Second build, no filter applied: both stages' RUN steps should hit cache.
+  run_buildah build $WITH_POLICY_JSON --layers -t "${target}-second" -f "$contextdir/Containerfile" "$contextdir"
+  base_cached=$(echo "$output" | grep -A1 "RUN echo base-stage" | grep -c "Using cache" || true)
+  final_cached=$(echo "$output" | grep -A1 "RUN echo final-stage" | grep -c "Using cache" || true)
+  assert "$base_cached" -eq 1 "base stage should hit cache when --no-cache-filter is not used"
+  assert "$final_cached" -eq 1 "final stage should hit cache when --no-cache-filter is not used"
+
+  # Third build, filtering the "final" stage by name: only "base" should still hit cache.
+  run_buildah build $WITH_POLICY_JSON --layers --no-cache-filter=final -t "${target}-third" -f "$contextdir/Containerfile" "$contextdir"
+  base_cached=$(echo "$output" | grep -A1 "RUN echo base-stage" | grep -c "Using cache" || true)
+  final_cached=$(echo "$output" | grep -A1 "RUN echo final-stage" | grep -c "Using cache" || true)
+  assert "$base_cached" -eq 1 "base stage should still hit cache when 'final' is passed to --no-cache-filter"
+  assert "$final_cached" -eq 0 "final stage should NOT hit cache when 'final' is passed to --no-cache-filter"
+
+  # Fourth build, filtering by the "final" stage's numeric position (1): should behave
+  # the same as filtering by name, confirming position 1 maps to "final".
+  run_buildah build $WITH_POLICY_JSON --layers --no-cache-filter=1 -t "${target}-fourth" -f "$contextdir/Containerfile" "$contextdir"
+  base_cached=$(echo "$output" | grep -A1 "RUN echo base-stage" | grep -c "Using cache" || true)
+  final_cached=$(echo "$output" | grep -A1 "RUN echo final-stage" | grep -c "Using cache" || true)
+  assert "$base_cached" -eq 1 "base stage (position 0) should still hit cache when position 1 is passed to --no-cache-filter"
+  assert "$final_cached" -eq 0 "final stage (position 1) should NOT hit cache, confirming position 1 maps to 'final'"
+
+  # Fifth build, passing --no-cache-filter twice (repeatable flag): neither stage should hit cache.
+  run_buildah build $WITH_POLICY_JSON --layers --no-cache-filter=base --no-cache-filter=final -t "${target}-fifth" -f "$contextdir/Containerfile" "$contextdir"
+  base_cached=$(echo "$output" | grep -A1 "RUN echo base-stage" | grep -c "Using cache" || true)
+  final_cached=$(echo "$output" | grep -A1 "RUN echo final-stage" | grep -c "Using cache" || true)
+  assert "$base_cached" -eq 0 "base stage should NOT hit cache when --no-cache-filter is passed multiple times covering both stages"
+  assert "$final_cached" -eq 0 "final stage should NOT hit cache when --no-cache-filter is passed multiple times covering both stages"
+}
+
+@test "bud with --no-cache-filter without --layers" {
+  _prefetch alpine
+
+  local contextdir="${TEST_SCRATCH_DIR}/no-cache-filter-no-layers"
+  mkdir -p "$contextdir"
+  cat > "$contextdir/Containerfile" << _EOF
+FROM alpine AS base
+RUN echo base-stage
+FROM base AS final
+RUN echo final-stage
+_EOF
+
+  local target="no-cache-filter-no-layers-test-$(safename)"
+
+  run_buildah build $WITH_POLICY_JSON -t "$target" -f "$contextdir/Containerfile" "$contextdir"
+
+  # Without --layers, per-stage cache lookups never happen at all, so
+  # --no-cache-filter should be a pure no-op: no "Using cache" output,
+  # same as a build without the flag.
+  run_buildah build $WITH_POLICY_JSON --no-cache-filter=final -t "$target" -f "$contextdir/Containerfile" "$contextdir"
+  assert "$output" !~ "Using cache" "no per-stage cache messages should appear without --layers, even with --no-cache-filter set"
+}
+
 @test "build --unsetenv PATH" {
   _prefetch alpine
   mytmpdir=${TEST_SCRATCH_DIR}/my-dir


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

 /kind feature
 
#### What this PR does / why we need it:

`buildah build` only supports `--no-cache`, which disables caching for the entire build. This adds `--no-cache-filter <stage>` (repeatable, matches by stage name or numeric position), mirroring `docker buildx build --no-cache-filter`. It lets a build skip cache lookups for one or more specific stages while still using cache normally for the rest - useful when only one stage (e.g. a `dnf update` or the final app-copy stage) needs to always rebuild fresh.

#### How to verify it

by the new unit test: `go test ./imagebuildah/ -run TestStageMatchesNoCacheFilter -v`

#### Which issue(s) this PR fixes:

Fixes #7072

#### Does this PR introduce a user-facing change?

```
Add `--no-cache-filter` to `buildah build` for disabling cache on specific build stages.
```

