### PR TITLE
Add helpful error hint when lchown fails with EINVAL

### DIFF
--- a/copier/syscall_unix.go
+++ b/copier/syscall_unix.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"syscall"
 	"time"
+	"errors"
 
 	"golang.org/x/sys/unix"
 )
@@ -54,7 +55,12 @@ func chown(path string, uid, gid int) error {
 }
 
 func lchown(path string, uid, gid int) error {
-	return os.Lchown(path, uid, gid)
+	err := os.Lchown(path, uid, gid)
+	// if the kernel rejects the ID mapping, provide an actionable hint
+	if err != nil && errors.Is(err, syscall.EINVAL) {
+		return fmt.Errorf("%w: check that your subuid/subgid ranges are large enough to cover %d:%d", err, uid, gid)
+	}
+	return err
 }
 
 func lutimes(_ bool, path string, atime, mtime time.Time) error {


### PR DESCRIPTION


<!--
Thanks for sending a pull request!


-->

#### What type of PR is this?

<!--
Please label this pull request according to what type of issue you are
addressing, especially if this is a release targeted pull request.

Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

> /kind failing-test 

#### What this PR does / why we need it:
When extracting tar archives in rootless mode, if the archive contains UIDs/GIDs that exceed the host's allocated `subuid`/`subgid` ranges, `os.Lchown` fails with `syscall.EINVAL`. 

Currently, this results in a bit unclear error message : 
`lchown <path>: invalid argument`

Modifing the error message to be a bit clear.

Fixes :  https://github.com/podman-container-tools/podman/issues/29652

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Uncomment the following comment block and include the issue
number or None on one line.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`, or `None`.

-->

<!--
Fixes #
or
None
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes please follow the kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Improved error messaging when `lchown` fails in rootless mode due to exhausted subuid/subgid ranges.

```

