### PR TITLE
docs: fix typos and phrasing in man pages

### DIFF
--- a/docs/buildah-images.1.md
+++ b/docs/buildah-images.1.md
@@ -33,16 +33,16 @@ Filter output based on conditions provided (default []).
     Filter on images created before the given image.
 
   **dangling=true|false**
-    Show dangling images. An images is considered to be dangling if it has no associated names and tags.
+    Show dangling images. An image is considered to be dangling if it has no associated names and tags.
 
   **id=id**
     Show image with this specific ID.
 
   **intermediate=true|false**
-    Show intermediate images. An images is considered to be an indermediate image if it is dangling and has no children.
+    Show intermediate images. An image is considered to be an intermediate image if it is dangling and has no children.
 
   **label=key[=value]**
-    Filter by images labels key and/or value.
+    Filter by image labels key and/or value.
 
   **readonly=true|false**
     Show only read only images or Read/Write images. The default is to show both.  Read/Only images can be configured by modifying the  "additionalimagestores" in the /etc/containers/storage.conf file.

--- a/docs/buildah-push.1.md
+++ b/docs/buildah-push.1.md
@@ -8,7 +8,7 @@ buildah\-push - Push an image, manifest list or image index from local storage t
 
 ## DESCRIPTION
 Pushes an image from local storage to a specified destination, decompressing
-and recompessing layers as needed.
+and recompressing layers as needed.
 
 ## imageID
 Image stored in local container/storage

--- a/docs/buildah-source-add.1.md
+++ b/docs/buildah-source-add.1.md
@@ -7,7 +7,7 @@ buildah\-source\-add - Add a source artifact to a source image
 **buildah source add** [*options*] *path* *artifact*
 
 ## DESCRIPTION
-Add add a source artifact to a source image.  The artifact will be added as a
+Add a source artifact to a source image.  The artifact will be added as a
 gzip-compressed tar ball.  Add attempts to auto-tar and auto-compress only if
 necessary.
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This PR fixes typos, duplicated words, and grammatical phrasing in documentation man pages:

- **`docs/buildah-images.1.md`**:
  - Fix `An images` -> `An image` for dangling and intermediate filter descriptions.
  - Fix typo `indermediate` -> `intermediate`.
  - Fix `Filter by images labels` -> `Filter by image labels`.
- **`docs/buildah-push.1.md`**:
  - Fix typo `recompessing` -> `recompressing`.
- **`docs/buildah-source-add.1.md`**:
  - Fix duplicate word `Add add` -> `Add`.

#### How to verify it:
Review the updated files in `docs/`:
- `docs/buildah-images.1.md`
- `docs/buildah-push.1.md`
- `docs/buildah-source-add.1.md`

#### Which issue(s) this PR fixes:
fixes #7075 

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
```release-note
None
