### PR TITLE
Updating the incorrect resetting logic for multi-stage builds

### DIFF
--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1115,18 +1115,27 @@ func (s *stageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 	// In a multi-stage build where `FROM --platform=<>` was used then we must
 	// reset context for new stages so that new stages don't inherit unexpected
 	// `--platform` from prior stages.
-	if stage.Builder.Platform != "" || (len(s.stages) > 1 && (s.systemContext.ArchitectureChoice == "" && s.systemContext.VariantChoice == "" && s.systemContext.OSChoice == "")) {
-		imageOS, imageArch, imageVariant, err := parse.Platform(stage.Builder.Platform)
+	effectivePlatform := stage.Builder.Platform
+	if effectivePlatform == "" &&
+		len(s.stages) > 1 &&
+		s.systemContext.ArchitectureChoice == "" &&
+		s.systemContext.VariantChoice == "" &&
+		s.systemContext.OSChoice == "" {
+		for _, prevStage := range s.stages[:s.index] {
+			if prevStage.Builder.Platform != "" {
+				effectivePlatform = "local" // triggers host default resolution
+				break
+			}
+		}
+	}
+	if effectivePlatform != "" {
+		imageOS, imageArch, imageVariant, err := parse.Platform(effectivePlatform)
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse platform %q: %w", stage.Builder.Platform, err)
+			return nil, fmt.Errorf("unable to parse platform %q: %w", effectivePlatform, err)
 		}
-		if imageArch != "" || imageVariant != "" {
-			s.systemContext.ArchitectureChoice = imageArch
-			s.systemContext.VariantChoice = imageVariant
-		}
-		if imageOS != "" {
-			s.systemContext.OSChoice = imageOS
-		}
+		s.systemContext.ArchitectureChoice = imageArch
+		s.systemContext.VariantChoice = imageVariant
+		s.systemContext.OSChoice = imageOS
 	}
 
 	builderOptions := buildah.BuilderOptions{

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -10836,3 +10836,50 @@ _EOF
     run_buildah --log-level error build $WITH_POLICY_JSON --layers -t quiet -f $contextdir/Containerfile $contextdir
     assert "$output" "!~" "Using cache"
 }
+
+@test "bud multi-stage build preserves architecture of local external images" {
+  # This tests that stages without a --platform flag are NOT aggressively
+  # reset to the host architecture. It ensures Buildah does not strict-match
+  # and crash when trying to resolve local images of a foreign architecture.
+
+  run_buildah info --format '{{.host.arch}}'
+  host_arch="$output"
+  
+  # Select a foreign test architecture + variant
+  test_arch="arm"
+  test_variant="v7"
+  if [[ "$host_arch" == "arm" ]]; then
+    test_arch="arm64"
+    test_variant="v8"
+  fi
+
+  local contextdir="${TEST_SCRATCH_DIR}/multi-stage-variant"
+  mkdir -p "$contextdir"
+
+  # 1. Build an external local image with a foreign architecture
+  cat > "$contextdir/Dockerfile.base" << EOF
+FROM scratch
+ENV STAGE=base
+EOF
+  run_buildah build $WITH_POLICY_JSON --platform=linux/${test_arch}/${test_variant} -t local-cross-builder -f "$contextdir/Dockerfile.base" "$contextdir"
+
+  # 2. Main Dockerfile
+  cat > "$contextdir/Dockerfile" << EOF
+ARG BASE=local-cross-builder
+
+# Stage 1: Exists purely to test multi-stage behavior with local
+FROM scratch AS stage1
+
+# Stage 2: Uses the local foreign image without a --platform flag.
+# This should leave the context empty and successfully accept the local foreign image.
+FROM \${BASE} AS final
+ENV STAGE=final
+EOF
+
+  # 3. Build the multi-stage image.
+  run_buildah build $WITH_POLICY_JSON --target final -t test-final "$contextdir"
+
+  # 4. Verify the final image successfully retained the exact foreign architecture and variant.
+  run_buildah inspect --format '{{.OCIv1.Architecture}}/{{.OCIv1.Variant}}' test-final
+  expect_output "${test_arch}/${test_variant}"
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind bug

#### What this PR does / why we need it:

This fixes an upstream issue reported in Podman: https://github.com/containers/podman/issues/29633

Root cause : So the current logic, does not work becuase the architecture of the host get's updated incorrectly in the if-else block and it does not reset when `s.stages` > 1 becuase the architecture of the host is not null.
Subsequent builds assumes that we are running the image on different architecture which shouldn't be the case. 

So the solution should be simply decoupling the (if-else) a bit such that when we are on multi-satge builds it sepcifically distinguishes if we are using the `--platform` flag or not, if not then `s.stages` logic should always reset to the global build architecture that is null.

#### Which issue(s) this PR fixes:
Fixes : https://github.com/containers/podman/issues/29633

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
   Fix multi-stage builds incorrectly forcing the host platform when a stage omits FROM --platform.

