### PR TITLE
from: fix --chown/--chmod parsing in onbuild ADD/COPY

### DIFF
--- a/cmd/buildah/from.go
+++ b/cmd/buildah/from.go
@@ -121,15 +121,29 @@ func onBuild(builder *buildah.Builder, quiet bool) error {
 			fmt.Fprintf(os.Stderr, "STEP %d: %s\n", ctr, onBuildSpec)
 		}
 		switch command {
-		case "ADD":
-		case "COPY":
+		case "ADD", "COPY":
 			dest := ""
 			size := len(args)
 			if size > 1 {
 				dest = args[size-1]
 				args = args[:size-1]
 			}
-			if err := builder.Add(dest, command == "ADD", buildah.AddAndCopyOptions{}, args...); err != nil {
+			var options buildah.AddAndCopyOptions
+			for len(args) > 0 && strings.HasPrefix(args[0], "--") {
+				flag := args[0]
+				switch {
+				case strings.HasPrefix(flag, "--chown="):
+					options.Chown = strings.TrimPrefix(flag, "--chown=")
+				case strings.HasPrefix(flag, "--chmod="):
+					options.Chmod = strings.TrimPrefix(flag, "--chmod=")
+				case command == "ADD" && strings.HasPrefix(flag, "--checksum="):
+					options.Checksum = strings.TrimPrefix(flag, "--checksum=")
+				default:
+					return fmt.Errorf("unrecognized flag %q in onbuild command", flag)
+				}
+				args = args[1:]
+			}
+			if err := builder.Add(dest, command == "ADD", options, args...); err != nil {
 				return err
 			}
 		case "ANNOTATION":

--- a/tests/from.bats
+++ b/tests/from.bats
@@ -639,3 +639,51 @@ load helpers
   run_buildah run ${cid2} hostname -f
   expect_output "${cid2:0:12}"
 }
+
+@test "from-onbuild-copy-chown-chmod" {
+  mkdir -p ${TEST_SCRATCH_DIR}/onbuild-src
+  echo test > ${TEST_SCRATCH_DIR}/onbuild-src/file1
+  echo test > ${TEST_SCRATCH_DIR}/onbuild-src/file2
+
+  run_buildah from --quiet $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah config --onbuild "COPY --chown=1:1 file1 /file1" --onbuild "COPY --chmod=0640 file2 /file2" $cid
+  run_buildah commit $WITH_POLICY_JSON --format docker $cid onbuild-copy-flags
+  run_buildah rm $cid
+
+  pushd ${TEST_SCRATCH_DIR}/onbuild-src > /dev/null
+  run_buildah from --quiet --cidfile ${TEST_SCRATCH_DIR}/cid $WITH_POLICY_JSON onbuild-copy-flags
+  popd > /dev/null
+  cid=$(< ${TEST_SCRATCH_DIR}/cid)
+
+  run_buildah_mount ${cid}
+  root=$output
+  run stat -c '%u:%g' ${root}/file1
+  expect_output "1:1"
+  run stat -c '%a' ${root}/file2
+  expect_output "640"
+  run_buildah_umount ${cid}
+}
+
+@test "from-onbuild-add-honors-chown" {
+  mkdir -p ${TEST_SCRATCH_DIR}/onbuild-src
+  echo test > ${TEST_SCRATCH_DIR}/onbuild-src/file1
+
+  run_buildah from --quiet $WITH_POLICY_JSON scratch
+  cid=$output
+  run_buildah config --onbuild "ADD --chown=1:1 file1 /file1" $cid
+  run_buildah commit $WITH_POLICY_JSON --format docker $cid onbuild-add-chown
+  run_buildah rm $cid
+
+  pushd ${TEST_SCRATCH_DIR}/onbuild-src > /dev/null
+  run_buildah from --quiet --cidfile ${TEST_SCRATCH_DIR}/cid $WITH_POLICY_JSON onbuild-add-chown
+  popd > /dev/null
+  cid=$(< ${TEST_SCRATCH_DIR}/cid)
+
+  run_buildah_mount ${cid}
+  root=$output
+  test -e ${root}/file1
+  run stat -c '%u:%g' ${root}/file1
+  expect_output "1:1"
+  run_buildah_umount ${cid}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure you've read and understood our contributing guidelines
(https://github.com/containers/buildah/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.
-->

#### What type of PR is this?
<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind bug

#### What this PR does / why we need it:
`buildah config --onbuild "COPY --chown=..."` followed by `buildah from` mishandled `--chown`/
`--chmod`/`--checksum`: the onbuild dispatcher passed an empty `AddAndCopyOptions{}` to 
`builder.Add()`, so those flags were treated as literal source paths instead of being parsed.

Also merges the `ADD`/`COPY` switch cases, `ADD` had an empty case body with no fallthrough, 
so onbuild `ADD` triggers were silently no-ops. Sharing `COPY`'s logic fixes that too.

#### How to verify it
`bats --show-output-of-passing-tests -f "from-onbuild" ./tests/` 
#### Which issue(s) this PR fixes:
Closes #6330
<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
`ADD` wasn't specifically mentioned but it was a no-op , its been left unchanged since its introduction. If unwanted I could change it back 

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
buildah config --onbuild triggers for COPY/ADD now parses chown, chmod, and checksum (for ADD), instead of misinterpreting them as source paths

```

