### PR TITLE
imagebuildah: don't delete stage containers while stages are running

### DIFF
--- a/imagebuildah/build_jobs_test.go
+++ b/imagebuildah/build_jobs_test.go
@@ -1,0 +1,161 @@
+package imagebuildah
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.podman.io/buildah/define"
+	"go.podman.io/storage"
+	storageTypes "go.podman.io/storage/types"
+)
+
+// concurrentStageCount is high enough that several stages are still copying when the
+// stage that cannot succeed reports its failure, which is what gives the teardown
+// something to race against.
+const concurrentStageCount = 24
+
+// synchronizedBuffer collects output from every stage running in parallel, which a plain
+// bytes.Buffer cannot do safely.
+type synchronizedBuffer struct {
+	lock     sync.Mutex
+	contents bytes.Buffer
+}
+
+func (b *synchronizedBuffer) Write(p []byte) (int, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return b.contents.Write(p)
+}
+
+func (b *synchronizedBuffer) String() string {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return b.contents.String()
+}
+
+// newTestStore returns a store backed by temporary directories, so the test does not
+// disturb the caller's containers and needs no privileges beyond writing to its own
+// scratch space.
+func newTestStore(t *testing.T) storage.Store {
+	t.Helper()
+	store, err := storage.GetStore(storageTypes.StoreOptions{
+		RunRoot:         t.TempDir(),
+		GraphRoot:       t.TempDir(),
+		GraphDriverName: "vfs",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if _, err := store.Shutdown(true); err != nil {
+			t.Logf("shutting down test store: %v", err)
+		}
+	})
+	return store
+}
+
+// writeConcurrentFailureContext writes a build context holding many independent stages
+// which each copy a payload, one stage which cannot succeed, and a final stage which
+// pulls from all of them so that none are skipped as unused.
+func writeConcurrentFailureContext(t *testing.T) string {
+	t.Helper()
+	contextDirectory := t.TempDir()
+
+	// Large enough that copying it takes long enough to overlap with the failing stage,
+	// small enough to keep the test quick.
+	payload := bytes.Repeat([]byte("buildah"), 1024*1024)
+	require.NoError(t, os.WriteFile(filepath.Join(contextDirectory, "payload"), payload, 0o644))
+
+	var containerfile strings.Builder
+	for stage := range concurrentStageCount {
+		fmt.Fprintf(&containerfile, "FROM scratch AS worker%d\nCOPY payload /payload%d\n\n", stage, stage)
+	}
+
+	// Fails while the workers above are still running: the file is absent from the
+	// context, so the copier reports the error almost immediately.
+	containerfile.WriteString("FROM scratch AS broken\nCOPY this-file-is-not-in-the-context /\n\n")
+
+	containerfile.WriteString("FROM scratch\n")
+	for stage := range concurrentStageCount {
+		fmt.Fprintf(&containerfile, "COPY --from=worker%d /payload%d /worker%d\n", stage, stage, stage)
+	}
+	containerfile.WriteString("COPY --from=broken / /broken\n")
+
+	containerfilePath := filepath.Join(contextDirectory, "Containerfile")
+	require.NoError(t, os.WriteFile(containerfilePath, []byte(containerfile.String()), 0o644))
+	return contextDirectory
+}
+
+// TestConcurrentStageFailureReportsErrorWithoutCrashing covers a build where one stage
+// fails while its siblings are still running. Tearing the build down used to delete the
+// working containers of the stages that had not finished yet, so a surviving stage either
+// dereferenced the builder that had just been cleared, taking the process down with a
+// SIGSEGV, or lost its layers partway through an instruction and reported "layer not
+// known". The build is expected to fail here - what matters is that it fails by returning
+// the error from the stage that could not succeed.
+func TestConcurrentStageFailureReportsErrorWithoutCrashing(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("mounting an overlay over the build context requires root privileges, skipping")
+	}
+	store := newTestStore(t)
+	contextDirectory := writeConcurrentFailureContext(t)
+
+	jobs := 8
+	var buildOutput synchronizedBuffer
+
+	// Tearing a running stage down reports itself through the logger rather than
+	// through the error returned to us, so collect that too.
+	previousLogOutput := logrus.StandardLogger().Out
+	logrus.SetOutput(&buildOutput)
+	t.Cleanup(func() { logrus.SetOutput(previousLogOutput) })
+
+	_, _, err := BuildDockerfiles(context.Background(), store, define.BuildOptions{
+		ContextDirectory: contextDirectory,
+		Jobs:             &jobs,
+		// None of the stages RUN anything, so the build needs no network and should
+		// not depend on the helper binaries that setting one up would require.
+		ConfigureNetwork: define.NetworkDisabled,
+		Out:              &buildOutput,
+		Err:              &buildOutput,
+		ReportWriter:     &buildOutput,
+	}, filepath.Join(contextDirectory, "Containerfile"))
+
+	require.Error(t, err, "the build should fail, because one of its stages cannot succeed")
+
+	// The failure has to be the one the Containerfile asks for. Reporting a deleted
+	// working container or a missing layer instead means a stage was torn down while
+	// it was still running.
+	assert.Contains(t, err.Error(), "this-file-is-not-in-the-context",
+		"build should fail on the missing file, not on teardown of a running stage")
+	for _, teardownSymptom := range []string{
+		"layer not known",
+		"identifier is not a container",
+		"working container was deleted while the stage was still running",
+	} {
+		assert.NotContains(t, err.Error(), teardownSymptom,
+			"a stage was torn down while it was still running")
+		assert.NotContains(t, buildOutput.String(), teardownSymptom,
+			"a stage was torn down while it was still running")
+	}
+}
+
+// TestRecordWorkingContainerAfterDeleteFailsStage covers the guard on its own, since the
+// race above only reaches it once the timing lines up. A stage whose working container has
+// been deleted has to report that rather than dereference the builder that Delete cleared.
+func TestRecordWorkingContainerAfterDeleteFailsStage(t *testing.T) {
+	t.Parallel()
+	stage := &stageExecutor{name: "worker0"}
+
+	err := stage.recordWorkingContainer()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "worker0")
+	assert.Empty(t, stage.containerIDs, "nothing should be recorded when there is no working container")
+}

--- a/imagebuildah/executor.go
+++ b/imagebuildah/executor.go
@@ -829,8 +829,24 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 		b.out = io.Discard
 	}
 
+	// Assigned once the per-stage goroutines have been started, so that cleanup below can wait
+	// for them. Declared here because cleanup is defined before the stages are launched.
+	var stagesWaitGroup *sync.WaitGroup
+
 	cleanup := func() error {
 		var lastErr error
+
+		// A stage reporting an error makes Build return immediately, while the other stages
+		// may still be running. Deleting their working containers here pulls the filesystem
+		// out from under them: the stage either dereferences the builder that Delete just
+		// cleared, crashing the process, or fails with "layer not known" partway through an
+		// instruction. Wait for the stages to stop before deleting anything they might still
+		// be using. The result channel is buffered with one slot per stage, so a stage can
+		// always report and exit without a reader, and this cannot deadlock.
+		if stagesWaitGroup != nil {
+			stagesWaitGroup.Wait()
+		}
+
 		// Clean up any containers associated with the final container
 		// built by a stage, for stages that succeeded, since we no
 		// longer need their filesystem contents.
@@ -1125,6 +1141,7 @@ func (b *executor) Build(ctx context.Context, stages imagebuilder.Stages) (image
 
 	var wg sync.WaitGroup
 	wg.Add(len(stages))
+	stagesWaitGroup = &wg
 
 	var commitResults buildah.CommitResults
 	go func() {

--- a/imagebuildah/main_test.go
+++ b/imagebuildah/main_test.go
@@ -1,0 +1,17 @@
+package imagebuildah
+
+import (
+	"os"
+	"testing"
+
+	"go.podman.io/storage/pkg/reexec"
+)
+
+// TestMain lets the helpers that the build path re-executes, such as the copier, run as
+// themselves instead of re-entering the test binary.
+func TestMain(m *testing.M) {
+	if reexec.Init() {
+		return
+	}
+	os.Exit(m.Run())
+}

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1920,6 +1920,14 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 		rebase = moreInstructions || rootfsIsUsedLater
 
 		if rebase {
+			// Our working container is gone if the build was torn down while this
+			// stage was still running, which Delete signals by clearing the builder.
+			// Fail the stage rather than dereferencing it and taking the process with
+			// us; the executor reports this like any other stage error.
+			if s.builder == nil {
+				return "", nil, false, fmt.Errorf("stage %q: working container was deleted while the stage was still running", s.name)
+			}
+
 			// Since we either committed the working container or
 			// are about to replace it with one based on a cached
 			// image, add the current working container's ID to the

--- a/imagebuildah/stage_executor.go
+++ b/imagebuildah/stage_executor.go
@@ -1228,6 +1228,21 @@ func (s *stageExecutor) prepare(ctx context.Context, from string, initializeIBCo
 	return builder, nil
 }
 
+// recordWorkingContainer notes the stage's working container so that it gets cleaned up
+// once the build no longer needs its filesystem.
+//
+// The working container is gone if the build was torn down while this stage was still
+// running, which Delete signals by clearing the builder. Report that rather than
+// dereferencing it and taking the process down with a SIGSEGV; the executor handles this
+// like any other stage error.
+func (s *stageExecutor) recordWorkingContainer() error {
+	if s.builder == nil {
+		return fmt.Errorf("stage %q: working container was deleted while the stage was still running", s.name)
+	}
+	s.containerIDs = append(s.containerIDs, s.builder.ContainerID)
+	return nil
+}
+
 // Delete deletes the stage's working container, if we have one.
 func (s *stageExecutor) Delete() (err error) {
 	if s.builder != nil {
@@ -1920,20 +1935,14 @@ func (s *stageExecutor) execute(ctx context.Context, base string) (imgID string,
 		rebase = moreInstructions || rootfsIsUsedLater
 
 		if rebase {
-			// Our working container is gone if the build was torn down while this
-			// stage was still running, which Delete signals by clearing the builder.
-			// Fail the stage rather than dereferencing it and taking the process with
-			// us; the executor reports this like any other stage error.
-			if s.builder == nil {
-				return "", nil, false, fmt.Errorf("stage %q: working container was deleted while the stage was still running", s.name)
-			}
-
 			// Since we either committed the working container or
 			// are about to replace it with one based on a cached
 			// image, add the current working container's ID to the
 			// list of successful intermediate containers that
 			// we'll clean up later.
-			s.containerIDs = append(s.containerIDs, s.builder.ContainerID)
+			if err := s.recordWorkingContainer(); err != nil {
+				return "", nil, false, err
+			}
 
 			// Prepare for the next step or subsequent phases by
 			// creating a new working container with the


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

With `--jobs` greater than one, a single stage failure can take the whole build process down with a SIGSEGV, and can leave images with missing layers behind in the store.

When a stage reports an error, `Build` returns from its result loop immediately (`executor.go`, `return "", nil, r.Error`), while the goroutines for the other stages are still running. The deferred `cleanup()` then walks `cleanupStages` and calls `Delete()` on every stage executor registered there, including ones that are still executing, since stages are registered before `Execute()` runs when `forceRmIntermediateCtrs` is set or layers are disabled.

`Delete()` removes the stage's working container and clears `s.builder`, so a stage that is still running loses the filesystem underneath it. It then either dereferences the builder that was just cleared:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0x147f6fe]

goroutine 221736 [running]:
github.com/containers/buildah/imagebuildah.(*StageExecutor).Execute(...)
        github.com/containers/buildah/imagebuildah/stage_executor.go:1766
github.com/containers/buildah/imagebuildah.(*Executor).buildStage(...)
        github.com/containers/buildah/imagebuildah/executor.go:586
github.com/containers/buildah/imagebuildah.(*Executor).Build.func3.1()
        github.com/containers/buildah/imagebuildah/executor.go:953
```

(`addr=0xa0` is the offset of `ContainerID` in `Builder`, reached from
`s.containerIDs = append(s.containerIDs, s.builder.ContainerID)`.)

or fails partway through an instruction, with errors such as:

```
error unmounting container: unmounting build container "": layer not known
initializing source containers-storage:<id>-working-container-1: unable to read layer "<hash>": layer not known
Error: identifier is not a container: building at STEP "COPY --from=stage-0 /opt /opt": copier: stat: "/opt": no such file or directory
```

`b.stagesLock` protects the `cleanupStages` map, not the lifetime of the builders it holds, so it does not prevent any of this.

The fix waits for the stage goroutines to finish before deleting anything they might still be using. The dereference is additionally guarded so that a working container removed by any other path fails that stage rather than the
whole process.

This should also cover the "layer not known" reports in #5805, since the same teardown is what removes layers other stages are still referencing.

#### How to verify it

Reproduces most easily with many stages and `--jobs` > 1 where one stage fails. It was found on a build with 49 `FROM scratch` stages feeding a final stage at `--jobs=8`: one stage failing reliably panicked the process and left damaged images in the store, which then broke later builds against that store.

Note the failure is probabilistic; #5805 reports roughly 66%, so it is worth running a reproducer several times before and after.

#### Which issue(s) this PR fixes:

None
<!-- Related to #5805; happy to link it as Fixes if maintainers agree the
     "layer not known" reports there share this root cause. -->

#### Special notes for your reviewer:

Two points I would like a maintainer's opinion on:

1. This changes teardown timing. A failing build now waits for in-flight stages before returning instead of tearing down immediately, so a failure with slow stages takes longer to surface. That seemed the right trade against corrupting the store, but it is a user-visible behaviour change.

2. The wait is deadlock-safe because `ch` is buffered with `len(stages)`, so every stage can report and exit without a reader, and `cancel` stops not-yet-started stages from doing work. 

#### Does this PR introduce a user-facing change?

```release-note
Fixed a crash and possible image store corruption when a stage fails during a multi-stage build run with --jobs greater than one.
```
