### PR TITLE
integration tests: set $CONTAINERS_POLICY_JSON

### DIFF
--- a/tests/chroot.bats
+++ b/tests/chroot.bats
@@ -101,7 +101,7 @@ load helpers
   # and --map-groups, but fedora 37's is too old, so the older OUTER,INNER,SIZE
   # (using commas instead of colons as field separators) will have to do
   echo "env | sort" >> ${TEST_SCRATCH_DIR}/script.sh
-  echo "env _CONTAINERS_USERNS_CONFIGURED=done unshare -Umpf --mount-proc --setuid 0 --setgid 0 --map-users=${subid},0,${rangesize} --map-groups=${subid},0,${rangesize} ${TEST_SCRATCH_DIR}/copy ${storageopts} dir:$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
+  echo "env _CONTAINERS_USERNS_CONFIGURED=done unshare -Umpf --mount-proc --setuid 0 --setgid 0 --map-users=${subid},0,${rangesize} --map-groups=${subid},0,${rangesize} ${TEST_SCRATCH_DIR}/copy $WITH_POLICY_JSON ${storageopts} dir:$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
   # try to do a build with all of the volume mounts
   echo "env _CONTAINERS_USERNS_CONFIGURED=done unshare -Umpf --mount-proc --setuid 0 --setgid 0 --map-users=${subid},0,${rangesize} --map-groups=${subid},0,${rangesize} ${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} build --isolation chroot --pull=never $mounts $context" >> ${TEST_SCRATCH_DIR}/script.sh
   # run that whole script in a nested mount namespace with no $XDG_...
@@ -255,7 +255,7 @@ EOF
   # confirm we really are in a setgroups-denied namespace -- the bug's precondition
   echo "test \"\$(cat /proc/self/setgroups)\" = deny" >> ${TEST_SCRATCH_DIR}/script.sh
   # seed the store from the prefetched cache so the build needs no network
-  echo "${TEST_SCRATCH_DIR}/copy ${storageopts} dir:\$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
+  echo "${TEST_SCRATCH_DIR}/copy $WITH_POLICY_JSON ${storageopts} dir:\$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
   # the actual regression: this build used to fail at the RUN step with EPERM
   echo "${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} build --isolation chroot --pull=never $context" >> ${TEST_SCRATCH_DIR}/script.sh
 
@@ -349,7 +349,7 @@ EOF
   echo "mount -t tmpfs tmpfs /run/lock" >> ${TEST_SCRATCH_DIR}/script.sh
   # setgroups-denied single-ID namespace -- same environment as #6947
   echo "test \"\$(cat /proc/self/setgroups)\" = deny" >> ${TEST_SCRATCH_DIR}/script.sh
-  echo "${TEST_SCRATCH_DIR}/copy ${storageopts} dir:\$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
+  echo "${TEST_SCRATCH_DIR}/copy $WITH_POLICY_JSON ${storageopts} dir:\$_BUILDAH_IMAGE_CACHEDIR/$baseimagef containers-storage:$baseimage" >> ${TEST_SCRATCH_DIR}/script.sh
   echo "ctr=\$(${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} from --pull=never -q $baseimage)" >> ${TEST_SCRATCH_DIR}/script.sh
   echo "${TEST_SCRATCH_DIR}/buildah ${BUILDAH_REGISTRY_OPTS} ${storageopts} run --isolation chroot -v $probe:/probe:z \"\$ctr\" -- sh -c 'echo setgroups:\$(cat /proc/self/setgroups); stat -c \"member_denied=%u:%g:%a\" /probe/member_denied; stat -c \"nonmember_allowed=%u:%g:%a\" /probe/nonmember_allowed; grep ^Gid: /proc/self/status; cat /probe/nonmember_allowed && ! cat /probe/member_denied'" >> ${TEST_SCRATCH_DIR}/script.sh
 

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -38,6 +38,7 @@ BUDFILES=${TEST_SOURCES}/bud
 
 # Used hundreds of times throughout all the tests
 WITH_POLICY_JSON="--signature-policy ${TEST_SOURCES}/policy.json"
+export CONTAINERS_POLICY_JSON=${TEST_SOURCES}/policy.json
 
 # We don't invoke gnupg directly in many places, but this avoids ENOTTY errors
 # when we invoke it directly in batch mode, and CI runs us without a terminal
@@ -267,11 +268,11 @@ function buildah() {
 }
 
 function imgtype() {
-    ${IMGTYPE_BINARY} ${ROOTDIR_OPTS} "$@"
+    ${IMGTYPE_BINARY} -signature-policy ${TEST_SOURCES}/policy.json ${ROOTDIR_OPTS} "$@"
 }
 
 function copy() {
-    ${COPY_BINARY} --max-parallel-downloads=1 ${ROOTDIR_OPTS} ${BUILDAH_REGISTRY_OPTS} "$@"
+    ${COPY_BINARY} $WITH_POLICY_JSON --max-parallel-downloads=1 ${ROOTDIR_OPTS} ${BUILDAH_REGISTRY_OPTS} "$@"
 }
 
 function podman() {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test 

#### What this PR does / why we need it:

Set $CONTAINERS_POLICY_JSON to point to our in-tree test file, for the sake of test helpers which weren't already being explicitly told where it is.

Pass it explicitly when we call imgtype and copy via their shell function wrappers, and when we call the binary directly in chroot tests.

#### How to verify it

Integration tests should keep not failing, but this is mainly for the sake of #7100.

#### Which issue(s) this PR fixes:

Possible fix for a test failure being seen at https://github.com/podman-container-tools/buildah/actions/runs/34600729265/job/103270011335?pr=7100#step:4:118 in https://github.com/podman-container-tools/buildah/pull/7100.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```