### PR TITLE
Set up log/slog and direct logrus output to it

### DIFF
--- a/buildah_test.go
+++ b/buildah_test.go
@@ -3,10 +3,13 @@ package buildah
 import (
 	"context"
 	"flag"
+	"io"
+	"log/slog"
 	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	imagetypes "go.podman.io/image/v5/types"
@@ -35,7 +38,10 @@ func TestMain(m *testing.M) {
 	if debug && level < logrus.DebugLevel {
 		level = logrus.DebugLevel
 	}
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	logrus.SetLevel(level)
+	slog.SetLogLoggerLevel(lslog.Level(level).Level())
 	os.Exit(m.Run())
 }
 

--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"go.podman.io/buildah/bind"
 	"go.podman.io/buildah/internal/pty"
 	"go.podman.io/buildah/util"
@@ -170,9 +172,13 @@ func runUsingChrootMain() {
 	runtime.LockOSThread()
 
 	// Set logging.
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	if level := os.Getenv("LOGLEVEL"); level != "" {
 		if ll, err := strconv.Atoi(level); err == nil {
-			logrus.SetLevel(logrus.Level(ll))
+			ll := logrus.Level(ll)
+			logrus.SetLevel(ll)
+			slog.SetLogLoggerLevel(lslog.Level(ll).Level())
 		}
 		os.Unsetenv("LOGLEVEL")
 	}
@@ -579,9 +585,13 @@ func runUsingChrootExecMain() {
 	runtime.LockOSThread()
 
 	// Set logging.
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	if level := os.Getenv("LOGLEVEL"); level != "" {
 		if ll, err := strconv.Atoi(level); err == nil {
-			logrus.SetLevel(logrus.Level(ll))
+			ll := logrus.Level(ll)
+			logrus.SetLevel(ll)
+			slog.SetLogLoggerLevel(lslog.Level(ll).Level())
 		}
 		os.Unsetenv("LOGLEVEL")
 	}

--- a/cmd/buildah/common_test.go
+++ b/cmd/buildah/common_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"flag"
+	"io"
+	"log/slog"
 	"os"
 	"os/user"
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"github.com/spf13/cobra"
 	"go.podman.io/buildah"
 	"go.podman.io/image/v5/types"
@@ -40,9 +43,13 @@ func TestMain(m *testing.M) {
 	if buildah.InitReexec() {
 		return
 	}
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	logrus.SetLevel(logrus.ErrorLevel)
+	slog.SetLogLoggerLevel(slog.LevelError)
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
+		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
 	os.Exit(m.Run())
 }

--- a/cmd/buildah/main.go
+++ b/cmd/buildah/main.go
@@ -3,6 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"runtime"
@@ -13,6 +16,7 @@ import (
 	ispecs "github.com/opencontainers/image-spec/specs-go"
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.podman.io/buildah"
@@ -22,6 +26,7 @@ import (
 	"go.podman.io/common/pkg/config"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/unshare"
+	"golang.org/x/term"
 )
 
 const (
@@ -167,9 +172,16 @@ func before(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("unable to parse log level: %w", err)
 	}
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	logrus.SetLevel(logrusLvl)
+	slog.SetLogLoggerLevel(lslog.Level(logrusLvl).Level())
 	if globalFlagResults.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+	}
+	if term.IsTerminal(int(os.Stderr.Fd())) {
+		log.SetFlags(0) // We don’t want date/time in interactive output
 	}
 
 	switch cmd.Use {

--- a/copier/copier.go
+++ b/copier/copier.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net"
 	"os"
 	"os/user"
@@ -23,6 +24,7 @@ import (
 	"unicode"
 
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	mode "github.com/tonistiigi/dchapes-mode"
 	"go.podman.io/image/v5/pkg/compression"
 	"go.podman.io/image/v5/types"
@@ -943,9 +945,13 @@ func copierMain() {
 	_, _ = net.LookupHost("localhost")
 
 	// Set logging.
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	if level := os.Getenv("LOGLEVEL"); level != "" {
 		if ll, err := strconv.Atoi(level); err == nil {
-			logrus.SetLevel(logrus.Level(ll))
+			ll := logrus.Level(ll)
+			logrus.SetLevel(ll)
+			slog.SetLogLoggerLevel(lslog.Level(ll).Level())
 		}
 	}
 

--- a/copier/copier_test.go
+++ b/copier/copier_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -24,9 +25,10 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tonistiigi/dchapes-mode"
+	mode "github.com/tonistiigi/dchapes-mode"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/idtools"
 	"go.podman.io/storage/pkg/reexec"
@@ -37,8 +39,11 @@ func TestMain(m *testing.M) {
 		return
 	}
 	flag.Parse()
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	if testing.Verbose() {
 		logrus.SetLevel(logrus.DebugLevel)
+		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
 	os.Exit(m.Run())
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"slices"
@@ -195,7 +196,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 	stderr = os.Stderr
 	reporter = os.Stderr
 	if iopts.Logwriter != nil {
-		logrus.SetOutput(iopts.Logwriter)
+		log.SetOutput(iopts.Logwriter)
 		stdout = iopts.Logwriter
 		stderr = iopts.Logwriter
 		reporter = iopts.Logwriter

--- a/pkg/rusage/rusage_test.go
+++ b/pkg/rusage/rusage_test.go
@@ -2,10 +2,13 @@ package rusage
 
 import (
 	"flag"
+	"io"
+	"log/slog"
 	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"github.com/stretchr/testify/require"
 	"go.podman.io/storage/pkg/reexec"
 )
@@ -26,8 +29,12 @@ func TestMain(m *testing.M) {
 		return
 	}
 	flag.Parse()
+
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	if testing.Verbose() {
 		logrus.SetLevel(logrus.DebugLevel)
+		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
 	os.Exit(m.Run())
 }

--- a/run_common.go
+++ b/run_common.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net"
 	"os"
 	"os/exec"
@@ -30,6 +31,7 @@ import (
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"go.podman.io/buildah/bind"
 	"go.podman.io/buildah/copier"
 	"go.podman.io/buildah/define"
@@ -1079,9 +1081,13 @@ func reapStrays() {
 func runUsingRuntimeMain() {
 	var options runUsingRuntimeSubprocOptions
 	// Set logging.
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	if level := os.Getenv("LOGLEVEL"); level != "" {
 		if ll, err := strconv.Atoi(level); err == nil {
-			logrus.SetLevel(logrus.Level(ll))
+			ll := logrus.Level(ll)
+			logrus.SetLevel(ll)
+			slog.SetLogLoggerLevel(lslog.Level(ll).Level())
 		}
 	}
 	// Unpack our configuration.

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"maps"
 	"os"
 	"path"
@@ -34,6 +35,7 @@ import (
 	"github.com/openshift/imagebuilder"
 	"github.com/openshift/imagebuilder/dockerclient"
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.podman.io/buildah"
@@ -142,7 +144,10 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		logrus.Fatalf("error parsing log level %q: %v", logLevel, err)
 	}
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	logrus.SetLevel(level)
+	slog.SetLogLoggerLevel(lslog.Level(level).Level())
 	result := m.Run()
 	if err = os.RemoveAll(tempdir); err != nil {
 		logrus.Errorf("removing temporary directory %q: %v", tempdir, err)

--- a/tests/copy/copy.go
+++ b/tests/copy/copy.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"strings"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"github.com/spf13/cobra"
 	"go.podman.io/common/libnetwork/network"
 	"go.podman.io/common/pkg/config"
@@ -72,7 +75,10 @@ func main() {
 			if err != nil {
 				return err
 			}
+			logrus.SetOutput(io.Discard)
+			logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 			logrus.SetLevel(level)
+			slog.SetLogLoggerLevel(lslog.Level(level).Level())
 
 			store, err := storage.GetStore(storeOptions)
 			if err != nil {

--- a/tests/formats.bats
+++ b/tests/formats.bats
@@ -40,7 +40,7 @@ function check_imgtype() {
 
   # Can't embed entire string because the '+' sign is interpreted as regex
   expect_output --substring \
-                "level=error msg=\"expected .* type \\\\\".*, got " \
+                "ERROR expected .* type \".*, got " \
                 "Checking imagetype($image) == $2"
 }
 

--- a/tests/imgtype/imgtype.go
+++ b/tests/imgtype/imgtype.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"strings"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
+	lslog "github.com/sirupsen/logrus/hooks/slog"
 	"go.podman.io/buildah/define"
 	"go.podman.io/buildah/docker"
 	"go.podman.io/buildah/util"
@@ -50,9 +53,13 @@ func main() {
 	showc := flag.Bool("show-config", false, "output the configuration JSON")
 	rebuildc := flag.Bool("rebuild-config", false, "rebuild the configuration JSON")
 	flag.Parse()
+	logrus.SetOutput(io.Discard)
+	logrus.AddHook(lslog.NewHook(slog.Default(), nil))
 	logrus.SetLevel(logrus.ErrorLevel)
+	slog.SetLogLoggerLevel(slog.LevelError)
 	if debug != nil && *debug {
 		logrus.SetLevel(logrus.DebugLevel)
+		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
 	switch *mtype {
 	case define.OCIv1ImageManifest:

--- a/tests/loglevel.bats
+++ b/tests/loglevel.bats
@@ -4,7 +4,7 @@ load helpers
 
 @test "log-level set to debug" {
   run_buildah --log-level=debug images -q
-  expect_output --substring "level=debug "
+  expect_output --substring " DEBUG "
 }
 
 @test "log-level set to info" {

--- a/vendor/github.com/sirupsen/logrus/hooks/slog/handler.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/slog/handler.go
@@ -1,0 +1,201 @@
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// HandlerOptions are options for a [Handler].
+// A zero HandlerOptions consists entirely of default values.
+type HandlerOptions struct {
+	// AddSource causes the handler to include the source code position
+	// of the log statement in the Logrus entry.
+	AddSource bool
+
+	// LevelMapper maps slog levels to Logrus levels. If nil, the default
+	// mapping is used. Set it to customize level mapping, for example to map
+	// custom slog levels to specific Logrus levels.
+	LevelMapper func(slog.Level) logrus.Level
+}
+
+// Handler is a [slog.Handler] that writes records to a [logrus.Logger].
+//
+// It is intended for bridging libraries or application code that log via slog
+// into an existing Logrus logger, for example during a gradual migration.
+//
+// By default, slog levels are mapped using [SlogLevel].
+// Set [HandlerOptions.LevelMapper] to customize the mapping.
+//
+// Mapping to [logrus.FatalLevel] or [logrus.PanicLevel] preserves the level
+// only; handling a record does not exit or panic.
+type Handler struct {
+	logger *logrus.Logger
+	opts   HandlerOptions
+
+	// fields holds attributes from prior WithAttrs calls, already resolved
+	// under the group prefix that applied when they were added.
+	fields logrus.Fields
+
+	// groups is the current group name stack for attributes added later.
+	groups []string
+}
+
+var _ slog.Handler = (*Handler)(nil)
+
+// NewHandler creates a [slog.Handler] that writes to the provided
+// [logrus.Logger].
+//
+// The provided logger must not be nil. NewHandler panics if logger is nil.
+// If opts is nil, the default options are used.
+func NewHandler(logger *logrus.Logger, opts *HandlerOptions) *Handler {
+	if logger == nil {
+		panic("cannot create handler from nil logger")
+	}
+	if opts == nil {
+		opts = &HandlerOptions{}
+	}
+	return &Handler{
+		logger: logger,
+		opts:   *opts,
+	}
+}
+
+// toLogrusLevel maps a slog level using LevelMapper or the default mapping.
+func (h *Handler) toLogrusLevel(level slog.Level) logrus.Level {
+	if h.opts.LevelMapper != nil {
+		return h.opts.LevelMapper(level)
+	}
+	return SlogLevel(level).Level()
+}
+
+// Enabled reports whether the handler handles records at the given level.
+// It maps the slog level to a logrus level and consults the underlying logger.
+func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
+	return h.logger.IsLevelEnabled(h.toLogrusLevel(level))
+}
+
+// Handle converts the slog record into a logrus entry and logs it.
+// Record time, context, message, and attributes (including those from
+// [Handler.WithAttrs]/[Handler.WithGroup]) are preserved. Attributes are
+// attached as logrus fields; group names are joined with "." as a key prefix
+// (similar to [slog.TextHandler]).
+func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
+	// Stop recursive forwarding before it can cycle back through this logger.
+	if hasLogrusLogger(ctx, h.logger) {
+		return nil
+	}
+	level := h.toLogrusLevel(record.Level)
+	if !h.logger.IsLevelEnabled(level) {
+		return nil
+	}
+
+	entry := &logrus.Entry{
+		Logger:  h.logger,
+		Data:    h.fields,
+		Time:    record.Time,
+		Context: ctx,
+	}
+
+	if h.opts.AddSource && record.PC != 0 {
+		// Preserve the caller selected by slog instead of rediscovering it
+		// through Logrus's caller stack filtering.
+		//
+		// Record.PC is a return PC; resolve it with CallersFrames.
+		frame, _ := runtime.CallersFrames([]uintptr{record.PC}).Next()
+		entry.Caller = &frame
+	}
+
+	if n := record.NumAttrs(); n > 0 {
+		// Clone before mutating the handler's fields.
+		entry.Data = maps.Clone(h.fields)
+		if entry.Data == nil {
+			entry.Data = make(logrus.Fields, n)
+		}
+		record.Attrs(func(a slog.Attr) bool {
+			appendAttr(entry.Data, h.groups, a)
+			return true
+		})
+	}
+
+	entry.Log(level, record.Message)
+	return nil
+}
+
+// WithAttrs returns a new Handler whose attributes consist of h's attributes
+// followed by attrs.
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	h2 := h.clone()
+	h2.fields = maps.Clone(h.fields)
+	if h2.fields == nil {
+		h2.fields = make(logrus.Fields, len(attrs))
+	}
+	for _, a := range attrs {
+		appendAttr(h2.fields, h.groups, a)
+	}
+	return h2
+}
+
+// WithGroup returns a new Handler with a group appended to the receiver's
+// existing groups. All attributes added to the returned handler (via WithAttrs
+// or Handle) are nested under the combined group names.
+// If name is empty, WithGroup returns h unchanged.
+func (h *Handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	h2 := h.clone()
+	h2.groups = append(slices.Clip(h.groups), name)
+	return h2
+}
+
+// clone returns a shallow copy of h. Callers must clone fields or groups
+// before modifying them.
+func (h *Handler) clone() *Handler {
+	return &Handler{
+		logger: h.logger,
+		opts:   h.opts,
+		fields: h.fields,
+		groups: h.groups,
+	}
+}
+
+// appendAttr adds attr to fields, resolving it and applying group prefixes.
+// Group attributes are flattened with "."-separated keys.
+func appendAttr(fields logrus.Fields, groups []string, attr slog.Attr) {
+	attr.Value = attr.Value.Resolve()
+	if attr.Equal(slog.Attr{}) {
+		return
+	}
+	if attr.Value.Kind() == slog.KindGroup {
+		gs := attr.Value.Group()
+		if len(gs) == 0 {
+			return
+		}
+		g := groups
+		if attr.Key != "" {
+			g = append(slices.Clip(groups), attr.Key)
+		}
+		for _, a := range gs {
+			appendAttr(fields, g, a)
+		}
+		return
+	}
+
+	key := attr.Key
+	if len(groups) > 0 {
+		key = strings.Join(groups, ".")
+		if attr.Key != "" {
+			key += "." + attr.Key
+		}
+	}
+	fields[key] = attr.Value.Any()
+}

--- a/vendor/github.com/sirupsen/logrus/hooks/slog/level.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/slog/level.go
@@ -1,0 +1,119 @@
+package slog
+
+import (
+	"log/slog"
+
+	"github.com/sirupsen/logrus"
+)
+
+// slog levels corresponding to Logrus levels.
+const (
+	slogLevelTrace = slog.LevelDebug - 4
+	slogLevelDebug = slog.LevelDebug
+	slogLevelInfo  = slog.LevelInfo
+	slogLevelWarn  = slog.LevelWarn
+	slogLevelError = slog.LevelError
+	slogLevelFatal = slog.LevelError + 2
+	slogLevelPanic = slog.LevelError + 4
+)
+
+// A Leveler provides a [logrus.Level] value.
+//
+// It is the Logrus counterpart of [slog.Leveler].
+//
+// As [SlogLevel] itself implements Leveler, clients typically supply
+// a SlogLevel value wherever a Leveler is needed.
+// Clients who need to vary the level dynamically can provide a more complex
+// Leveler implementation.
+type Leveler interface {
+	Level() logrus.Level
+}
+
+// Level adapts a [logrus.Level] to a [slog.Leveler] using the default
+// Logrus-to-slog level mapping:
+//
+//   - [logrus.TraceLevel] -> [slog.LevelDebug] - 4
+//   - [logrus.DebugLevel] -> [slog.LevelDebug]
+//   - [logrus.InfoLevel] -> [slog.LevelInfo]
+//   - [logrus.WarnLevel] -> [slog.LevelWarn]
+//   - [logrus.ErrorLevel] -> [slog.LevelError]
+//   - [logrus.FatalLevel] -> [slog.LevelError] + 2
+//   - [logrus.PanicLevel] -> [slog.LevelError] + 4
+//
+// Unknown Logrus levels map to [slog.LevelError].
+type Level logrus.Level
+
+// Level returns l mapped to the corresponding slog level.
+func (l Level) Level() slog.Level {
+	return toSlogLevel(logrus.Level(l))
+}
+
+var _ slog.Leveler = Level(0)
+
+// SlogLevel adapts a [slog.Level] to a [Leveler] using the default
+// slog-to-Logrus level mapping:
+//
+//   - [slog.LevelDebug] - 4 -> [logrus.TraceLevel]
+//   - [slog.LevelDebug] -> [logrus.DebugLevel]
+//   - [slog.LevelInfo] -> [logrus.InfoLevel]
+//   - [slog.LevelWarn] -> [logrus.WarnLevel]
+//   - [slog.LevelError] -> [logrus.ErrorLevel]
+//   - [slog.LevelError] + 2 -> [logrus.FatalLevel]
+//   - [slog.LevelError] + 4 -> [logrus.PanicLevel]
+//
+// Levels between these boundaries map to the next lower Logrus severity.
+// Levels below [slog.LevelDebug] map to [logrus.TraceLevel], and levels at or
+// above the Panic boundary map to [logrus.PanicLevel].
+type SlogLevel slog.Level
+
+// Level returns l mapped to the corresponding Logrus level.
+func (l SlogLevel) Level() logrus.Level {
+	return toLogrusLevel(slog.Level(l))
+}
+
+var _ Leveler = SlogLevel(0)
+
+// toLogrusLevel maps a slog level using the default mapping.
+func toLogrusLevel(level slog.Level) logrus.Level {
+	switch {
+	case level >= slogLevelPanic:
+		return logrus.PanicLevel
+	case level >= slogLevelFatal:
+		return logrus.FatalLevel
+	case level >= slogLevelError:
+		return logrus.ErrorLevel
+	case level >= slogLevelWarn:
+		return logrus.WarnLevel
+	case level >= slogLevelInfo:
+		return logrus.InfoLevel
+	case level >= slogLevelDebug:
+		return logrus.DebugLevel
+	case level >= slogLevelTrace:
+		return logrus.TraceLevel
+	default:
+		return logrus.TraceLevel
+	}
+}
+
+// toSlogLevel maps a Logrus level using the default mapping.
+func toSlogLevel(level logrus.Level) slog.Level {
+	switch level {
+	case logrus.PanicLevel:
+		return slogLevelPanic
+	case logrus.FatalLevel:
+		return slogLevelFatal
+	case logrus.ErrorLevel:
+		return slogLevelError
+	case logrus.WarnLevel:
+		return slogLevelWarn
+	case logrus.InfoLevel:
+		return slogLevelInfo
+	case logrus.DebugLevel:
+		return slogLevelDebug
+	case logrus.TraceLevel:
+		return slogLevelTrace
+	default:
+		// Treat all unknown levels as errors
+		return slogLevelError
+	}
+}

--- a/vendor/github.com/sirupsen/logrus/hooks/slog/slog.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/slog/slog.go
@@ -1,0 +1,126 @@
+// Package slog provides adapters between Logrus and log/slog.
+//
+// [Handler] forwards slog records to a Logrus logger, while [Hook] forwards
+// Logrus entries to a slog logger. They can be used independently to support
+// incremental migration between the two logging APIs.
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+
+	"github.com/sirupsen/logrus"
+)
+
+// logrusLoggerContextKey is the context key used to track Logrus loggers a
+// record has already traversed while being forwarded through slog adapters.
+type logrusLoggerContextKey struct{}
+
+// withLogrusLogger returns a context that records logger as having already
+// handled the current log record.
+func withLogrusLogger(ctx context.Context, logger *logrus.Logger) context.Context {
+	seen, _ := ctx.Value(logrusLoggerContextKey{}).(map[*logrus.Logger]struct{})
+	seen = maps.Clone(seen)
+	if seen == nil {
+		seen = make(map[*logrus.Logger]struct{}, 1)
+	}
+	seen[logger] = struct{}{}
+	return context.WithValue(ctx, logrusLoggerContextKey{}, seen)
+}
+
+// hasLogrusLogger reports whether logger has already handled the current log
+// record while it was forwarded through slog adapters.
+func hasLogrusLogger(ctx context.Context, logger *logrus.Logger) bool {
+	seen, _ := ctx.Value(logrusLoggerContextKey{}).(map[*logrus.Logger]struct{})
+	_, ok := seen[logger]
+	return ok
+}
+
+// HookOptions are options for a [Hook].
+// A zero HookOptions consists entirely of default values.
+type HookOptions struct {
+	// LevelMapper maps Logrus levels to slog levels. If nil, the default
+	// mapping is used. Set it to customize level mapping, for example to map
+	// custom Logrus levels to specific slog levels.
+	LevelMapper func(logrus.Level) slog.Level
+}
+
+// Hook sends Logrus entries to slog.
+//
+// It is intended for bridging libraries or application code that log via
+// Logrus into an existing slog logger, for example during a gradual migration.
+//
+// By default, Logrus levels are mapped using [Level]. Set
+// [HookOptions.LevelMapper] to customize the mapping.
+type Hook struct {
+	logger *slog.Logger
+	opts   HookOptions
+}
+
+var _ logrus.Hook = (*Hook)(nil)
+
+// NewHook creates a [logrus.Hook] that sends logs to the provided [slog.Logger].
+//
+// This hook is intended to be used during transition from Logrus to slog,
+// or as a shim between different parts of your application or different
+// libraries that depend on different loggers.
+//
+// The provided logger must not be nil. NewHook panics if logger is nil.
+// If opts is nil, the default options are used.
+func NewHook(logger *slog.Logger, opts *HookOptions) *Hook {
+	if logger == nil {
+		panic("cannot create hook from nil logger")
+	}
+	if opts == nil {
+		opts = &HookOptions{}
+	}
+	return &Hook{
+		logger: logger,
+		opts:   *opts,
+	}
+}
+
+// toSlogLevel maps a Logrus level using LevelMapper or the default mapping.
+func (h *Hook) toSlogLevel(level logrus.Level) slog.Level {
+	if h.opts.LevelMapper != nil {
+		return h.opts.LevelMapper(level)
+	}
+	return Level(level).Level()
+}
+
+// Levels always returns all levels, since slog allows controlling level
+// enabling based on context.
+func (h *Hook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire forwards the provided logrus Entry to the underlying slog.Logger's
+// Handler, mapping it to a slog.Record. Time and caller information are
+// preserved when available, and Entry.Data is converted to attributes.
+// If Entry.Context is nil, context.Background() is used.
+func (h *Hook) Fire(entry *logrus.Entry) error {
+	ctx := entry.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// Track this logger to guard against recursive forwarding.
+	ctx = withLogrusLogger(ctx, entry.Logger)
+
+	level := h.toSlogLevel(entry.Level)
+	handler := h.logger.Handler()
+	if !handler.Enabled(ctx, level) {
+		return nil
+	}
+	attrs := make([]slog.Attr, 0, len(entry.Data))
+	for k, v := range entry.Data {
+		attrs = append(attrs, slog.Any(k, v))
+	}
+	var pc uintptr
+	if entry.Caller != nil {
+		pc = entry.Caller.PC
+	}
+	r := slog.NewRecord(entry.Time, level, entry.Message, pc)
+	r.AddAttrs(attrs...)
+	return handler.Handle(ctx, r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -406,6 +406,7 @@ github.com/sigstore/sigstore/pkg/signature/payload
 # github.com/sirupsen/logrus v1.10.2
 ## explicit; go 1.23
 github.com/sirupsen/logrus
+github.com/sirupsen/logrus/hooks/slog
 # github.com/smallstep/pkcs7 v0.2.1
 ## explicit; go 1.14
 github.com/smallstep/pkcs7


### PR DESCRIPTION
Per earlier discussion in https://github.com/podman-container-tools/skopeo/pull/2958 :

This allows us to start using `log/slog` calls, both here and in container-libs.

Smoke-tested by adding a few logging calls (of both kinds) to `version.go`; I didn't test logging from the various subprocesses.

Buildah exposes an API that lets callers use custom `logrus.Logger` destinations; that is unchanged by this. This API does not affect other code like container-libs, so it can be migrated independently if desired.

#### What type of PR is this?

> /kind other

#### What this PR does / why we need it:

#### How to verify it

Hoping to rely on existing tests

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The output format of logs has changed, from using logrus prefixes+quoting to a form log/slog prefixes+quoting.
```

