### PR TITLE
run: add a --umask CLI flag

### DIFF
--- a/chroot/run_common.go
+++ b/chroot/run_common.go
@@ -741,6 +741,11 @@ func runUsingChrootExecMain() {
 		os.Exit(1)
 	}
 
+	if user.Umask != nil {
+		logrus.Debugf("setting umask %04o", *user.Umask)
+		unix.Umask(int(*user.Umask))
+	}
+
 	// Set $PATH to the value for the container, so that when args[0] is not an absolute path,
 	// exec.Command() can find it using exec.LookPath().
 	for _, env := range slices.Backward(options.Spec.Process.Env) {

--- a/cmd/buildah/run.go
+++ b/cmd/buildah/run.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -36,6 +37,7 @@ type runInputOptions struct {
 	noHosts        bool
 	noPivot        bool
 	terminal       bool
+	umask          string
 	validExitCodes []int32
 	volumes        []string
 	workingDir     string
@@ -84,6 +86,7 @@ func runInit() {
 	flags.BoolVar(&opts.noHosts, "no-hosts", false, "do not override the /etc/hosts file within the container")
 	flags.BoolVar(&opts.noPivot, "no-pivot", false, "do not use pivot root to jail process inside rootfs")
 	flags.BoolVarP(&opts.terminal, "terminal", "t", false, "allocate a pseudo-TTY in the container")
+	flags.StringVar(&opts.umask, "umask", "", "set umask for command")
 	flags.Int32SliceVar(&opts.validExitCodes, "valid-exit-codes", []int32{0}, "list of exit codes to consider successful (default [0])")
 	flags.StringArrayVarP(&opts.volumes, "volume", "v", []string{}, "bind mount a host location into the container while running the command")
 	flags.StringArrayVar(&opts.mounts, "mount", []string{}, "attach a filesystem mount to the container (default [])")
@@ -167,6 +170,19 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		}
 	}
 
+	var umask *uint32
+	if c.Flag("umask").Changed {
+		parsed, err := strconv.ParseUint(iopts.umask, 8, 32)
+		if err != nil {
+			return fmt.Errorf("parsing umask value %q: %w", iopts.umask, err)
+		}
+		truncated := uint32(parsed & 0o777)
+		if uint64(truncated) != parsed {
+			return fmt.Errorf("umask value %#o is out of range", parsed)
+		}
+		umask = &truncated
+	}
+
 	options := buildah.RunOptions{
 		Hostname:         iopts.hostname,
 		Runtime:          iopts.runtime,
@@ -185,6 +201,7 @@ func runCmd(c *cobra.Command, args []string, iopts runInputOptions) error {
 		DeviceSpecs:      iopts.devices,
 		CDIConfigDir:     iopts.cdiConfigDir,
 		ValidExitCodes:   iopts.validExitCodes,
+		Umask:            umask,
 	}
 
 	if c.Flag("terminal").Changed {

--- a/docs/buildah-run.1.md
+++ b/docs/buildah-run.1.md
@@ -1,4 +1,4 @@
-# buildah-run "1" "March 2017" "buildah"
+# buildah-run "1" "September 2026" "buildah"
 
 ## NAME
 buildah\-run - Run a command inside of the container.
@@ -283,6 +283,12 @@ attached to a pseudo-TTY.  Setting the `--tty` option to `true` will cause a
 pseudo-TTY to be allocated inside the container connecting the user's "terminal"
 with the stdin and stdout stream of the container.  Setting the `--tty` option to
 `false` will prevent the pseudo-TTY from being allocated.
+
+**--umask** *octal_value*
+
+Set the umask(2) for the command.  Commands are able to modify the umask, so
+for some commands this provides no meaningful effect.  This value is not
+applied to files created by `buildah` itself.
 
 **--user** *user*[:*group*]
 

--- a/run.go
+++ b/run.go
@@ -192,6 +192,8 @@ type RunOptions struct {
 	// ValidExitCodes is a list of exit codes which should be considered
 	// successful. If empty, only exit code 0 is considered success.
 	ValidExitCodes []int32
+	// Initial umask to set for the process.
+	Umask *uint32
 }
 
 // RunMountArtifacts are the artifacts created when using a run mount.

--- a/run_common.go
+++ b/run_common.go
@@ -300,6 +300,9 @@ func (b *Builder) configureUIDGID(g *generate.Generator, mountPoint string, opti
 		}
 		g.AddProcessAdditionalGid(uint32(gid))
 	}
+	if options.Umask != nil {
+		g.SetProcessUmask(*options.Umask)
+	}
 
 	// Remove capabilities if not running as root except Bounding set
 	if user.UID != 0 && g.Config.Process.Capabilities != nil {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1084,6 +1084,22 @@ _EOF
   assert "$output" !~ "caught reparented child process"
 }
 
+@test "run-umask" {
+  skip_if_no_runtime
+
+  _prefetch busybox
+  run_buildah from --quiet --pull=false $WITH_POLICY_JSON busybox
+  cid=$output
+
+  for umaskval in 2 22 222 123 ; do
+    run_buildah run --umask=$umaskval $cid sh -c umask
+    expect_output $(printf %04o 0$umaskval)
+  done
+
+  run_buildah 125 run --umask=1000 $cid sh -c umask
+  expect_output --substring "umask value 01000 is out of range"
+}
+
 @test "run-valid-exit-codes" {
   skip_if_no_runtime
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a --umask flag to `buildah run`.  We continue to not pass a value to the runtime, as before, if the flag is not used.

#### How to verify it

New integration test!

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`buildah run` now accepts an optional `--umask` flag.
```