### PR TITLE
docs: fix grammar, articles, and SEE ALSO reference in man pages

### DIFF
--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -1280,7 +1280,7 @@ Sets the configuration for user namespaces when handling `RUN` instructions.
 The configured value can be "" (the empty string) , "private" or "auto" to indicate
 that a new user namespace should be created, it can be "host" to indicate that
 the user namespace in which `buildah` itself is being run should be reused, or
-it can be the path to a user namespace which is already in use by another
+it can be the path to a user namespace that is already in use by another
 process.
 
 auto: automatically create a unique user namespace.

--- a/docs/buildah-build.1.md
+++ b/docs/buildah-build.1.md
@@ -1280,7 +1280,7 @@ Sets the configuration for user namespaces when handling `RUN` instructions.
 The configured value can be "" (the empty string) , "private" or "auto" to indicate
 that a new user namespace should be created, it can be "host" to indicate that
 the user namespace in which `buildah` itself is being run should be reused, or
-it can be the path to an user namespace which is already in use by another
+it can be the path to a user namespace which is already in use by another
 process.
 
 auto: automatically create a unique user namespace.
@@ -1578,7 +1578,7 @@ FROM --after=builder oci-archive:fedora.ociarchive
 # This stage will wait for builder to complete before evaluating FROM
 ```
 
-### Building an multi-architecture image using the --manifest option (requires emulation software)
+### Building a multi-architecture image using the --manifest option (requires emulation software)
 
 buildah build --arch arm --manifest myimage /tmp/mysrc
 

--- a/docs/buildah-commit.1.md
+++ b/docs/buildah-commit.1.md
@@ -428,7 +428,7 @@ This example commits the container to the image on the local registry using cred
 This example saves an image based on the container, but stores dates based on epoch time.
 `buildah commit --timestamp=0 containerID newImageName`
 
-### Building an multi-architecture image using the --manifest option (requires emulation software)
+### Building a multi-architecture image using the --manifest option (requires emulation software)
 
 ```
 #!/bin/sh

--- a/docs/buildah-from.1.md
+++ b/docs/buildah-from.1.md
@@ -470,7 +470,7 @@ used for `buildah run`.
 The configured value can be "" (the empty string) or "container" to indicate
 that a new user namespace should be created, it can be "host" to indicate that
 the user namespace in which `Buildah` itself is being run should be reused, or
-it can be the path to an user namespace which is already in use by another
+it can be the path to a user namespace which is already in use by another
 process.
 
 **--userns-gid-map** *mapping*

--- a/docs/buildah-manifest-exists.1.md
+++ b/docs/buildah-manifest-exists.1.md
@@ -28,7 +28,7 @@ $ echo $?
 $
 ```
 
-Check if an manifest called `mylist` exists (the manifest list does not actually exist).
+Check if a manifest called `mylist` exists (the manifest list does not actually exist).
 ```
 $ buildah manifest exists mylist
 $ echo $?

--- a/docs/buildah-mount.1.md
+++ b/docs/buildah-mount.1.md
@@ -21,7 +21,7 @@ with `buildah unshare` you can then use `buildah mount` and have
 access to the mounted file system.
 
 ## RETURN VALUE
-The location of the mounted file system.  On error an empty string and errno is
+The location of the mounted file system.  On error an empty string and errno are
 returned.
 
 ## OPTIONS

--- a/docs/buildah-umount.1.md
+++ b/docs/buildah-umount.1.md
@@ -24,4 +24,4 @@ buildah umount containerID1 containerID2 containerID3
 buildah umount --all
 
 ## SEE ALSO
-buildah(1), buildah-umount(1), buildah-unshare(1)
+buildah(1), buildah-mount(1), buildah-unshare(1)

--- a/docs/buildah.1.md
+++ b/docs/buildah.1.md
@@ -94,7 +94,7 @@ specify additional options via the `--storage-opt` flag.
 
 **--storage-opt** **value**
 
-Storage driver option, Default storage driver options are configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode). The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options overrides all.
+Storage driver option. Default storage driver options are configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode). The `STORAGE_OPTS` environment variable overrides the default. The --storage-opt specified options override all.
 
 **--transient-store** *bool-value*
 


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This PR fixes grammatical phrasing, incorrect indefinite articles, and an incorrect SEE ALSO link in documentation man pages:

- **`docs/buildah-umount.1.md`**:
  - Fix self-referencing `buildah-umount(1)` in `SEE ALSO` to reference counterpart `buildah-mount(1)`.
- **`docs/buildah-manifest-exists.1.md`**:
  - Fix `an manifest` -> `a manifest`.
- **`docs/buildah-build.1.md`**:
  - Fix `an user namespace` -> `a user namespace`.
  - Fix `an multi-architecture` -> `a multi-architecture`.
- **`docs/buildah-from.1.md`**:
  - Fix `an user namespace` -> `a user namespace`.
- **`docs/buildah-commit.1.md`**:
  - Fix `an multi-architecture` -> `a multi-architecture`.
- **`docs/buildah-mount.1.md`**:
  - Fix compound subject agreement `an empty string and errno is returned` -> `are returned`.
- **`docs/buildah.1.md`**:
  - Fix comma splice `Storage driver option, Default` -> `Storage driver option. Default`.
  - Fix plural subject agreement `options overrides all` -> `options override all`.

#### How to verify it:
Review the updated markdown files in `docs/`:
- `docs/buildah-umount.1.md`
- `docs/buildah-manifest-exists.1.md`
- `docs/buildah-build.1.md`
- `docs/buildah-from.1.md`
- `docs/buildah-commit.1.md`
- `docs/buildah-mount.1.md`
- `docs/buildah.1.md`

#### Which issue(s) this PR fixes:
fixes #7105 

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
```release-note
None
