### PR TITLE
 --log-level error/fatal silences Containerfile Steps

### DIFF
--- a/cmd/buildah/push.go
+++ b/cmd/buildah/push.go
@@ -219,7 +219,7 @@ func pushCmd(c *cobra.Command, args []string, iopts pushOptions) error {
 			return fmt.Errorf("unable to parse value provided %q as --retry-delay: %w", iopts.retryDelay, err)
 		}
 	}
-	if !iopts.quiet {
+	if !iopts.quiet && logrus.IsLevelEnabled(logrus.WarnLevel) {
 		options.ReportWriter = os.Stderr
 	}
 	defaultContainerConfig, err := config.Default()

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -680,6 +680,9 @@ func (b *executor) buildStage(ctx context.Context, cleanupStages map[int]*stageE
 	if stageExecutor.log == nil {
 		stepCounter := 0
 		stageExecutor.log = func(format string, args ...any) {
+			if !logrus.IsLevelEnabled(logrus.WarnLevel) {
+				return
+			}
 			prefix := b.logPrefix
 			if len(stages) > 1 {
 				prefix += fmt.Sprintf("[%d/%d] ", stageIndex+1, len(stages))
@@ -1266,6 +1269,9 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 				return imageID, ref, fmt.Errorf("locating just-written image %q: %w", transports.ImageName(dest), err)
 			}
 			for _, name := range img.Names {
+				if !logrus.IsLevelEnabled(logrus.WarnLevel) {
+					continue
+				}
 				fmt.Fprintf(b.out, "Successfully tagged %s\n", name)
 			}
 

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1364,7 +1364,7 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 	// logCachePulled produces build log for cases when `--cache-from`
 	// is used and a valid intermediate image is pulled from remote source.
 	logCachePulled := func(cacheKey string, remote reference.Named) {
-		if !s.executor.quiet {
+		if !s.executor.quiet && logrus.IsLevelEnabled(logrus.WarnLevel) {
 			cachePullMessage := "--> Cache pulled from remote"
 			fmt.Fprintf(s.executor.out, "%s %s\n", cachePullMessage, fmt.Sprintf("%s:%s", remote.String(), cacheKey))
 		}
@@ -1372,13 +1372,13 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 	// logCachePush produces build log for cases when `--cache-to`
 	// is used and a valid intermediate image is pushed tp remote source.
 	logCachePush := func(cacheKey string) {
-		if !s.executor.quiet {
+		if !s.executor.quiet && logrus.IsLevelEnabled(logrus.WarnLevel) {
 			cachePushMessage := "--> Pushing cache"
 			fmt.Fprintf(s.executor.out, "%s %s\n", cachePushMessage, fmt.Sprintf("%s:%s", s.executor.cacheTo, cacheKey))
 		}
 	}
 	logCacheHit := func(cacheID string) {
-		if !s.executor.quiet {
+		if !s.executor.quiet && logrus.IsLevelEnabled(logrus.WarnLevel) {
 			cacheHitMessage := "--> Using cache"
 			fmt.Fprintf(s.executor.out, "%s %s\n", cacheHitMessage, cacheID)
 		}
@@ -1387,7 +1387,7 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 		if len(imgID) > 12 {
 			imgID = imgID[:12]
 		}
-		if s.executor.iidfile == "" {
+		if s.executor.iidfile == "" && logrus.IsLevelEnabled(logrus.WarnLevel) {
 			fmt.Fprintf(s.executor.out, "--> %s\n", imgID)
 		}
 	}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -511,7 +511,7 @@ func GenBuildOptions(c *cobra.Command, inputArgs []string, iopts BuildOptions) (
 		logrus.Debugf("Setting MaxPullPushRetries to %d and PullPushRetryDelay to %v", iopts.Retry, options.PullPushRetryDelay)
 	}
 
-	if iopts.Quiet {
+	if iopts.Quiet || !logrus.IsLevelEnabled(logrus.WarnLevel) {
 		options.ReportWriter = io.Discard
 	}
 

--- a/tests/bud.bats
+++ b/tests/bud.bats
@@ -10752,3 +10752,54 @@ _EOF
     done
   done
 }
+
+@test "bud-log-level suppresses build progress and keeps RUN output" {
+    _prefetch alpine
+    local contextdir=${TEST_SCRATCH_DIR}/bud/log-level
+    mkdir -p $contextdir
+    cat > $contextdir/Containerfile << _EOF
+FROM alpine
+RUN echo "hello from RUN"
+RUN echo "another RUN step"
+_EOF
+
+    # default log level still shows progress
+    run_buildah build $WITH_POLICY_JSON -t default -f $contextdir/Containerfile $contextdir
+    expect_output --substring "STEP 1/3"
+    expect_output --substring "hello from RUN"
+    expect_output --substring "COMMIT"
+    expect_output --substring "Successfully tagged localhost/default:latest"
+
+    # --log-level error: RUN output stays, everything else is suppressed
+    run_buildah --log-level error build $WITH_POLICY_JSON -t quiet -f $contextdir/Containerfile $contextdir
+    expect_output --substring "hello from RUN"
+    expect_output --substring "another RUN step"
+    assert "$output" "!~" "STEP"
+    assert "$output" "!~" "COMMIT"
+    assert "$output" "!~" "Successfully tagged"
+    assert "$output" "!~" "Getting image source signatures"
+    assert "$output" "!~" "Copying blob"
+    assert "$output" "!~" "Writing manifest to image destination"
+}
+
+@test "bud-log-level suppresses cache-hit messages" {
+    _prefetch alpine
+    local contextdir=${TEST_SCRATCH_DIR}/bud/log-level-cache
+    mkdir -p $contextdir
+    cat > $contextdir/Containerfile << _EOF
+FROM alpine
+RUN echo "hello from RUN"
+RUN echo "another RUN step"
+_EOF
+
+    # populate the layer cache
+    run_buildah build $WITH_POLICY_JSON --layers -t default -f $contextdir/Containerfile $contextdir
+
+    # default log level: identical build hits cache, message shows
+    run_buildah build $WITH_POLICY_JSON --layers -t default -f $contextdir/Containerfile $contextdir
+    expect_output --substring "Using cache"
+
+    # --log-level error: identical build still hits cache, but message is suppressed
+    run_buildah --log-level error build $WITH_POLICY_JSON --layers -t quiet -f $contextdir/Containerfile $contextdir
+    assert "$output" "!~" "Using cache"
+}

--- a/tests/conformance/conformance_test.go
+++ b/tests/conformance/conformance_test.go
@@ -112,7 +112,7 @@ func TestMain(m *testing.M) {
 	}
 	testDataDir = filepath.Join(cwd, "testdata")
 
-	flag.StringVar(&logLevel, "log-level", "error", "buildah logging log level")
+	flag.StringVar(&logLevel, "log-level", "warn", "buildah logging log level")
 	flag.BoolVar(&compareLayers, "compare-layers", compareLayers, "compare instruction-by-instruction")
 	flag.BoolVar(&compareImagebuilder, "compare-imagebuilder", compareImagebuilder, "also compare using imagebuilder")
 	flag.StringVar(&testDataDir, "testdata", testDataDir, "location of conformance testdata")

--- a/tests/push.bats
+++ b/tests/push.bats
@@ -214,6 +214,21 @@ load helpers
   expect_output ""
 }
 
+@test "push with --log-level error suppresses progress output" {
+  mytmpdir=${TEST_SCRATCH_DIR}/my-dir
+  mkdir -p $mytmpdir
+
+  _prefetch alpine
+
+  # default log level: progress output shows
+  run_buildah push $WITH_POLICY_JSON alpine dir:$mytmpdir
+  expect_output --substring "Copying blob"
+
+  # --log-level error: progress output is suppressed, same as --quiet
+  run_buildah --log-level error push $WITH_POLICY_JSON alpine dir:$mytmpdir
+  expect_output ""
+}
+
 @test "push with --compression-format" {
   _prefetch alpine
   run_buildah from --quiet --pull alpine


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?
`--log-level error/fatal` was supposed to quiet things down, but didnt touch buildah build's STEP/COMMIT lines, --> <img-id>/cache-hit messages, or the image-copy progress output during build and push. Only --quiet suppressed those, and also killed RUN output which users would not want to lose. 

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind bug

#### What this PR does / why we need it:

#### How to verify it
`bats --show-output-of-passing-tests -f "push with --log-level error" ./tests/`
`bats --show-output-of-passing-tests -f "bud-log-level" ./tests/`

#### Which issue(s) this PR fixes:
Fixes #6362
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->
<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
buildah build and buildah push will honor --log-level error/fatal by suppressing output. Previously only --quiet did so but killed RUN  command output 
```

